### PR TITLE
feat: improve Simtropolis error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ See also https://github.com/memo33/sc4pac/issues/49 for the initial idea and dis
 
 - [x] Implement a proof of concept
 - [x] Use the STEX api instead of html scraping
-- [x] Automatically keep track of when the Simtropolis api was last called and only request new files after that date ([#12](https://github.com/sebamarynissen/simtropolis-channel/pull/21))
+- [x] Automatically keep track of when the Simtropolis api was last called and only request new files after that date ([#21](https://github.com/sebamarynissen/simtropolis-channel/pull/21))
 - [x] Support custom metadata as part of the package (by means of a metadata.yaml file in one of the uploads)
-- [ ] Handle various Simtropolis error scenarios (down for maintenance, 520, ...)
+- [x] Handle various Simtropolis error scenarios (down for maintenance, 520, ...) ([#35](https://github.com/sebamarynissen/simtropolis-channel/pull/35))
 - [x] Setup an action that creates a PR instead of pushing to main
 - [ ] Make the metadata generation robust & fool proof
   - [x] Ensure incorrect metadata cannot be deployed

--- a/actions/fetch/action.js
+++ b/actions/fetch/action.js
@@ -5,10 +5,23 @@ import fetch from './fetch.js';
 const url = core.getInput('url');
 const requireMetadata = core.getInput('require-metadata');
 try {
-	const { packages, timestamp } = await fetch({
+	const {
+		packages,
+		timestamp,
+		notices = [],
+		warnings = [],
+	} = await fetch({
 		id: url,
 		requireMetadata,
 	});
+
+	// Log the warnings and notices.
+	for (let warning of warnings) {
+		core.warning(warning);
+	}
+	for (let notice of notices) {
+		core.notice(notice);
+	}
 
 	// Set the proper output variables.
 	let hasNewContent = packages.length > 0;

--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -4,10 +4,11 @@ import fs from 'node:fs';
 import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 import ora from 'ora';
-import { kFileInfo } from './symbols.js';
 import tmp from 'tmp-promise';
 import yauzl from 'yauzl';
 import { parseAllDocuments } from 'yaml';
+import { kFileInfo } from './symbols.js';
+import { SimtropolisError } from './errors.js';
 
 // # Downloader
 // A helper class for downloading urls to a temp folder.
@@ -31,7 +32,7 @@ export default class Downloader {
 			Cookie: process.env.SC4PAC_SIMTROPOLIS_COOKIE,
 		});
 		if (res.status >= 400) {
-			throw new Error(`HTTP ${res.status}`);
+			throw new SimtropolisError(res);
 		}
 		const ws = fs.createWriteStream(destination);
 		await finished(Readable.fromWeb(res.body).pipe(ws));

--- a/actions/fetch/errors.js
+++ b/actions/fetch/errors.js
@@ -1,0 +1,9 @@
+// # errors.js
+export class SimtropolisError extends Error {
+	code = 'simtropolis_error';
+	status = 400;
+	constructor(res) {
+		super(`Simtropolis returned ${res.status} for ${res.url}`);
+		this.status = res.status;
+	}
+}

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -9,6 +9,7 @@ import patchMetadata from './patch-metadata.js';
 import scrape from './scrape.js';
 import Permissions from './permissions.js';
 import { urlToFileId } from './util.js';
+import { SimtropolisError } from './errors.js';
 const MS_DAY = 24*3600e3;
 
 // # fetch(opts)
@@ -79,7 +80,7 @@ export default async function fetchPackage(opts) {
 	let lastRun = new Date().toISOString();
 	let res = await fetch(url);
 	if (res.status >= 400) {
-		throw new Error(`Simtropolis returned ${res.status}!`);
+		throw new SimtropolisError(res);
 	}
 	let json = await res.json();
 	if (id && (!Array.isArray(json) || json.length === 0)) {

--- a/actions/fetch/permissions.js
+++ b/actions/fetch/permissions.js
@@ -35,8 +35,18 @@ export default class PermissionsApi {
 	isUploadAllowed(upload) {
 		if (!this.index) return true;
 		let permission = this.index.usersById.get(String(upload.uid));
-		if (!permission || permission.blocked) return false;
+		if (permission?.blocked) return false;
 		return true;
+	}
+
+	// ## assertUploadAllowed(upload)
+	assertUploadAllowed(upload) {
+		if (!this.isUploadAllowed(upload)) {
+			throw new PermissionsError({
+				message: `Author ${upload.uid} is not allowed to upload a package to the channel!`,
+				code: 'upload_not_allowed',
+			});
+		}
 	}
 
 	// ## assertPackageAllowed(upload, data)

--- a/actions/fetch/scrape.js
+++ b/actions/fetch/scrape.js
@@ -2,6 +2,7 @@
 import { JSDOM } from 'jsdom';
 import ora from 'ora';
 import parseDescription from './parse-description.js';
+import { SimtropolisError } from './errors.js';
 
 // Currently the STEX api does not include the description, nor images. Hence we 
 // still use a scraping approach for now.
@@ -9,7 +10,8 @@ export default async function scrape(url) {
 	let spinner = ora(`Scraping ${url}`).start();
 	let res = await fetch(url);
 	if (res.status >= 400) {
-		throw new Error(`HTTP ${res.status}`);
+		spinner.fail();
+		throw new SimtropolisError(res);
 	}
 	let html = await res.text();
 	spinner.succeed();

--- a/actions/fetch/test/faker.js
+++ b/actions/fetch/test/faker.js
@@ -74,7 +74,7 @@ export function upload(upload = {}) {
 
 // # uploads()
 // Generates a number of fake uploads.
-export function uploads(props = faker.number.int(25)) {
+export function uploads(props = faker.number.int({ min: 1, max: 25 })) {
 	if (typeof props === 'number') {
 		props = new Array(props).fill();
 	}

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1,6 +1,6 @@
 // # integration-test.js
 import { expect } from 'chai';
-import { Document, parseAllDocuments } from 'yaml';
+import { Document, parseAllDocuments, stringify } from 'yaml';
 import mime from 'mime';
 import path from 'node:path';
 import yazl from 'yazl';
@@ -30,6 +30,7 @@ describe('The fetch action', function() {
 
 			const {
 				handler = () => void 0,
+				permissions = null,
 				uploads,
 				lastRun,
 				now = Date.now(),
@@ -37,7 +38,7 @@ describe('The fetch action', function() {
 
 			// Setup a virtual file system where the files reside.
 			let fs = Volume.fromJSON();
-			fs.writeFileSync('/permissions.yaml', '');
+			fs.writeFileSync('/permissions.yaml', permissions ? stringify(permissions) : '');
 
 			// Populate the file where we store when the last file was fetched.
 			if (lastRun) {
@@ -168,7 +169,7 @@ describe('The fetch action', function() {
 			};
 
 			async function run(opts) {
-				let { packages, timestamp } = await action({
+				let { packages, timestamp, notices, warnings } = await action({
 					fs,
 					cwd: '/',
 					...opts,
@@ -181,6 +182,8 @@ describe('The fetch action', function() {
 					},
 					timestamp,
 					packages,
+					notices,
+					warnings,
 					result: packages[0],
 				};
 			};
@@ -591,6 +594,22 @@ describe('The fetch action', function() {
 
 	});
 
+	it('a package without metadata that results in notices', async function() {
+
+		let upload = faker.upload({
+			files: [
+				{
+					contents: {},
+				},
+			],
+		});
+		const { run } = this.setup({ uploads: [upload] });
+		const { packages, notices } = await run({ id: upload.id });
+		expect(packages).to.have.length(0);
+		expect(notices).to.have.length(1);
+
+	});
+
 	it('handles uses with periods in their username', async function() {
 
 		let upload = faker.upload({
@@ -767,8 +786,33 @@ describe('The fetch action', function() {
 			uploads,
 		});
 		let e = await reject(() => run({ id: uploads[0].id }));
+		if (e.code !== 'simtropolis_error') {
+			console.log(e);
+		}
 		expect(e.code).to.equal('simtropolis_error');
 		expect(e.status).to.equal(503);
+
+	});
+
+	it('returns warnings when a user is blocked from the channel', async function() {
+
+		const upload = faker.upload({
+			uid: 5624,
+		});
+		const { run } = this.setup({
+			uploads: [upload],
+			permissions: {
+				authors: [
+					{
+						id: 5624,
+						blocked: true,
+					},
+				],
+			},
+		});
+		const { packages, warnings } = await run({ id: upload.id });
+		expect(packages).to.have.length(0);
+		expect(warnings).to.have.length(1);
 
 	});
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -10,6 +10,17 @@ import action from '../fetch.js';
 import { urlToFileId } from '../util.js';
 import * as faker from './faker.js';
 
+// # reject(fn)
+async function reject(fn) {
+	try {
+		let result = fn();
+		await result;
+	} catch (e) {
+		return e;
+	}
+	throw new Error(`Expected promise to be rejected!`);
+}
+
 describe('The fetch action', function() {
 
 	before(function() {
@@ -18,6 +29,7 @@ describe('The fetch action', function() {
 		this.setup = function(testOptions) {
 
 			const {
+				handler = () => void 0,
 				uploads,
 				lastRun,
 				now = Date.now(),
@@ -35,6 +47,13 @@ describe('The fetch action', function() {
 			// We'll mock the global "fetch" method so that we can mock the api 
 			// & download responses.
 			globalThis.fetch = async function(url) {
+
+				// We will check first of all whether this request should be 
+				// handled by a custom handler, which allows us to simulate 
+				// error codes returned by Simtropolis.
+				let req = new Request(url);
+				let res = handler(req);
+				if (res) return res;
 
 				// Parse the url and check what type of request the action is 
 				// making. Based on this we'll return a different result.
@@ -717,6 +736,40 @@ describe('The fetch action', function() {
 		const { run } = this.setup({ uploads: [upload] });
 		const { result } = await run({ id: upload.id });
 		expect(result.metadata.package.subfolder).to.equal('200-residential');
+	});
+
+	it('throws when the STEX api returns 429', async function() {
+
+		const { run } = this.setup({
+			handler(req) {
+				let url = new URL(req.url);
+				if (url.pathname.startsWith('/stex/files-api.php')) {
+					return new Response('Too many requests', { status: 429 });
+				}
+			},
+			uploads: faker.uploads(),
+		});
+		let e = await reject(() => run());
+		expect(e.code).to.equal('simtropolis_error');
+
+	});
+
+	it('throws when Simtropolis is in maintenance 503', async function() {
+
+		const uploads = faker.uploads();
+		const { run } = this.setup({
+			handler(req) {
+				let url = new URL(req.url);
+				if (url.pathname.startsWith('/files/file')) {
+					return new Response('Maintenance mode', { status: 503 });
+				}
+			},
+			uploads,
+		});
+		let e = await reject(() => run({ id: uploads[0].id }));
+		expect(e.code).to.equal('simtropolis_error');
+		expect(e.status).to.equal(503);
+
 	});
 
 });

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -1,18 +1,16 @@
-# List of creators that are allowed to add their plugin to the channel. For now 
-# you *must* be listed. Once stable, we can lift this requirement, but the 
-# permissions will still be useful for determining who has access to which 
-# groups.
+# For now, everyone is allowed to include their package on the channel, but if
+# it turns out that people are abusing this, then they might be blocked from the 
+# channel. This can be done by including them here, and then blocking them.
 authors:
-  - name: smf_16
-    id: 259789
 
-  # Allow Jasoncw for testing
-  - name: Jasoncw
-    id: 85340
-
-# Exemplar for permissions for specific packages.
+# Example for permissions for specific packages.
 # authors:
 #   - name: Aaron Graham
 #     id: 226625
 #     groups:
 #       - nybt
+
+# Example for blocking someone
+# authors:
+#   - id: 1234
+#     blocked: true


### PR DESCRIPTION
This PR improves the error handling for when Simtropolis returns an HTTP 400 or higher (like `429 Too many requests`, `403 Forbidding`, `503 Service Unavailable`).

Currently the action will simply throw an error. However, there's a case where we might actually *partially* succeed. Imagine for example the case where the STEX api returns 3 new uploads. The first one is handled without problems, the second one bumps into a 520, but the third one is again processed correctly. In this case, we could continue and create a PR for upload 1, and then advance the last run date to the update date of file 1, instead of the current time. We can't do this for upload 3, because this would advance the last run date too much, and hence upload 2 won't be processed again the next run.

What's your opinion on this, @memo33?