### PR TITLE
feat: tag known GitHub users if linting fails

### DIFF
--- a/actions/create-prs/create-prs.js
+++ b/actions/create-prs/create-prs.js
@@ -223,12 +223,20 @@ async function createPr(pkg, prs) {
 			target_url,
 		});
 
+		// If we know the GitHub username of the user that created this package, 
+		// tag them in the body.
+		let body = '';
+		if (pkg.githubUsername) {
+			body = `@${pkg.githubUsername}\n\n`;
+		}
+		body += `⚠️ There is an issue with the metadata for this package:\n\n\`\`\`\n${message}\n\`\`\``;
+
 		// Make a comment in the PR with the linting output.
 		let message = String(result.stdout) || String(result.stderr);
 		await octokit.rest.issues.createComment({
 			...context.repo,
 			issue_number: pr.number,
-			body: `⚠️ There is an issue with the metadata for this package:\n\n\`\`\`\n${message}\n\`\`\``,
+			body,
 		});
 
 	}

--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -105,6 +105,9 @@ export default async function handleUpload(json, opts = {}) {
 		};
 	}
 
+	// Check if the user has a GitHub username associated with them.
+	let githubUsername = permissions.getGithubUsername(json);
+
 	// Allright, we're pretty much done now. Write away the metadata and return 
 	// the information about what we've generated.
 	let { group, name } = main;
@@ -120,6 +123,7 @@ export default async function handleUpload(json, opts = {}) {
 		branchId: String(json.id),
 		deletions,
 		additions: [relativePath],
+		githubUsername,
 	};
 
 }

--- a/actions/fetch/permissions.js
+++ b/actions/fetch/permissions.js
@@ -94,4 +94,13 @@ export default class PermissionsApi {
 
 	}
 
+	// ## getGithubUsername(upload)
+	// Returns the github username associated with the given upload, so that the 
+	// pr generating action can tag them if needed.
+	getGithubUsername(upload) {
+		if (!this.index) return;
+		let config = this.index.usersById.get(String(upload.id)) || {};
+		return config.github;
+	}
+
 }

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1295,6 +1295,27 @@ describe('The fetch action', function() {
 
 	});
 
+	it('attaches the GitHub username if known', async function() {
+
+		const upload = faker.upload({
+			id: 123,
+		});
+		const { run } = this.setup({
+			upload,
+			permissions: {
+				authors: [
+					{
+						id: 123,
+						github: 'sebamarynissen',
+					},
+				],
+			},
+		});
+		const { result } = await run({ id: upload.id });
+		expect(result.githubUsername).to.equal('sebamarynissen');
+
+	});
+
 });
 
 function jsonToYaml(json) {

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -6,17 +6,30 @@ authors:
     id: 2813
     prefixes:
       - peg
+  - name: deadwoods
+    id: 5563
+    prefixes:
+      - dedwd
   - name: kingofsimcity
     id: 33566
     prefixes:
       - kosc
       - king's
+  - name: memo
+    id: 95442
+    github: memo33
   - name: MarcosMX
     id: 111156
     prefixes:
       - blam
       - mx
       - rnp
+  - name: Null 45
+    id: 246111
+    github: 0xC0000054
+  - name: smf_16
+    id: 259789
+    github: sebamarynissen
   - name: pclark06
     id: 364367
     prefixes:
@@ -25,18 +38,15 @@ authors:
     id: 444001
     prefixes:
       - sm2
+  - name: nos.17
+    id: 455740
+    github: noah-severyn
+    groups:
+      - b62
   - name: RRetail
     id: 744613
     prefixes:
       - rr
-  - name: deadwoods
-    id: 5563
-    prefixes:
-      - dedwd
-  - name: nos.17
-    id: 455740
-    groups:
-      - b62
 
 # Example for permissions for specific packages.
 # authors:


### PR DESCRIPTION
Following #67, the bot should now automatically tag GitHub users if the linting fails. This is also relevant for #37, as tying a ST user to a GitHub user will be needed.