### PR TITLE
feat: implement new naming convention

### DIFF
--- a/actions/fetch/attempt.js
+++ b/actions/fetch/attempt.js
@@ -1,0 +1,9 @@
+// # attempt(fn)
+// Helper function that mimicks the "safe assignment operator" proposal.
+export default async function attempt(fn) {
+	try {
+		return [null, await fn()];
+	} catch (e) {
+		return [e, null];
+	}
+}

--- a/actions/fetch/check-previous-version.js
+++ b/actions/fetch/check-previous-version.js
@@ -54,11 +54,6 @@ export default async function checkPreviousVersion(id, metadata, opts) {
 	// Now return that the old file has to be deleted when creating a new PR. 
 	// Note that if the name of the file doesn't change, this isn't a problem, 
 	// it will be overwritten anyway by the new contents!
-	return [
-		{
-			type: 'deletion',
-			file: `${srcPath}/${author}/${prev}`,
-		},
-	];
+	return [`${srcPath}/${author}/${prev}`];
 
 }

--- a/actions/fetch/check-previous-version.js
+++ b/actions/fetch/check-previous-version.js
@@ -1,0 +1,64 @@
+// # check-previous-version.js
+import path from 'node:path';
+import attempt from './attempt.js';
+import { parseAllDocuments } from 'yaml';
+
+// See #42. This function checks for a previous version of the file. If it 
+// exists, then it makes sure the name of the package can't be changed 
+// unintentionally by keeping the original name.
+export default async function checkPreviousVersion(id, metadata, opts) {
+
+	// Check if a previous version of the file exists by file id. We do this by 
+	// checking the folder for the author.
+	let { cwd, srcPath, fs } = opts;
+	let author = metadata.package.group;
+	let dir = path.resolve(cwd, srcPath, author);
+	const [error, contents] = await attempt(() => fs.promises.readdir(dir));
+	if (error) {
+
+		// If the author's directory does not even exist, we're good.
+		if (error.code === 'ENOENT') return [];
+		else throw error;
+	}
+
+	// Look for all files in the authors directory for the file id. If we can't 
+	// find it, this is a new file and nothing needs to be done.
+	let prev = contents.find(name => name.startsWith(`${id}-`));
+	if (!prev) return [];
+
+	// Cool, we now know that a previous version of metadata for this file 
+	// upload existed. We'll read it in & parse it so that we can keep the 
+	// metadata backwards compatible.
+	let filePath = path.join(dir, prev);
+	let yaml = await fs.promises.readFile(filePath);
+	let packages = parseAllDocuments(String(yaml))
+		.map(doc => doc.toJSON())
+		.filter(doc => doc.group);
+
+	// Note: there's a possible edge case. If the user manually wrote metadata 
+	// for multiple packages, then we can't really know what the "main" package 
+	// is. For example, when a package was split up in resources and lots, it 
+	// can be hard to determine what the "main" package is. It's kind of an 
+	// extreme case though, and we'll encourage users to explicitly specify the 
+	// name in those case. We might even enforce this somehow.
+	packages.sort((a, b) => {
+		return (
+			(+!!b.info?.website - +!!a.info?.website) ||
+			(+!!b.info?.images - +!!a.info?.images)
+		);
+	});
+	let [main] = packages;
+	metadata.package.group = main.group;
+	metadata.package.name = main.name;
+
+	// Now return that the old file has to be deleted when creating a new PR. 
+	// Note that if the name of the file doesn't change, this isn't a problem, 
+	// it will be overwritten anyway by the new contents!
+	return [
+		{
+			type: 'deletion',
+			file: `${srcPath}/${author}/${prev}`,
+		},
+	];
+
+}

--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -9,6 +9,7 @@ import yauzl from 'yauzl';
 import { parseAllDocuments } from 'yaml';
 import { kFileInfo } from './symbols.js';
 import { SimtropolisError } from './errors.js';
+import attempt from './attempt.js';
 
 // # Downloader
 // A helper class for downloading urls to a temp folder.
@@ -168,14 +169,4 @@ function withResolvers() {
 		reject = _reject;
 	});
 	return { promise, resolve, reject };
-}
-
-// # attempt(fn)
-// Helper function that mimicks the "safe assignment operator" proposal.
-async function attempt(fn) {
-	try {
-		return [null, await fn()];
-	} catch (e) {
-		return [e, null];
-	}
 }

