### PR TITLE
feat: fetch all uploads since last run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,17 @@
 name: JavaScript tests
 on:
   push:
+    paths:
+      - 'actions/**'
     branches:
       - main
   # If we're using pull requests to generate the packages as well, we have to 
   # specify to not run the JS tests on package pull requests.
   pull_request:
+    paths:
+      - 'actions/**'
     branches:
-      - 'feature/*'
+      - main
 
 jobs:
   test:

--- a/actions/fetch/action.yaml
+++ b/actions/fetch/action.yaml
@@ -2,8 +2,8 @@ name: fetch-from-simtropolis
 description: Fetches a file from Simtropolis and generates metadata from it
 inputs:
   url:
-    description: The url to parse the medata from
-    required: true
+    description: File id or url. If not specified, fetches all files since the last run.
+    optional: true
   require-metadata:
     description: Whether a metadata.yaml file is required to add the package. Useful to turn this off for testing.
     type: boolean

--- a/actions/fetch/api-to-metadata.js
+++ b/actions/fetch/api-to-metadata.js
@@ -63,7 +63,7 @@ function getAssetSuffix(file, index, json) {
 	if (json.files.length < 2) return '';
 
 	// Normalize the filename to get the suffix.
-	let slug = slugify(file.name);
+	let slug = file.name.toLowerCase();
 	let name = path.basename(slug, path.extname(slug));
 	if (/dark\s?ni(te|ght)/.test(name)) return 'darknite';
 	if (/maxis\s?ni(te|ght)/.test(name)) return 'maxisnite';

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -16,6 +16,7 @@ const MS_DAY = 24*3600e3;
 // Main entrypoint for fetching the latest plugins released from the STEX.
 export default async function fetchPackage(opts) {
 	let {
+		id,
 		fs = nodeFs,
 		cwd = process.env.GITHUB_WORKSPACE ?? process.cwd(),
 		after,
@@ -31,7 +32,6 @@ export default async function fetchPackage(opts) {
 	// uploads from the api, but only request the specified file. Useful for 
 	// manually retriggering files.
 	let storeLastRun = true;
-	let { id } = opts;
 	if (id) {
 		if (String(id).startsWith('https://')) {
 			id = urlToFileId(id);

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -83,7 +83,7 @@ export default async function fetchPackage(opts) {
 	}
 
 	// Handle all files one by one to not flood Simtropolis.
-	let results = [];
+	let packages = [];
 	let data = parse(await fs.promises.readFile(path.join(cwd, 'permissions.yaml'))+'');
 	let permissions = new Permissions(data);
 	let handleOptions = {
@@ -114,7 +114,7 @@ export default async function fetchPackage(opts) {
 				console.log(result.error.message);
 				continue;
 			}
-			results.push(result);
+			packages.push(result);
 		}
 
 	}
@@ -124,7 +124,10 @@ export default async function fetchPackage(opts) {
 	if (storeLastFetch) {
 		await fs.promises.writeFile(path.join(cwd, 'LAST_FETCH'), lastFetch);
 	}
-	return results;
+	return {
+		timestamp: lastFetch,
+		packages,
+	};
 
 }
 

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -10,23 +10,69 @@ import scrape from './scrape.js';
 import Permissions from './permissions.js';
 import { urlToFileId } from './util.js';
 const endpoint = 'https://community.simtropolis.com/stex/files-api.php';
+const MS_DAY = 24*3600e3;
 
 // # fetch(opts)
+// Main entrypoint for fetching the latest plugins released from the STEX.
 export default async function fetchPackage(opts) {
-
-	// If the id given is a url, extract the id from it.
-	let { id } = opts;
-	if (String(id).startsWith('https://')) {
-		id = urlToFileId(id);
-	}
+	let {
+		fs = nodeFs,
+		cwd = process.env.GITHUB_WORKSPACE ?? process.cwd(),
+		after,
+		now = Date.now(),
+	} = opts;
 
 	// Build up the url.
 	const url = new URL(endpoint);
 	url.searchParams.set('key', process.env.STEX_API_KEY);
-	url.searchParams.set('id', id);
+
+	// If an id is given, then we will not check when we fetched the latest 
+	// uploads from the api, but only request the specified file. Useful for 
+	// manually retriggering files.
+	let storeLastFetch = true;
+	let { id } = opts;
+	if (id) {
+		if (String(id).startsWith('https://')) {
+			id = urlToFileId(id);
+		}
+		url.searchParams.set('id', id);
+
+		// Now set "after" to somewhere very far in the past so that we don't 
+		// accidentally filter out the specific file later on.
+		storeLastFetch = false;
+		after = -Infinity;
+
+	} else if (!after) {
+		try {
+
+			// Unfortunately the STEX api does not support passing in an exact 
+			// date - to check if this could be added. It only supports 
+			// specifying an amount of days to go back. It's not really clear 
+			// whether this means 24 hours, so we'll use a bit of leeway and 
+			// then just filter it out later on.
+			let filePath = path.join(cwd, 'LAST_FETCH');
+			let contents = String(await fs.promises.readFile(filePath));
+			after = Date.parse(contents);
+			let days = Math.ceil((+now - after) / MS_DAY)+1;
+			url.searchParams.set('days', days);
+
+		} catch (e) {
+
+			// If the file was not found, we'll only fetch the last day. This 
+			// should only happen the very first time we run this.
+			if (e.code === 'ENOENT') {
+				url.searchParams.set('days', 1);
+				after = -Infinity;
+			} else {
+				throw e;
+			}
+		}
+
+	}
 
 	// Fetch from the api.
-	// TODO: handle errors here.
+	// TODO: handle various STEX errors here.
+	let lastFetch = new Date().toISOString();
 	let res = await fetch(url);
 	if (res.status >= 400) {
 		throw new Error(`Simtropolis returned ${res.status}!`);
@@ -37,10 +83,6 @@ export default async function fetchPackage(opts) {
 	}
 
 	// Handle all files one by one to not flood Simtropolis.
-	const {
-		fs = nodeFs,
-		cwd = process.env.GITHUB_WORKSPACE ?? process.cwd(),
-	} = opts;
 	let results = [];
 	let data = parse(await fs.promises.readFile(path.join(cwd, 'permissions.yaml'))+'');
 	let permissions = new Permissions(data);
@@ -50,10 +92,22 @@ export default async function fetchPackage(opts) {
 		permissions,
 	};
 	for (let obj of json) {
+
+		// Discard objects that we have already processed based on the "after" 
+		// parameter.
+		let updated = parseDate(obj.updated);
+		if (updated.getTime() < after) continue;
+
+		// Check whether the creator is allowed to publish files on the STEX 
+		// channel. We don't create a failing PR in this case, but we do log the 
+		// results in the action so that we can inspect on GitHub what happened.
 		if (!permissions.isUploadAllowed(obj)) {
 			console.log(`Creator of ${obj.fileURL} is not allowed to add a plugin to the channel.`);
 			continue;
 		}
+
+		// Cool, try to handle the file now. Again, errors will be logged, but 
+		// no PR will be created for them.
 		let result = await handleFile(obj, handleOptions);
 		if (result) {
 			if (result.error) {
@@ -62,9 +116,23 @@ export default async function fetchPackage(opts) {
 			}
 			results.push(result);
 		}
+
+	}
+
+	// Update the timestamp that we last fetched the stex api, but only if not 
+	// explicitly requesting a specific file!
+	if (storeLastFetch) {
+		await fs.promises.writeFile(path.join(cwd, 'LAST_FETCH'), lastFetch);
 	}
 	return results;
 
+}
+
+// # parseDate(str)
+// Parses a date from a date string included in the stex api response. It 
+// doesn't follow the ISO format for now.
+function parseDate(str) {
+	return new Date(str.replace(' ', 'T')+'Z');
 }
 
 // # handleFile(json)

--- a/actions/fetch/scrape.js
+++ b/actions/fetch/scrape.js
@@ -6,7 +6,7 @@ import parseDescription from './parse-description.js';
 // Currently the STEX api does not include the description, nor images. Hence we 
 // still use a scraping approach for now.
 export default async function scrape(url) {
-	let spinner = ora(`Scraping ${url}...`).start();
+	let spinner = ora(`Scraping ${url}`).start();
 	let res = await fetch(url);
 	if (res.status >= 400) {
 		throw new Error(`HTTP ${res.status}`);

--- a/actions/fetch/test/faker.js
+++ b/actions/fetch/test/faker.js
@@ -1,4 +1,5 @@
 // # faker.js
+import { slugify } from '../util.js';
 import { faker } from '@faker-js/faker';
 
 // # file(file)
@@ -29,7 +30,7 @@ export function upload(upload = {}) {
 		files = 1,
 		id = faker.number.int(1_000_000),
 		title = faker.company.name(),
-		aliasEntry = faker.helpers.slugify(title).toLowerCase(),
+		aliasEntry = slugify(title),
 		updated = faker.date.past(),
 		submitted = faker.date.past({ refDate: updated }),
 		images = faker.number.int(5),
@@ -40,7 +41,12 @@ export function upload(upload = {}) {
 		files = new Array(files).fill();
 	}
 	if (typeof images === 'number') {
-		images = new Array(images).fill().map(() => faker.internet.url());
+		images = new Array(images).fill().map(() => {
+			return new URL(
+				faker.system.commonFileName('jpg'),
+				faker.internet.url(),
+			).href;
+		});
 	}
 	return {
 		id,

--- a/actions/fetch/test/faker.js
+++ b/actions/fetch/test/faker.js
@@ -1,0 +1,89 @@
+// # faker.js
+import { faker } from '@faker-js/faker';
+
+// # file(file)
+// Generates a fake file record
+export function file(file = {}) {
+	let {
+		metadata = '',
+		...rest
+	} = file;
+	return {
+		id: faker.number.int(1_000_000),
+		name: faker.system.commonFileName('zip'),
+
+		// Assume that by default every file has at least a metadata.yaml file 
+		// set. Can be overridden though to mock files without metadata.
+		contents: {
+			'metadata.yaml': metadata,
+		},
+		...rest,
+
+	};
+}
+
+// # upload(upload)
+// Generates a fake upload record.
+export function upload(upload = {}) {
+	let {
+		files = 1,
+		id = faker.number.int(1_000_000),
+		title = faker.company.name(),
+		aliasEntry = faker.helpers.slugify(title).toLowerCase(),
+		updated = faker.date.past(),
+		submitted = faker.date.past({ refDate: updated }),
+		images = faker.number.int(5),
+		description = faker.lorem.paragraphs(3, '\n\n'),
+		...rest
+	} = upload;
+	if (typeof files === 'number') {
+		files = new Array(files).fill();
+	}
+	if (typeof images === 'number') {
+		images = new Array(images).fill().map(() => faker.internet.url());
+	}
+	return {
+		id,
+		uid: faker.number.int(10_000),
+		cid: faker.number.int(106),
+		author: faker.internet.username(),
+		title,
+		aliasEntry,
+		release: faker.system.semver(),
+		fileURL: `https://community.simtropolis.com/files/file/${id}-${aliasEntry}`,
+		submitted: formatDate(submitted),
+		updated: formatDate(updated),
+		description,
+		images,
+		files: files.map(props => {
+			if (typeof props === 'string') {
+				return file({ name: props });
+			} else {
+				return file(props);
+			}
+		}),
+		...rest,
+	};
+}
+
+// # uploads()
+// Generates a number of fake uploads.
+export function uploads(props = faker.number.int(25)) {
+	if (typeof props === 'number') {
+		props = new Array(props).fill();
+	}
+	return props.map(props => {
+		if (typeof props === 'string') {
+			props = new Date(props);
+		}
+		if (props instanceof Date) {
+			props = { updated: props };
+		}
+		return upload(props);
+	});
+}
+
+function formatDate(date) {
+	if (typeof date === 'string') return date;
+	return date.toISOString().slice(0, 19).replace('T', ' ');
+}

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -23,7 +23,7 @@ describe('The fetch action', function() {
 
 			// Populate the file where we store when the last file was fetched.
 			if (lastFetch) {
-				fs.writeFileSync('/LAST_FETCH', lastFetch);
+				fs.writeFileSync('/LAST_RUN', lastFetch);
 			}
 
 			// We'll mock the global "fetch" method so that we can mock the api 
@@ -557,12 +557,12 @@ describe('The fetch action', function() {
 		expect(results).to.have.length(1);
 		expect(results[0].metadata.package.info.website).to.equal(uploads[0].fileURL);
 
-		let updated = fs.readFileSync('/LAST_FETCH').toString();
+		let updated = fs.readFileSync('/LAST_RUN').toString();
 		expect(Date.parse(updated)).to.be.above(Date.parse(lastFetch));
 
 	});
 
-	it('does not update the LAST_FETCH file when Simtropolis is unavailable');
+	it('does not update the LAST_RUN file when Simtropolis is unavailable');
 
 });
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -103,7 +103,7 @@ describe('The fetch action', function() {
 			};
 
 			async function run(opts) {
-				let results = await action({
+				let result = await action({
 					fs,
 					cwd: '/',
 					...opts,
@@ -114,8 +114,8 @@ describe('The fetch action', function() {
 						let contents = fs.readFileSync(file).toString();
 						return parseAllDocuments(contents).map(doc => doc.toJSON());
 					},
-					results,
-					result: results[0],
+					results: result.packages,
+					result: result.packages[0],
 				};
 			};
 

--- a/actions/fetch/util.js
+++ b/actions/fetch/util.js
@@ -1,8 +1,11 @@
 // # slugify(name)
-// Converts the name of the author into a slugged version.
+// Converts an author's name or a package title into a format that sc4pac 
+// accepts as group and package names. See https://memo33.github.io/
+// sc4pac/#/metadata?id=group for the spec: anything non alphanumeric should 
+// become hyphenated.
 export function slugify(name) {
 	let lc = name.toLowerCase();
-	return lc.replaceAll(/[\s_]+/g, '-');
+	return lc.replaceAll(/[^a-z0-9]+/g, '-');
 }
 
 // # urlToFileId(href)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,14 @@
       "devDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
+        "@faker-js/faker": "^9.3.0",
         "@sebamarynissen/sc4pac-helpers": "github:sebamarynissen/sc4pac-helpers#main",
         "@whisthub/eslint-config": "^3.1.0",
         "chai": "^5.1.2",
         "commander": "^12.1.0",
         "eslint": "^9.17.0",
+        "human-interval": "^2.0.1",
+        "marked": "^15.0.4",
         "memfs": "^4.15.0",
         "mocha": "^11.0.1",
         "yazl": "^3.3.1"
@@ -705,6 +708,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.3.0.tgz",
+      "integrity": "sha512-r0tJ3ZOkMd9xsu3VRfqlFR6cz0V/jFYRswAIpC+m/DIfAUXq7g8N7wTAlhSANySXYGKzGryfDXwtwsY8TxEIDw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -2988,6 +3008,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-interval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-2.0.1.tgz",
+      "integrity": "sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "numbered": "^1.1.0"
+      }
+    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -3411,6 +3441,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.4.tgz",
+      "integrity": "sha512-TCHvDqmb3ZJ4PWG7VEGVgtefA5/euFmsIhxtD0XsBxI39gUSKL81mIRFdt0AiNQozUahd4ke98ZdirExd/vSEw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/memfs": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.15.0.tgz",
@@ -3764,6 +3807,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/numbered": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/numbered/-/numbered-1.1.0.tgz",
+      "integrity": "sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.16",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
   "devDependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
+    "@faker-js/faker": "^9.3.0",
     "@sebamarynissen/sc4pac-helpers": "github:sebamarynissen/sc4pac-helpers#main",
     "@whisthub/eslint-config": "^3.1.0",
     "chai": "^5.1.2",
     "commander": "^12.1.0",
     "eslint": "^9.17.0",
+    "human-interval": "^2.0.1",
+    "marked": "^15.0.4",
     "memfs": "^4.15.0",
     "mocha": "^11.0.1",
     "yazl": "^3.3.1"


### PR DESCRIPTION
This PR adds support for fetching all uploads since the last run. This will allow setting up a cron job for periodically checking the STEX, instead of only running for specific files. The date of the last run is stored in the root of the repo under the `LAST_RUN` file.