### PR TITLE
fix: handle 404 for no new files

### DIFF
--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -854,6 +854,22 @@ describe('The fetch action', function() {
 
 	});
 
+	it('does not throw when the STEX api returns 404', async function() {
+
+		const { run } = this.setup({
+			handler() {
+				return new Response(JSON.stringify({
+					message: 'No STEX files were found for the specified query',
+					code: '404',
+				}), { status: 404 });
+			},
+		});
+		let result = await run({});
+		expect(result.packages).to.eql([]);
+		expect(result.timestamp).to.be.ok;
+
+	});
+
 });
 
 function jsonToYaml(json) {


### PR DESCRIPTION
Apparently the STEX api returns 404 if it couldn't find any files that match the criteria, meaning that if we call it with a parameter `days=2`, but no files were updated during that period, then it won't return an empty array, but 404 and an error message. This is not actually an error for the action, so this PR makes sure this is gracefully handled.