### PR TITLE
feat: automatically strip prefixes

### DIFF
--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -30,7 +30,8 @@ export default async function handleUpload(json, opts = {}) {
 	// sufficient to look for a `metadata.yaml` file in the downloads. We'll do 
 	// that first before completing the metadata with scraping, because we might 
 	// be able to shortcut already here.
-	let metadata = apiToMetadata(json);
+	let { permissions } = opts;
+	let metadata = apiToMetadata(permissions.transform(json));
 	let parsedMetadata = false;
 	let downloader = new Downloader();
 	for (let asset of metadata.assets) {
@@ -87,7 +88,6 @@ export default async function handleUpload(json, opts = {}) {
 	} = patchMetadata(metadata, parsedMetadata, original);
 	let zipped = [...packages, ...metadata.assets];
 	try {
-		let { permissions } = opts;
 		permissions.assertPackageAllowed(json, packages);
 	} catch (e) {
 		return {

--- a/actions/fetch/permissions.js
+++ b/actions/fetch/permissions.js
@@ -29,6 +29,26 @@ export default class PermissionsApi {
 		}
 	}
 
+	// ## transform(upload)
+	// The transform function applies some transformations to the stex api 
+	// response based on our permissions configuration. Most notably this allows 
+	// us to strip prefixes from the title as certain authors sometimes prefix 
+	// their uploads.
+	transform(upload) {
+		let config = this.index?.usersById.get(String(upload.uid));
+		if (!config) return upload;
+		let clone = { ...upload };
+		for (let prefix of config.prefixes || []) {
+			let regex = new RegExp(`^${prefix}\\b`, 'i');
+			clone.title = clone.title.replace(regex, '').trim();
+			clone.aliasEntry = clone.aliasEntry
+				.replace(regex, '')
+				.replace(/^-+/, '')
+				.trim();
+		}
+		return clone;
+	}
+
 	// ## isUploadAllowed(upload)
 	// Returns whether the user that has made the given stex upload - as stex 
 	// api response - is actually allowed to do this.

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1043,6 +1043,32 @@ describe('The fetch action', function() {
 
 	});
 
+	it('strips known prefixes from the upload title', async function() {
+
+		const upload = faker.upload({
+			uid: 444001,
+			author: 'Simmer2',
+			title: 'SM2 Some package',
+		});
+		const { run } = this.setup({
+			uploads: [upload],
+			permissions: {
+				authors: [{
+					name: 'Simmer2',
+					id: 444001,
+					prefixes: [
+						'sm2',
+					],
+				}],
+			},
+		});
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata[0].group).to.equal('simmer2');
+		expect(result.metadata[0].name).to.equal('some-package');
+		expect(result.metadata[0].info.summary).to.equal('Some package');
+
+	});
+
 });
 
 function jsonToYaml(json) {

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -2,6 +2,33 @@
 # it turns out that people are abusing this, then they might be blocked from the 
 # channel. This can be done by including them here, and then blocking them.
 authors:
+  - name: Pegasus
+    id: 2813
+    prefixes:
+      - peg
+  - name: kingofsimcity
+    id: 33566
+    prefixes:
+      - kosc
+      - king's
+  - name: MarcosMX
+    id: 111156
+    prefixes:
+      - blam
+      - mx
+      - rnp
+  - name: pclark06
+    id: 364367
+    prefixes:
+      - pc
+  - name: Simmer2
+    id: 444001
+    prefixes:
+      - sm2
+  - name: RRetail
+    id: 744613
+    prefixes:
+      - rr
 
 # Example for permissions for specific packages.
 # authors:


### PR DESCRIPTION
This PR adds the functionality to automatically strip prefixes from STEX titles. This is needed because certain creators prefix the title of their content, such as `SM2 Concrete Sound Barriers`. It doesn't make sense to transform this into the name `simmer2:sm2-concrete-sound-barriers`, so we strip this from the title automatically.