### PR TITLE
fix: Github usernames are not logged in PRs

### DIFF
--- a/actions/fetch/permissions.js
+++ b/actions/fetch/permissions.js
@@ -99,7 +99,7 @@ export default class PermissionsApi {
 	// pr generating action can tag them if needed.
 	getGithubUsername(upload) {
 		if (!this.index) return;
-		let config = this.index.usersById.get(String(upload.id)) || {};
+		let config = this.index.usersById.get(String(upload.uid)) || {};
 		return config.github;
 	}
 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1298,7 +1298,7 @@ describe('The fetch action', function() {
 	it('attaches the GitHub username if known', async function() {
 
 		const upload = faker.upload({
-			id: 123,
+			uid: 123,
 		});
 		const { run } = this.setup({
 			upload,


### PR DESCRIPTION
Due to a bug, the Github usernames are not mentioned in the failing PRs (see #68).