### PR TITLE
build: deploy to root instead of `/channel`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,9 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
     # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
     concurrency:
@@ -33,17 +33,16 @@ jobs:
       run: |
         mv tmp_gh-pages/channel/* tmp_gh-pages/
         rmdir tmp_gh-pages/channel
-    - run: tree
-    # - name: Setup Pages
-    #   uses: actions/configure-pages@v4
-    # - name: Upload artifact
-    #   # note that this action dereferences our `latest` symlinks, but that's not a huge problem, it just duplicates each json file (could maybe be avoided by using tar)
-    #   uses: actions/upload-pages-artifact@v3
-    #   with:
-    #     path: 'tmp_gh-pages'
-    # - name: Deploy to GitHub Pages
-    #   id: deployment
-    #   uses: actions/deploy-pages@v4
-    # permissions:
-    #   pages: write
-    #   id-token: write
+    - name: Setup Pages
+      uses: actions/configure-pages@v4
+    - name: Upload artifact
+      # note that this action dereferences our `latest` symlinks, but that's not a huge problem, it just duplicates each json file (could maybe be avoided by using tar)
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: 'tmp_gh-pages'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4
+    permissions:
+      pages: write
+      id-token: write

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,7 @@ jobs:
         pages-output-path: 'tmp_gh-pages'
         channel-label: ${{ env.CHANNEL_LABEL }}
         metadata-source-url: ${{ format('https://github.com/{0}/blob/{1}/{2}/', github.repository, github.event.repository.default_branch, 'src/yaml') }}
+    - run: tree
     - name: Setup Pages
       uses: actions/configure-pages@v4
     - name: Upload artifact

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,16 +30,16 @@ jobs:
         channel-label: ${{ env.CHANNEL_LABEL }}
         metadata-source-url: ${{ format('https://github.com/{0}/blob/{1}/{2}/', github.repository, github.event.repository.default_branch, 'src/yaml') }}
     - run: tree
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-    - name: Upload artifact
-      # note that this action dereferences our `latest` symlinks, but that's not a huge problem, it just duplicates each json file (could maybe be avoided by using tar)
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: 'tmp_gh-pages'
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
-    permissions:
-      pages: write
-      id-token: write
+    # - name: Setup Pages
+    #   uses: actions/configure-pages@v4
+    # - name: Upload artifact
+    #   # note that this action dereferences our `latest` symlinks, but that's not a huge problem, it just duplicates each json file (could maybe be avoided by using tar)
+    #   uses: actions/upload-pages-artifact@v3
+    #   with:
+    #     path: 'tmp_gh-pages'
+    # - name: Deploy to GitHub Pages
+    #   id: deployment
+    #   uses: actions/deploy-pages@v4
+    # permissions:
+    #   pages: write
+    #   id-token: write

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,10 @@ jobs:
         pages-output-path: 'tmp_gh-pages'
         channel-label: ${{ env.CHANNEL_LABEL }}
         metadata-source-url: ${{ format('https://github.com/{0}/blob/{1}/{2}/', github.repository, github.event.repository.default_branch, 'src/yaml') }}
+    - name: Move channel content to root
+      run: |
+        mv tmp_gh-pages/channel/* tmp_gh-pages/
+        rmdir tmp_gh-pages/channel
     - run: tree
     # - name: Setup Pages
     #   uses: actions/configure-pages@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,9 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
     # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
     concurrency:


### PR DESCRIPTION
This PR ensures that the deployment to GitHub pages uses the root path instead of `/channel`. This means that the channel becomes available on https://sebamarynissen.github.io/simtropolis-channel instead of https://sebamarynissen.github.io/simtropolis-channel/channel. This will be especially better when running under a simtropolis domain name. Users then simply would have to add https://sc4pac.simtropolis.com to their channels in the gui.

Related: #29.