### PR TITLE
metadata: add modular amusement park pack

### DIFF
--- a/src/yaml/aldara6166/17557-modular-amusement-park-pack-essentials.yaml
+++ b/src/yaml/aldara6166/17557-modular-amusement-park-pack-essentials.yaml
@@ -1,0 +1,42 @@
+group: aldara6166
+name: modular-amusement-park-pack-essentials
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Modular Amusement Park Pack Essentials
+  description: |-
+    **The MAPP** - ***the first official download of 2007*** - is finally here!!  
+      
+    Are trips to the local mall, or the local zoo and aquarium the only entertainment that you can provide for your Sims? Have your Sims every wanted for something more to do on a long, summer's weekend than just go to the beach?  
+    Well now you too can provide the fun and entertainment that your Sims so desperately deserve. Introducing the Modular Amusement Park Pack (MAPP) presented by RJM Designs.
+
+    This set is made up of amusement park rides, roller coasters, midway entertainment and more. Currently there are a few amusement park BATs available on the STEX, but this pack draws everything together.\[/size\]  
+    So dive right in and create that "dream park" that you have always dreamt of, or re-create your favorite amusement park from the memories of your childhood.  
+    The MAPP . . . making your Sims' entertainment dreams a reality!
+
+    \* NOTE - The MAPP uses the ped-malls that are included in Network Addon Mod to tie all of our custom BATs together. See How to build an Amusement Park in the readme file for instructions.\*
+
+    This is the Essentials pack. It includes several custom props, textures, etc. This pack also includes many buildings that you would normally associate as "core buildings" within any amusement park. Without this pack the other packs will not function properly.  
+      
+    Please delete any and all prior versions of all MAPP lots (including the construction lot) prior to installation to avoid conflicts.  
+      
+    **Dependancies:**
+
+    [Porkie Props Vol.1](https://community.simtropolis.com/files/file/11421-porkie-props-vol1-european-street-accessories/)  
+    [BSC Textures Mega Pack](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+  author: aldara6166
+  website: https://community.simtropolis.com/files/file/17557-modular-amusement-park-pack-essentials/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_05_2011/9ea96d20d60fae9dc52ac9366efcf37e-mapp_ancillary1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2011/a5481ffffca08a633308484e7a642b2b-mapp_ancillary2.jpg
+dependencies:
+  - bsc:textures-vol01
+  - porkissimo:jenx-porkie-expanded-porkie-props
+assets:
+  - assetId: aldara6166-modular-amusement-park-pack-essentials
+
+---
+assetId: aldara6166-modular-amusement-park-pack-essentials
+version: "1.0"
+lastModified: "2007-01-01T08:46:03Z"
+url: https://community.simtropolis.com/files/file/17557-modular-amusement-park-pack-essentials/?do=download&r=86577

--- a/src/yaml/aldara6166/17558-modular-amusement-park-pack-classic-rides.yaml
+++ b/src/yaml/aldara6166/17558-modular-amusement-park-pack-classic-rides.yaml
@@ -1,0 +1,51 @@
+group: aldara6166
+name: modular-amusement-park-pack-classic-rides
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Modular Amusement Park Pack Classic Rides
+  description: |-
+    The MAPP - ***the first official download of 2007*** - is finally here!!  
+      
+     Are trips to the local mall, or the local zoo and aquarium the only entertainment that you can provide for your Sims? Have your Sims every wanted for something more to do on a long, summer's weekend than just go to the beach?
+
+    Well now you too can provide the fun and entertainment that your Sims so desperately deserve. Introducing the Modular Amusement Park Pack (MAPP) presented by RJM Designs.
+
+    This set is made up of amusement park rides, roller coasters, midway entertainment and more. Currently there are a few amusement park BATs available on the STEX, but this pack draws everything together.
+
+    So dive right in and create that "dream park" that you have always dreamt of, or re-create your favorite amusement park from the memories of your childhood.
+
+    The MAPP . . . making your Sims' entertainment dreams a reality!
+
+    ***\* NOTE - The MAPP uses the ped-malls that are included in Network Addon Mod to tie all of our custom BATs together. See How to build an Amusement Park in the readme file for instructions.******\**** 
+
+    This pack includes many classic amusement park rides that you would normally associate with any amusement park.  Without the Essentials pack, this pack will not function properly.  
+      
+    Please delete any and all prior versions of all MAPP lots (including the construction lot) prior to installation to avoid conflicts.  
+      
+    **dependencies:** 
+
+    **Porkie Props Vol. 1**
+
+    [**https://www.simtropolis.com/STEX/index.cfm?id=11421**](https://www.simtropolis.com/stex/index.cfm?id=11421)
+
+    **BSC PEG Texture Pack Vol. 01****  
+    **\- or -**  
+    **BSC Textures Mega Pack****
+  author: aldara6166
+  website: https://community.simtropolis.com/files/file/17558-modular-amusement-park-pack-classic-rides/
+  images:
+    - https://www.simtropolis.com/objects/screens/0024/de33e244078e09448cf950a949cd2900-MAPP_ClassicRides1.jpg
+    - https://www.simtropolis.com/objects/screens/0024/de33e244078e09448cf950a949cd2900-MAPP_ClassicRides2.jpg
+dependencies:
+  - aldara6166:modular-amusement-park-pack-essentials
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - bsc:textures-vol01
+assets:
+  - assetId: aldara6166-modular-amusement-park-pack-classic-rides
+
+---
+assetId: aldara6166-modular-amusement-park-pack-classic-rides
+version: "1.0"
+lastModified: "2007-01-01T08:53:17Z"
+url: https://community.simtropolis.com/files/file/17558-modular-amusement-park-pack-classic-rides/?do=download&r=40917

--- a/src/yaml/aldara6166/17559-modular-amusement-park-pack-modern-rides.yaml
+++ b/src/yaml/aldara6166/17559-modular-amusement-park-pack-modern-rides.yaml
@@ -1,0 +1,51 @@
+group: aldara6166
+name: modular-amusement-park-pack-modern-rides
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Modular Amusement Park Pack Modern Rides
+  description: |-
+    The MAPP - ***the first official download of 2007*** - is finally here!!  
+      
+     Are trips to the local mall, or the local zoo and aquarium the only entertainment that you can provide for your Sims? Have your Sims every wanted for something more to do on a long, summer's weekend than just go to the beach?
+
+    Well now you too can provide the fun and entertainment that your Sims so desperately deserve. Introducing the Modular Amusement Park Pack (MAPP) presented by RJM Designs.
+
+    This set is made up of amusement park rides, roller coasters, midway entertainment and more. Currently there are a few amusement park BATs available on the STEX, but this pack draws everything together.
+
+    So dive right in and create that "dream park" that you have always dreamt of, or re-create your favorite amusement park from the memories of your childhood.
+
+    The MAPP . . . making your Sims' entertainment dreams a reality!
+
+    ***\* NOTE - The MAPP uses the ped-malls that are included in Network Addon Mod to tie all of our custom BATs together. See How to build an Amusement Park in the readme file for instructions.******\**** 
+
+    This pack includes many modern amusement park rides that you would normally associate with most larger amusement parks.  Without the Essentials pack, this pack will not function properly.  
+      
+    Please delete any and all prior versions of all MAPP lots (including the construction lot) prior to installation to avoid conflicts.  
+      
+    **dependencies:** 
+
+    **Porkie Props Vol. 1**
+
+    [**https://www.simtropolis.com/STEX/index.cfm?id=11421**](https://www.simtropolis.com/stex/index.cfm?id=11421)
+
+    **BSC PEG Texture Pack Vol. 01****  
+    **\- or -**  
+    **BSC Textures Mega Pack****
+  author: aldara6166
+  website: https://community.simtropolis.com/files/file/17559-modular-amusement-park-pack-modern-rides/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/bec1fe8fc6b3193f16bedc6beb0e2910-MAPP_ModernRides1.jpg
+    - https://www.simtropolis.com/objects/screens/0021/bec1fe8fc6b3193f16bedc6beb0e2910-MAPP_ModernRides2.jpg
+dependencies:
+  - aldara6166:modular-amusement-park-pack-essentials
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - bsc:textures-vol01
+assets:
+  - assetId: aldara6166-modular-amusement-park-pack-modern-rides
+
+---
+assetId: aldara6166-modular-amusement-park-pack-modern-rides
+version: "1.0"
+lastModified: "2007-01-01T09:04:41Z"
+url: https://community.simtropolis.com/files/file/17559-modular-amusement-park-pack-modern-rides/?do=download&r=40919

--- a/src/yaml/aldara6166/17560-modular-amusement-park-pack-roller-coasters.yaml
+++ b/src/yaml/aldara6166/17560-modular-amusement-park-pack-roller-coasters.yaml
@@ -1,0 +1,45 @@
+group: aldara6166
+name: modular-amusement-park-pack-roller-coasters
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Modular Amusement Park Pack Roller Coasters
+  description: |-
+    The MAPP - ***the first official download of 2007*** - is finally here!!  
+      
+    Are trips to the local mall, or the local zoo and aquarium the only entertainment that you can provide for your Sims? Have your Sims every wanted for something more to do on a long, summer's weekend than just go to the beach?
+
+    Well now you too can provide the fun and entertainment that your Sims so desperately deserve. Introducing the Modular Amusement Park Pack (MAPP) presented by RJM Designs. This set is made up of amusement park rides, roller coasters, midway entertainment and more. Currently there are a few amusement park BATs available on the STEX, but this pack draws everything together
+
+    So dive right in and create that "dream park" that you have always dreamt of, or re-create your favorite amusement park from the memories of your childhood.
+
+    **The MAPP . . . making your Sims' entertainment dreams a reality!**
+
+    \* NOTE - The MAPP uses the ped-malls that are included in Network Addon Mod to tie all of our custom BATs together. See How to build an Amusement Park in the readme file for instructions\*
+
+    \*This pack includes all of the roller coasters that were previously on the STEX and a few new ones. The coasters have be reproduced with the original author's permission and have been completely reworked from the lots on up. Without the Essentials pack, this pack will not function properly.\*  
+      
+    Please delete any and all prior versions of all MAPP lots (including the construction lot) prior to installation to avoid conflicts.  
+      
+    **Dependancies:**  
+      
+    [Porkie Props Vol.1](https://community.simtropolis.com/files/file/11421-porkie-props-vol1-european-street-accessories/)
+
+    [BSC Texture Pack Vol 01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+  author: aldara6166
+  website: https://community.simtropolis.com/files/file/17560-modular-amusement-park-pack-roller-coasters/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_08_2011/1c4683cfbac1506ebb45571c779bf6a4-mapp_rollercoasters1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_08_2011/3e7a8d9cc2af360480e7860ec6f2d1e7-mapp_rollercoasters2.jpg
+dependencies:
+  - aldara6166:modular-amusement-park-pack-essentials
+  - bsc:textures-vol01
+  - porkissimo:jenx-porkie-expanded-porkie-props
+assets:
+  - assetId: aldara6166-modular-amusement-park-pack-roller-coasters
+
+---
+assetId: aldara6166-modular-amusement-park-pack-roller-coasters
+version: "1.0"
+lastModified: "2007-01-01T09:14:12Z"
+url: https://community.simtropolis.com/files/file/17560-modular-amusement-park-pack-roller-coasters/?do=download&r=89855


### PR DESCRIPTION
This PR adds [aldera6166](https://community.simtropolis.com/profile/53084-aldara6166/content/?type=downloads_file)'s modular amusement park pack.

![image](https://github.com/user-attachments/assets/8b448c13-fc25-46c1-ac4f-a835bfdfee2e)
