### PR TITLE
feat: read `LAST_RUN` from repository variables

### DIFF
--- a/.github/workflows/add-packages.yaml
+++ b/.github/workflows/add-packages.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: ./actions/fetch
         with:
           url: ${{ github.event.inputs.url }}
+          after: ${{ vars.LAST_RUN }}
           require-metadata: ${{ github.events.inputs.require-metadata }}
       - name: Setup linter
         if: steps.fetch.outputs.has-new-content == 'true'

--- a/actions/fetch/action.js
+++ b/actions/fetch/action.js
@@ -5,6 +5,7 @@ import fetch from './fetch.js';
 
 const url = core.getInput('url');
 const requireMetadata = yn(core.getInput('require-metadata'));
+const after = core.getInput('after');
 try {
 	const {
 		packages,
@@ -13,6 +14,7 @@ try {
 		warnings = [],
 	} = await fetch({
 		id: url,
+		after,
 		requireMetadata,
 	});
 

--- a/actions/fetch/action.yaml
+++ b/actions/fetch/action.yaml
@@ -8,11 +8,15 @@ inputs:
     description: Whether a metadata.yaml file is required to add the package. Useful to turn this off for testing.
     type: boolean
     default: true
+  last-run:
+    description: An ISO date string that holds the timestamp when the STEX api was last checked.
+    type: string
+    required: true
 outputs:
   packages:
     description: Info about the packages that have been created, given as a stringified json array.
   timestamp:
-    description: The timestamp when we last fetch from the STEX api. Can be empty if the timestamp shouldn't be logged.
+    description: The timestamp when we last fetched from the STEX api. Can be empty if the timestamp shouldn't be logged.
   has-new-content:
     description: Holds whether new content is available for which PRs need to be created or updated. If "false", you can exit the action early. Nothing needs to be done.
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -640,6 +640,25 @@ describe('The fetch action', function() {
 			'2024-12-20T12:00:00Z',
 			'2024-11-30T17:00:00Z',
 		]);
+		let after = '2024-12-21T12:00:00Z';
+		const { run } = this.setup({ uploads });
+
+		const { packages, timestamp } = await run({ after });
+		expect(packages).to.have.length(1);
+		expect(packages[0].metadata.package.info.website).to.equal(uploads[0].fileURL);
+
+		expect(Date.parse(timestamp)).to.be.above(Date.parse(after));
+
+	});
+
+	it('fetches all files from the STEX api since the last fetch date from LAST_RUN if no id was specified', async function() {
+
+		let uploads = faker.uploads([
+			'2024-12-21T14:00:00Z',
+			'2024-12-21T11:00:00Z',
+			'2024-12-20T12:00:00Z',
+			'2024-11-30T17:00:00Z',
+		]);
 		let lastRun = '2024-12-21T12:00:00Z';
 		const { run } = this.setup({
 			uploads,


### PR DESCRIPTION
Instead of committing the last run date to the repository every time, this PR moves this to the repository variables. Not ideal becuase it needs a personal access token, but we can think of a better solution in the meantime.

Related to a discussion in #37.