### PR TITLE
feat: determine subfolder based on descriptor

### DIFF
--- a/actions/fetch/api-to-metadata.js
+++ b/actions/fetch/api-to-metadata.js
@@ -81,5 +81,10 @@ function getAssetSuffix(file, index, json) {
 // # normalizeDate(date)
 // The date returned from the api does not have the correct format. Let's fix that.
 function normalizeDate(date) {
-	return date.replace(' ', 'T') + 'Z';
+	let normalized = date.replace(' ', 'T');
+	if (!normalized.endsWith('Z')) {
+		return `${normalized}Z`;
+	} else {
+		return normalized;
+	}
 }

--- a/actions/fetch/categories.js
+++ b/actions/fetch/categories.js
@@ -1,5 +1,45 @@
+// List of categories used by the STEX mapped to sc4pac subfolders, as per a 
+// list sent by Cyclone Boom.
 export default {
+	// Residential
 	101: '200-residential',
+	// Commercial
 	102: '300-commercial',
-	106: '610-safety',
+	// Industrial
+	103: '400-industrial',
+	// Agricultural
+	104: '410-agriculture',
+	// Building Sets
+	105: '100-props-textures',
+
+	// Civic & Non-RCI, but sc4pac makes further distinctions here. We solve 
+	// this by reading the file descriptor by using the scraping approach. 
+	// Ideally the STEX api can return this as well. By default we use 
+	// "landmarks" though.
+	106: '360-landmarks',
+	// 107 = Utilities
+	// 108 = Parks & Plazas
+	108: '660-parks',
+	// 109 = Waterfront
+	109: '660-parks',
+	// 110 = Transportation
+	110: '700-transit',
+	// 111 = Automata
+	111: '710-automata',
+	// 112 = Gameplay Mods
+	112: '150-mods',
+	// 113 = Graphical Mods
+	113: '150-mods',
+	// 114 = Cheats are normally DLL's, so they should go in the root.
+	114: null,
+	// 115 = Tools
+	// 116 = Maps
+	// 117 = Ready Made Regions
+	// 118 = Dependencies
+	118: '100-props-textures',
+	// 119 = 3ds Models
+	// 120 = Obsolete & Legacy
+	// 121 = Reference & Info
+	// DLL mods go in the root.
+	122: null,
 };

--- a/actions/fetch/categories.js
+++ b/actions/fetch/categories.js
@@ -16,7 +16,7 @@ export default {
 	// this by reading the file descriptor by using the scraping approach. 
 	// Ideally the STEX api can return this as well. By default we use 
 	// "landmarks" though.
-	106: '360-landmarks',
+	106: '360-landmark',
 	// 107 = Utilities
 	// 108 = Parks & Plazas
 	108: '660-parks',

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -147,7 +147,7 @@ async function handleFile(json, opts = {}) {
 	// this with scraping for the description and images as they are not 
 	// included in the api response yet.
 	let metadata = apiToMetadata(json);
-	let { description, images } = await scrape(json.fileURL);
+	let { description, images, subfolder } = await scrape(json.fileURL);
 	let { package: pkg } = metadata;
 	let { info } = pkg;
 	if (!info.description) {
@@ -156,6 +156,7 @@ async function handleFile(json, opts = {}) {
 	if (!info.images) {
 		info.images = images;
 	}
+	pkg.subfolder = subfolder;
 
 	// Now generate the variants from what we've decided to include. This will 
 	// multiply the available variants by 2 in every step.
@@ -181,12 +182,10 @@ async function handleFile(json, opts = {}) {
 		// when unzipping, then we'll just swallow it. It's always possible that 
 		// someone uploads an invalid zip file, nothing we can do about that, 
 		// but we don't want this to block our workflow.
-		// try {
-			let info = await downloader.handleAsset(asset);
-			if (info.metadata && !parsedMetadata) {
-				parsedMetadata = info.metadata;
-			}
-		// } catch {}
+		let info = await downloader.handleAsset(asset);
+		if (info.metadata && !parsedMetadata) {
+			parsedMetadata = info.metadata;
+		}
 
 	}
 

--- a/actions/fetch/scrape.js
+++ b/actions/fetch/scrape.js
@@ -117,6 +117,7 @@ const descriptorMap = {
 	'civics-rewards': '360-landmark',
 	'civics-parks': '660-parks',
 	civics: '600-civics',
+	services: '600-civics',
 	automata: '710-automata',
 	transport: '700-transit',
 	'mmp(s)': '180-flora',

--- a/actions/fetch/test/api-to-metadata-test.js
+++ b/actions/fetch/test/api-to-metadata-test.js
@@ -1,6 +1,7 @@
 // # parse-basic-metadata-test.js
 import { expect } from 'chai';
 import apiToMetadata from '../api-to-metadata.js';
+import * as faker from './faker.js';
 
 describe('#apiToMetadata', function() {
 
@@ -112,6 +113,19 @@ describe('#apiToMetadata', function() {
 		for (let asset of assets) {
 			expect(asset.version).to.equal('1.0.0');
 			expect(asset.lastModified).to.equal('2024-12-05T04:10:52Z');
+		}
+
+	});
+
+	it('handles iso date formats', function() {
+
+		let upload = faker.upload({
+			submitted: '2024-12-05T04:10:52Z',
+			updated: '2024-12-05T04:10:52Z',
+		});
+		let meta = apiToMetadata(upload);
+		for (let asset of meta.assets) {
+			expect(asset.lastModified).to.equal(upload.updated);
 		}
 
 	});

--- a/actions/fetch/test/descriptor-to-subfolder-test.js
+++ b/actions/fetch/test/descriptor-to-subfolder-test.js
@@ -1,0 +1,31 @@
+// # descriptor-to-subfolder-test.js
+import { expect } from 'chai';
+import { descriptorToSubfolder } from '../scrape.js';
+
+describe('#descriptorToSubfolder()', function() {
+
+	before(function() {
+		Object.defineProperty(this, 'folder', {
+			get() {
+				return descriptorToSubfolder(this.test.title.split(',').map(x => x.trim()));
+			},
+		});
+	});
+
+	it('mod, residential', function() {
+		expect(this.folder).to.equal('200-residential');
+	});
+
+	it('residential-re-lot', function() {
+		expect(this.folder).to.equal('200-residential');
+	});
+
+	it('civics, civics-parks-and-recreation', function() {
+		expect(this.folder).to.equal('660-parks');
+	});
+
+	it('utilities, utilities-power-nuclear', function() {
+		expect(this.folder).to.equal('500-utilities');
+	});
+
+});

--- a/actions/fetch/test/descriptor-to-subfolder-test.js
+++ b/actions/fetch/test/descriptor-to-subfolder-test.js
@@ -28,4 +28,8 @@ describe('#descriptorToSubfolder()', function() {
 		expect(this.folder).to.equal('500-utilities');
 	});
 
+	it('services-libraries', function() {
+		expect(this.folder).to.equal('600-civics');
+	});
+
 });

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -207,6 +207,7 @@ describe('The fetch action', function() {
 	it('a package with custom dependencies', async function() {
 
 		let upload = faker.upload({
+			cid: 104,
 			author: 'smf_16',
 			title: 'SMF Tower',
 			files: [
@@ -231,6 +232,7 @@ describe('The fetch action', function() {
 			group: 'smf-16',
 			name: 'smf-tower',
 			version: upload.release,
+			subfolder: '410-agriculture',
 			info: {
 				summary: upload.title,
 				description: 'Custom description',
@@ -258,6 +260,7 @@ describe('The fetch action', function() {
 	it('a package with MN and DN variants', async function() {
 
 		let upload = faker.upload({
+			cid: 102,
 			author: 'smf_16',
 			title: 'SMF Tower',
 			files: [
@@ -274,6 +277,7 @@ describe('The fetch action', function() {
 			group: 'smf-16',
 			name: 'smf-tower',
 			version: upload.release,
+			subfolder: '300-commercial',
 			info: {
 				summary: upload.title,
 				description: upload.description,
@@ -324,7 +328,7 @@ describe('The fetch action', function() {
 			uploads: [{
 				id: 5364,
 				uid: 259789,
-				cid: 100,
+				cid: 102,
 				author: 'smf_16',
 				title: 'SMF Tower',
 				aliasEntry: 'smf-tower',
@@ -356,6 +360,7 @@ describe('The fetch action', function() {
 			group: 'smf-16',
 			name: 'smf-tower',
 			version: '1.0.2',
+			subfolder: '300-commercial',
 			info: {
 				summary: 'SMF Tower',
 				description: 'This is the description',
@@ -403,7 +408,7 @@ describe('The fetch action', function() {
 			uploads: [{
 				id: 5364,
 				uid: 259789,
-				cid: 100,
+				cid: 101,
 				author: 'smf_16',
 				title: 'GitHub Tower',
 				aliasEntry: 'github-tower',
@@ -433,6 +438,7 @@ describe('The fetch action', function() {
 			group: 'github',
 			name: 'smf-github-tower',
 			version: '1.0.2',
+			subfolder: '200-residential',
 			info: {
 				summary: 'GitHub Tower',
 				description: 'This is the description',

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -114,17 +114,30 @@ describe('The fetch action', function() {
 						);
 
 					} else {
-						let { description, images = [] } = upload;
-						let html = images.map(img => {
+						let {
+							description,
+							images = [],
+							fileDescriptor,
+							fileDescriptors = [fileDescriptor],
+						} = upload;
+						let imageHtml = images.map(img => {
 							return `<span data-fullURL="${img}"></span>`;
 						}).join('');
+						let descriptorHtml = '';
+						if (fileDescriptors) {
+							descriptorHtml = `<li>
+								<span><strong>File Descriptor</strong></span>
+								<div>${fileDescriptors.join('\n<br>\n')}</div>
+							</li>`;
+						}
 						return new Response(`<html>
 							<body>
 								<div>
 									<h2>About this file</h2>
 									<section><div>${marked(description)}</div></section>
 								</div>
-								<ul class="cDownloadsCarousel">${html}</ul>
+								<ul class="cDownloadsCarousel">${imageHtml}</ul>
+								${descriptorHtml}
 							</body>
 						</html>`);
 					}
@@ -170,6 +183,7 @@ describe('The fetch action', function() {
 			author: 'smf_16',
 			title: 'SMF Tower',
 			release: '1.0.2',
+			fileDescriptor: 'Residential',
 		});
 		const { run } = this.setup({ uploads: [upload] });
 
@@ -223,6 +237,7 @@ describe('The fetch action', function() {
 					},
 				},
 			],
+			fileDescriptor: 'Agricultural',
 		});
 		const { run } = this.setup({ uploads: [upload] });
 
@@ -267,6 +282,7 @@ describe('The fetch action', function() {
 				'SMF Tower (MN).zip',
 				'SMF Tower (DN).zip',
 			],
+			fileDescriptor: 'Commercial',
 		});
 
 		const { run } = this.setup({ uploads: [upload] });
@@ -351,6 +367,7 @@ describe('The fetch action', function() {
 						contents: {},
 					},
 				],
+				fileDescriptor: 'Commercial',
 			}],
 		});
 
@@ -429,6 +446,7 @@ describe('The fetch action', function() {
 						},
 					},
 				],
+				fileDescriptor: 'Residential',
 			}],
 		});
 
@@ -506,6 +524,7 @@ describe('The fetch action', function() {
 						},
 					},
 				],
+				fileDescriptor: 'Residential',
 			}],
 		});
 
@@ -661,6 +680,33 @@ describe('The fetch action', function() {
 
 		const { packages } = await run({ id: upload.id });
 		expect(packages).to.have.length(0);
+
+	});
+
+	it('uses the file descriptor to generate the subfolder', async function() {
+
+		let upload = faker.upload({
+			fileDescriptor: 'Civics - Landmarks',
+		});
+		const { run } = this.setup({ uploads: [upload] });
+
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata.package.subfolder).to.equal('360-landmark');
+
+	});
+
+	it('picks the best subfolder in case there are multiple descriptors', async function() {
+
+		let upload = faker.upload({
+			fileDescriptors: [
+				'Mod',
+				'Services - Education',
+			],
+		});
+		const { run } = this.setup({ uploads: [upload] });
+
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata.package.subfolder).to.equal('620-education');
 
 	});
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -710,6 +710,15 @@ describe('The fetch action', function() {
 
 	});
 
+	it('picks a subfolder based on what matches best', async function() {
+		let upload = faker.upload({
+			fileDescriptor: 'Residential re-lot for real',
+		});
+		const { run } = this.setup({ uploads: [upload] });
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata.package.subfolder).to.equal('200-residential');
+	});
+
 });
 
 function jsonToYaml(json) {


### PR DESCRIPTION
This PR determines the [subfolder](https://memo33.github.io/sc4pac/#/metadata?id=subfolder) for the generated metadata based on the "file descriptor" from the STEX upload. Currently this is not yet included in the STEX api response, so we rely on the web scraping. This means that currently we rely on the scraping for 3 properties:
- description
- images
- file descriptor

Determining the subfolder happens based on the following map:
```yaml
dependency: 100-props-textures
residential: 200-residential
commercial: 300-commercial
industrial: 400-industrial
agricultural: 410-agriculture
utilities-water: 500-utilities
utilities-power: 500-utilities
utilities-garbage: 500-utilities
services-police: 610-safety
services-fire: 610-safety
services-education: 620-education
services-medical: 630-health
civics-landmarks: 360-landmark
civics-rewards: 360-landmark
civics-parks: 660-parks
civics: 600-civics
automata: 710-automata
transport: 700-transit
mmp(s): 180-flora
mod: 150-mods
misc: 150-mods
```

If a file has multiple descriptors - for example both `Mod` and `Residential`, then the result will be `200-residential` because it has a higher priority in the map.

It also takes into account that descriptors might have longer names. For example, `Residential - Re-lot` does not exist in the table, but if this is the file descriptor, this is reduced to `Residential` automatically. Some examples:

- `Civics`, `Civics - Parks and Recreation` ⇒ `660-parks`
- `Civics`, `Civics - A very specific category of civics` ⇒ `600-civics`
- `Residential Re-lot` ⇒ `200-residential`
- `Mod`, `Utilities - Water` ⇒ `500-utilities`