--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -108,8 +108,8 @@ export default async function handleUpload(json, opts = {}) {
 	await fs.promises.writeFile(output, yaml);
 	return {
 		id,
+		metadata: zipped,
 		branchId: String(json.id),
-		metadata,
 		deletions,
 		additions: [relativePath],
 	};

--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -97,7 +97,8 @@ export default async function handleUpload(json, opts = {}) {
 		};
 	}
 
-	// 
+	// Allright, we're pretty much done now. Write away the metadata and return 
+	// the information about what we've generated.
 	let { group, name } = main;
 	let id = `${group}:${name}`;
 	let yaml = serialize(zipped);
@@ -107,8 +108,10 @@ export default async function handleUpload(json, opts = {}) {
 	await fs.promises.writeFile(output, yaml);
 	return {
 		id,
+		branchId: String(json.id),
 		metadata,
-		files: [...deletions, relativePath],
+		deletions,
+		additions: [relativePath],
 	};
 
 }

--- a/actions/fetch/patch-metadata.js
+++ b/actions/fetch/patch-metadata.js
@@ -4,25 +4,38 @@ import * as dot from 'dot-prop';
 // This function takes the main package metadata as generated from the STEX, and 
 // then applies the user-defined metadata as a patch to it. Note that it's 
 // possible that the user has specified multiple packages.
