### PR TITLE
feat: improve resilience of downloads

### DIFF
--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -57,7 +57,8 @@ export default class Downloader {
 			metadata = await this.handleDownload(download);
 			spinner.succeed();
 		} catch (e) {
-			spinner.fail(e.message + '\n' + e.stack);
+			console.error(e);
+			spinner.fail();
 		} finally {
 			await download.cleanup();
 		}

--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -37,6 +37,7 @@ export default class Downloader {
 		await finished(Readable.fromWeb(res.body).pipe(ws));
 		return {
 			path: destination,
+			type: res.headers.get('Content-Type') ?? 'application/zip',
 			cleanup: async () => {
 				await fs.promises.unlink(destination);
 				await dir.cleanup();
@@ -51,7 +52,32 @@ export default class Downloader {
 	async handleAsset(asset) {
 		const spinner = ora(`Downloading ${asset.url}`).start();
 		const download = await this.download(asset);
-		const info = {};
+		let metadata;
+		try {
+			metadata = await this.handleDownload(download);
+			spinner.succeed();
+		} catch (e) {
+			spinner.fail(e.message + '\n' + e.stack);
+		} finally {
+			await download.cleanup();
+		}
+		return { metadata };
+	}
+
+	// ## handleDownload(download)
+	// Determines what strategy we'll use to look for metadata in this asset.
+	async handleDownload(download) {
+		switch (download.type) {
+			case 'application/zip':
+				return await this.handleZip(download);
+			default:
+				return null;
+		}
+	}
+
+	// ## handleZip(download)
+	async handleZip(download) {
+		let metadata;
 		const tasks = [];
 		const closed = withResolvers();
 		yauzl.open(download.path, { lazyEntries: false }, (err, zipFile) => {
@@ -61,8 +87,8 @@ export default class Downloader {
 				
 				// If we find a metadata.yaml at the root, read it in.
 				if (/^metadata\.ya?ml$/i.test(entry.fileName)) {
-					let task = readMetadata(zipFile, entry).then(metadata => {
-						info.metadata = metadata;
+					let task = readMetadata(zipFile, entry).then(_metadata => {
+						metadata = _metadata;
 					});
 					tasks.push(task);
 				}
@@ -71,9 +97,7 @@ export default class Downloader {
 		});
 		await closed.promise;
 		await Promise.all(tasks);
-		await download.cleanup();
-		spinner.succeed();
-		return info;
+		return metadata;
 	}
 
 }

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -174,7 +174,6 @@ async function handleFile(json, opts = {}) {
 	// prefilled metadata.
 	let parsedMetadata = false;
 	let downloader = new Downloader();
-	let filteredAssets = [];
 	for (let asset of metadata.assets) {
 
 		// If the assets contains metadata, we'll use this one, only if former 
@@ -182,25 +181,21 @@ async function handleFile(json, opts = {}) {
 		// when unzipping, then we'll just swallow it. It's always possible that 
 		// someone uploads an invalid zip file, nothing we can do about that, 
 		// but we don't want this to block our workflow.
-		let info = await downloader.handleAsset(asset) || {};
-		if (info.metadata && !parsedMetadata) {
-			parsedMetadata = info.metadata;
-		}
-		if (info.skip !== true) filteredAssets.push(asset);
+		// try {
+			let info = await downloader.handleAsset(asset);
+			if (info.metadata && !parsedMetadata) {
+				parsedMetadata = info.metadata;
+			}
+		// } catch {}
 
 	}
-
-	// During the download process, it might have been revealed that certain 
-	// files are not actually assets - for example the metadata.yaml file. Hence 
-	// we filter.
-	metadata.assets = filteredAssets;
 
 	// If we have not found any metadata at this moment, then we skip this 
 	// package. It means the user has not made their package compatible with 
 	// sc4pac.
 	const { requireMetadata = true } = opts;
 	if (!parsedMetadata && requireMetadata) {
-		console.log(`No metadata found for package ${json.fileURL}, skipping.`);
+		console.log(`Package ${json.fileURL} does not have a metadata.yaml file in its root, skipping.`);
 		return;
 	}
 

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -174,6 +174,7 @@ async function handleFile(json, opts = {}) {
 	// prefilled metadata.
 	let parsedMetadata = false;
 	let downloader = new Downloader();
+	let filteredAssets = [];
 	for (let asset of metadata.assets) {
 
 		// If the assets contains metadata, we'll use this one, only if former 
@@ -181,21 +182,25 @@ async function handleFile(json, opts = {}) {
 		// when unzipping, then we'll just swallow it. It's always possible that 
 		// someone uploads an invalid zip file, nothing we can do about that, 
 		// but we don't want this to block our workflow.
-		// try {
-			let info = await downloader.handleAsset(asset);
-			if (info.metadata && !parsedMetadata) {
-				parsedMetadata = info.metadata;
-			}
-		// } catch {}
+		let info = await downloader.handleAsset(asset) || {};
+		if (info.metadata && !parsedMetadata) {
+			parsedMetadata = info.metadata;
+		}
+		if (info.skip !== true) filteredAssets.push(asset);
 
 	}
+
+	// During the download process, it might have been revealed that certain 
+	// files are not actually assets - for example the metadata.yaml file. Hence 
+	// we filter.
+	metadata.assets = filteredAssets;
 
 	// If we have not found any metadata at this moment, then we skip this 
 	// package. It means the user has not made their package compatible with 
 	// sc4pac.
 	const { requireMetadata = true } = opts;
 	if (!parsedMetadata && requireMetadata) {
-		console.log(`Package ${json.fileURL} does not have a metadata.yaml file in its root, skipping.`);
+		console.log(`No metadata found for package ${json.fileURL}, skipping.`);
 		return;
 	}
 

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -177,11 +177,17 @@ async function handleFile(json, opts = {}) {
 	for (let asset of metadata.assets) {
 
 		// If the assets contains metadata, we'll use this one, only if former 
-		// assets did not contain metadata either.
-		let info = await downloader.handleAsset(asset);
-		if (info.metadata && !parsedMetadata) {
-			parsedMetadata = info.metadata;
-		}
+		// assets did not contain metadata either. Note: if something is wrong 
+		// when unzipping, then we'll just swallow it. It's always possible that 
+		// someone uploads an invalid zip file, nothing we can do about that, 
+		// but we don't want this to block our workflow.
+		// try {
+			let info = await downloader.handleAsset(asset);
+			if (info.metadata && !parsedMetadata) {
+				parsedMetadata = info.metadata;
+			}
+		// } catch {}
+
 	}
 
 	// If we have not found any metadata at this moment, then we skip this 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -658,29 +658,6 @@ describe('The fetch action', function() {
 
 	});
 
-	it('properly detects a metadata.yaml file in the assets', async function() {
-
-		let zip = faker.file();
-		let upload = faker.upload({
-			files: [
-				{
-					name: 'metadata.yaml',
-					contents: '',
-				},
-				zip,
-			],
-		});
-		const { run } = this.setup({ uploads: [upload] });
-
-		const { packages } = await run({ id: upload.id });
-		expect(packages).to.have.length(1);
-		let [pkg] = packages;
-		expect(pkg.metadata.assets).to.have.length(1);
-		let url = new URL(pkg.metadata.assets[0].url);
-		expect(url.searchParams.get('r')).to.equal(String(zip.id));
-
-	});
-
 });
 
 function jsonToYaml(json) {

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -658,6 +658,29 @@ describe('The fetch action', function() {
 
 	});
 
+	it('properly detects a metadata.yaml file in the assets', async function() {
+
+		let zip = faker.file();
+		let upload = faker.upload({
+			files: [
+				{
+					name: 'metadata.yaml',
+					contents: '',
+				},
+				zip,
+			],
+		});
+		const { run } = this.setup({ uploads: [upload] });
+
+		const { packages } = await run({ id: upload.id });
+		expect(packages).to.have.length(1);
+		let [pkg] = packages;
+		expect(pkg.metadata.assets).to.have.length(1);
+		let url = new URL(pkg.metadata.assets[0].url);
+		expect(url.searchParams.get('r')).to.equal(String(zip.id));
+
+	});
+
 });
 
 function jsonToYaml(json) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@octokit/rest": "^21.0.2",
         "dot-prop": "^9.0.0",
         "jsdom": "^25.0.1",
+        "mime": "^4.0.6",
         "ora": "^8.1.1",
         "simple-git": "^3.27.0",
         "tmp-promise": "^3.0.3",
@@ -3472,6 +3473,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
+      "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@octokit/rest": "^21.0.2",
     "dot-prop": "^9.0.0",
     "jsdom": "^25.0.1",
+    "mime": "^4.0.6",
     "ora": "^8.1.1",
     "simple-git": "^3.27.0",
     "tmp-promise": "^3.0.3",


### PR DESCRIPTION
This PR removes the resilience of the downloads, meaning that we only try to unzip stuff that actually has `Content-Type: application/zip` set as its header. Also, should an error occur during unzipping, it will fail gracefully instead of crashing the workflow - and potentially blocking the processing of other valid uploads.

On top of that, we've also added the possibility that an upload contains a `metadata.yaml` file as a separate upload, instead of being in the .zip. When this happens, the metadata.yaml does not get registered as an asset though.

@memo33: I'm not really sure whether this is a good idea though. At first I was convinced that it was, but on second thought it will probably confuse users if they want to download something manually and they have to choose between a zip and a `metadata.yaml` file. The approach with including a `metadata.yaml` in the zip itself is also not perfect, but at least it won't confuse users *before* downloading, it might only confuse them *after* downloading. However, whatever they decide to do with the `` `metadata.yaml` file - whether they put it in plugins or not - it doesn't really matter, so I think it's still better than including a `metadata.yaml` as separate file in the upload. I might hence remove support for this again. What do you think?