### PR TITLE
feat: transform `<iframe>` to links

### DIFF
--- a/actions/fetch/parse-description.js
+++ b/actions/fetch/parse-description.js
@@ -63,3 +63,17 @@ td.addRule('popular', {
 	},
 	replacement: () => '',
 });
+
+// Transform iframes into links.
+td.addRule('iframe', {
+	filter(node) {
+		if (node.nodeName !== 'IFRAME') return;
+		let src = node.getAttribute('src');
+		let url = new URL(src, 'https://community.simtropolis.com');
+		return url.hostname.includes('community.simtropolis.com');
+	},
+	replacement: (_content, node) => {
+		let src = node.getAttribute('src');
+		return `[${src}](${src})\n`;
+	},
+});

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1069,6 +1069,25 @@ describe('The fetch action', function() {
 
 	});
 
+	it('parses iframes from the html description', async function() {
+
+		const upload = faker.upload({
+			description: `
+			Here are some of my packages:
+
+			<iframe src="https://community.simtropolis.com/files/file/1-one"></iframe>
+			<iframe src="https://community.simtropolis.com/files/file/2-two"></iframe>
+			`.trim().split('\n').map(x => x.trim()).join('\n'),
+		});
+		const { run } = this.setup({
+			uploads: [upload],
+		});
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata[0].info.description).to.include('[https://community.simtropolis.com/files/file/1-one](https://community.simtropolis.com/files/file/1-one)');
+		expect(result.metadata[0].info.description).to.include('[https://community.simtropolis.com/files/file/2-two](https://community.simtropolis.com/files/file/2-two)');
+
+	});
+
 });
 
 function jsonToYaml(json) {


### PR DESCRIPTION
This PR transforms `<iframe>`'s in the description to links. This is useful when dependencies are included as an embedded iframe.