-export default function patchMetadata(metadata, patch) {
+export default function patchMetadata(metadata, patch, original) {
 
 	// If nothing needs to be patched, just return the package as is.
 	if (!patch || patch === true) {
-		return Object.assign([metadata.package], { main: metadata.package });
+		return {
+			packages: [metadata.package],
+			main: metadata.package,
+			basename: original.name,
+		};
 	}
 
 	// We first have to figure out what the "main package" of the user-defined 
 	// metadata is, because the parsed dependencies and variants from the api 
 	// should only be applied to the main package.
+	let basename = original.name;
 	let mainIndex = findMainPackageIndex(patch);
-	let patched = [patch]
+	let packages = [patch]
 		.flat()
-		.map((patch, index) => applyPatch(metadata.package, patch, {
-			main: index === mainIndex,
-		}))
-		.map(pkg => fill(pkg, metadata));
-	patched.main = patched[mainIndex];
-	return patched;
+		.map((patch, index) => {
+			let isMain = index === mainIndex;
+			let bare = applyPatch(metadata.package, patch, { main: isMain });
+			let filled = fill(bare, metadata);
+			if (isMain && patch.name) {
+				basename = filled.name;
+			}
+			return filled;
+		});
+	return {
+		packages,
+		main: packages[mainIndex],
+		basename,
+	};
 
 }
 

--- a/actions/fetch/patch-metadata.js
+++ b/actions/fetch/patch-metadata.js
@@ -4,7 +4,11 @@ import * as dot from 'dot-prop';
 // This function takes the main package metadata as generated from the STEX, and 
 // then applies the user-defined metadata as a patch to it. Note that it's 
 // possible that the user has specified multiple packages.
-export default function patchMetadata(metadata, patch, original) {
+export default function patchMetadata(
+	metadata,
+	patch,
+	original = metadata.package,
+) {
 
 	// If nothing needs to be patched, just return the package as is.
 	if (!patch || patch === true) {

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -212,11 +212,12 @@ describe('The fetch action', function() {
 		const { run } = this.setup({ uploads: [upload] });
 
 		let { read, result } = await run({ id: upload.id });
-		expect(result.files).to.eql([
+		expect(result.additions).to.eql([
 			`src/yaml/smf-16/${upload.id}-smf-tower.yaml`,
 		]);
+		expect(result.branchId).to.equal('111');
 
-		let metadata = read(result.files.at(0));
+		let metadata = read(result.additions.at(0));
 		expect(metadata[0]).to.eql({
 			group: 'smf-16',
 			name: 'smf-tower',
@@ -553,7 +554,7 @@ describe('The fetch action', function() {
 		});
 
 		let { read, result } = await run({ id: 2145 });
-		expect(result.files).to.eql([
+		expect(result.additions).to.eql([
 			'src/yaml/smf-16/2145-st-residences.yaml',
 		]);
 		let metadata = read('/src/yaml/smf-16/2145-st-residences.yaml');
@@ -938,14 +939,11 @@ describe('The fetch action', function() {
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
 		let { packages } = await run({ id: upload.id });
-		let [{ metadata, files }] = packages;
+		let [{ metadata, deletions, additions }] = packages;
 		expect(metadata.package.group).to.equal('smf-16');
 		expect(metadata.package.name).to.equal('old-title');
-		expect(files).to.have.length(2);
-		let deletion = files.find(file => file.type === 'deletion');
-		expect(deletion.file).to.equal('src/yaml/smf-16/42592-old-title.yaml');
-		let addition = files.find(file => typeof file === 'string');
-		expect(addition).to.equal('src/yaml/smf-16/42592-new-title.yaml');
+		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
+		expect(additions[0]).to.equal('src/yaml/smf-16/42592-new-title.yaml');
 
 	});
 
@@ -987,14 +985,11 @@ describe('The fetch action', function() {
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
 		let { packages } = await run({ id: upload.id });
-		let [{ metadata, files }] = packages;
+		let [{ metadata, deletions, additions }] = packages;
 		expect(metadata.package.group).to.equal('smf-16');
 		expect(metadata.package.name).to.equal('old-title');
-		expect(files).to.have.length(2);
-		let deletion = files.find(file => file.type === 'deletion');
-		expect(deletion.file).to.equal('src/yaml/smf-16/42592-old-title.yaml');
-		let addition = files.find(file => typeof file === 'string');
-		expect(addition).to.equal('src/yaml/smf-16/42592-new-title.yaml');
+		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
+		expect(additions[0]).to.equal('src/yaml/smf-16/42592-new-title.yaml');
 
 	});
 
@@ -1037,14 +1032,11 @@ describe('The fetch action', function() {
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
 		let { packages } = await run({ id: upload.id });
-		let [{ metadata, files }] = packages;
+		let [{ metadata, deletions, additions }] = packages;
 		expect(metadata.package.group).to.equal('smf-16');
 		expect(metadata.package.name).to.equal('old-title');
-		expect(files).to.have.length(2);
-		let deletion = files.find(file => file.type === 'deletion');
-		expect(deletion.file).to.equal('src/yaml/smf-16/42592-old-title.yaml');
-		let addition = files.find(file => typeof file === 'string');
-		expect(addition).to.equal('src/yaml/smf-16/42592-custom-new-title.yaml');
+		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
+		expect(additions[0]).to.equal('src/yaml/smf-16/42592-custom-new-title.yaml');
 
 	});
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -620,7 +620,7 @@ describe('The fetch action', function() {
 		});
 		const { run } = this.setup({ uploads: [upload] });
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata.package.group).to.equal('some-user');
+		expect(result.metadata[0].group).to.equal('some-user');
 
 	});
 
@@ -631,7 +631,7 @@ describe('The fetch action', function() {
 		});
 		const { run } = this.setup({ uploads: [upload] });
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata.package.name).to.equal('jast-o-conner-and-cremin');
+		expect(result.metadata[0].name).to.equal('jast-o-conner-and-cremin');
 
 	});
 
@@ -648,7 +648,7 @@ describe('The fetch action', function() {
 
 		const { packages, timestamp } = await run({ after });
 		expect(packages).to.have.length(1);
-		expect(packages[0].metadata.package.info.website).to.equal(uploads[0].fileURL);
+		expect(packages[0].metadata[0].info.website).to.equal(uploads[0].fileURL);
 
 		expect(Date.parse(timestamp)).to.be.above(Date.parse(after));
 
@@ -670,7 +670,7 @@ describe('The fetch action', function() {
 
 		const { packages, timestamp } = await run();
 		expect(packages).to.have.length(1);
-		expect(packages[0].metadata.package.info.website).to.equal(uploads[0].fileURL);
+		expect(packages[0].metadata[0].info.website).to.equal(uploads[0].fileURL);
 
 		expect(Date.parse(timestamp)).to.be.above(Date.parse(lastRun));
 
@@ -751,7 +751,7 @@ describe('The fetch action', function() {
 		const { run } = this.setup({ uploads: [upload] });
 
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata.package.subfolder).to.equal('360-landmark');
+		expect(result.metadata[0].subfolder).to.equal('360-landmark');
 
 	});
 
@@ -766,7 +766,7 @@ describe('The fetch action', function() {
 		const { run } = this.setup({ uploads: [upload] });
 
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata.package.subfolder).to.equal('620-education');
+		expect(result.metadata[0].subfolder).to.equal('620-education');
 
 	});
 
@@ -776,7 +776,7 @@ describe('The fetch action', function() {
 		});
 		const { run } = this.setup({ uploads: [upload] });
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata.package.subfolder).to.equal('200-residential');
+		expect(result.metadata[0].subfolder).to.equal('200-residential');
 	});
 
 	it('throws when the STEX api returns 429', async function() {
@@ -938,12 +938,13 @@ describe('The fetch action', function() {
 		await fs.promises.mkdir('/src/yaml/smf-16', { recursive: true });
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
-		let { packages } = await run({ id: upload.id });
-		let [{ metadata, deletions, additions }] = packages;
-		expect(metadata.package.group).to.equal('smf-16');
-		expect(metadata.package.name).to.equal('old-title');
+		let { read, packages } = await run({ id: upload.id });
+		let [{ deletions, additions }] = packages;
 		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
 		expect(additions[0]).to.equal('src/yaml/smf-16/42592-new-title.yaml');
+		let metadata = await read('src/yaml/smf-16/42592-new-title.yaml');
+		expect(metadata[0].group).to.equal('smf-16');
+		expect(metadata[0].name).to.equal('old-title');
 
 	});
 
@@ -984,16 +985,17 @@ describe('The fetch action', function() {
 		await fs.promises.mkdir('/src/yaml/smf-16', { recursive: true });
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
-		let { packages } = await run({ id: upload.id });
-		let [{ metadata, deletions, additions }] = packages;
-		expect(metadata.package.group).to.equal('smf-16');
-		expect(metadata.package.name).to.equal('old-title');
+		let { read, packages } = await run({ id: upload.id });
+		let [{ deletions, additions }] = packages;
 		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
 		expect(additions[0]).to.equal('src/yaml/smf-16/42592-new-title.yaml');
+		let metadata = await read('/src/yaml/smf-16/42592-new-title.yaml');
+		expect(metadata[0].group).to.equal('smf-16');
+		expect(metadata[0].name).to.equal('old-title');
 
 	});
 
-	it('changes the filename of an uploaded package with custom metadata without a name (#42)', async function() {
+	it('changes the filename of an uploaded package with custom metadata with a name (#42)', async function() {
 
 		const upload = faker.upload({
 			id: 42592,
@@ -1031,12 +1033,13 @@ describe('The fetch action', function() {
 		await fs.promises.mkdir('/src/yaml/smf-16', { recursive: true });
 		fs.writeFileSync('/src/yaml/smf-16/42592-old-title.yaml', src);
 
-		let { packages } = await run({ id: upload.id });
-		let [{ metadata, deletions, additions }] = packages;
-		expect(metadata.package.group).to.equal('smf-16');
-		expect(metadata.package.name).to.equal('old-title');
+		let { read, packages } = await run({ id: upload.id });
+		let [{ deletions, additions }] = packages;
 		expect(deletions[0]).to.equal('src/yaml/smf-16/42592-old-title.yaml');
 		expect(additions[0]).to.equal('src/yaml/smf-16/42592-custom-new-title.yaml');
+		let metadata = await read('/src/yaml/smf-16/42592-custom-new-title.yaml');
+		expect(metadata[0].group).to.equal('smf-16');
+		expect(metadata[0].name).to.equal('custom-new-title');
 
 	});
 

--- a/actions/fetch/test/patch-metadata-test.js
+++ b/actions/fetch/test/patch-metadata-test.js
@@ -23,7 +23,7 @@ describe('#patchMetadata()', function() {
 				},
 			},
 		};
-		let packages = patchMetadata(metadata, null);
+		let { packages } = patchMetadata(metadata, null);
 		expect(packages).to.have.length(1);
 		expect(packages[0]).to.eql(metadata.package);
 
@@ -44,7 +44,7 @@ describe('#patchMetadata()', function() {
 			},
 		};
 		let patch = read('group-override.yaml');
-		let packages = patchMetadata(metadata, patch);
+		let { packages } = patchMetadata(metadata, patch);
 		expect(packages).to.have.length(1);
 		let [pkg] = packages;
 		expect(pkg.group).to.equal('sfbt');
@@ -73,7 +73,7 @@ describe('#patchMetadata()', function() {
 		};
 
 		let patch = read('interpolation.yaml');
-		let [pkg] = patchMetadata(metadata, patch);
+		let { packages: [pkg] } = patchMetadata(metadata, patch);
 		expect(pkg).to.eql({
 			group: 'smf-16',
 			name: 'reference-assets',
@@ -116,7 +116,7 @@ describe('#patchMetadata()', function() {
 		};
 
 		let patch = read('resource-package.yaml');
-		let [resources, main] = patchMetadata(metadata, patch);
+		let { packages: [resources, main] } = patchMetadata(metadata, patch);
 		expect(resources).to.eql({
 			group: 'smf-16',
 			name: 'some-building-resources',


### PR DESCRIPTION
This PR implements the new naming convention as discussed in #42. This means that files now always get prefixed with the stex file id to ensure uniqueness. When a package changes names, the original stex title is kept, unless explicitly overridden.