### PR TITLE
feat: improve PR generation

### DIFF
--- a/actions/create-prs/create-prs.js
+++ b/actions/create-prs/create-prs.js
@@ -177,16 +177,10 @@ async function createPr(pkg, prs) {
 	} else {
 
 		// If a PR already exists, then update it.
-		if (pr.title !== title) {
-			await octokit.rest.pulls.update({
-				...context.repo,
-				pull_number: pr.number,
-				title,
-			});
-		}
-		await octokit.rest.issues.createComment({
+		await octokit.rest.pulls.update({
 			...context.repo,
-			issue_number: pr.number,
+			pull_number: pr.number,
+			title,
 			body,
 		});
 

--- a/actions/create-prs/create-prs.js
+++ b/actions/create-prs/create-prs.js
@@ -196,12 +196,25 @@ async function createPr(pkg, prs) {
 		target_url,
 	});
 
-	// Once the PR has been updated, we'll run the linting script.
+	// If the fetch script already reported errors, make sure to collect them.
+	let errors = [];
+	if (pkg.error) {
+		errors.push(new Error(pkg.error));
+	}
+	
+	// Run the linter as well. If it fails, that's another error.
 	let result = cp.spawnSync('sc4pac-lint', ['src/yaml'], {
 		cwd: process.env.GITHUB_WORKSPACE,
 	});
 	if (result.status === 0) {
 		console.log(result.stdout+'');
+	} else {
+		core.error(result.stdout+'');
+		errors.push(new Error(String(result.stdout) || String(result.stderr)));
+	}
+
+	// If there are no errors, cool, we'll merge the PR.
+	if (errors.length === 0) {
 		await octokit.rest.repos.createCommitStatus({
 			...context.repo,
 			sha,
@@ -214,7 +227,6 @@ async function createPr(pkg, prs) {
 			pull_number: pr.number,
 		});
 	} else {
-		core.error(result.stdout+'');
 		await octokit.rest.repos.createCommitStatus({
 			...context.repo,
 			sha,
@@ -223,9 +235,11 @@ async function createPr(pkg, prs) {
 			target_url,
 		});
 
+		// Compile the message from all the errors.
+		let message = errors.map(error => error.message).join('\n\n');
+
 		// If we know the GitHub username of the user that created this package, 
 		// tag them in the body.
-		let message = String(result.stdout) || String(result.stderr);
 		let body = '';
 		if (pkg.githubUsername) {
 			body = `@${pkg.githubUsername}\n\n`;

--- a/actions/fetch/api-to-metadata.js
+++ b/actions/fetch/api-to-metadata.js
@@ -127,5 +127,5 @@ function normalizeDate(date) {
 // # slugifyTitle(title)
 function slugifyTitle(title) {
 	return slugify(title.replaceAll(/&/g, 'and').replaceAll(/\$/g, 's'))
-		.replaceAll(/(\b)vol-/g, '$1vol');
+		.replaceAll(/(\b)vol-(\d)/g, '$1vol$2');
 }

--- a/actions/fetch/api-to-metadata.js
+++ b/actions/fetch/api-to-metadata.js
@@ -126,5 +126,6 @@ function normalizeDate(date) {
 
 // # slugifyTitle(title)
 function slugifyTitle(title) {
-	return slugify(title.replaceAll(/&/g, 'and').replaceAll(/\$/g, 's'));
+	return slugify(title.replaceAll(/&/g, 'and').replaceAll(/\$/g, 's'))
+		.replaceAll(/(\b)vol-/g, '$1vol');
 }

--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -94,15 +94,17 @@ export default async function handleUpload(json, opts = {}) {
 		main,
 		basename,
 	} = patchMetadata(metadata, parsedMetadata, original);
+	let error;
 	let zipped = [...packages, ...metadata.assets];
 	try {
 		permissions.assertPackageAllowed(json, packages);
 	} catch (e) {
-		return {
-			skipped: true,
-			type: 'warning',
-			reason: `${e.message}\n\n${serialize(zipped)}`,
-		};
+
+		// When there's an error, we *DO NOT* skip the package. We continue, but 
+		// add it as an error, which will subsequently be handled by the 
+		// create-prs action.
+		error = e.message;
+
 	}
 
 	// Check if the user has a GitHub username associated with them.
@@ -124,6 +126,7 @@ export default async function handleUpload(json, opts = {}) {
 		branchId: String(json.id),
 		additions: [relativePath],
 		githubUsername,
+		...error && { error },
 	};
 
 }

--- a/actions/fetch/permissions.js
+++ b/actions/fetch/permissions.js
@@ -18,10 +18,7 @@ export default class PermissionsApi {
 
 	// ## constructor(data)
 	constructor(data) {
-		if (!data?.authors) {
-			this.index = null;
-			return;
-		}
+		if (!data) return;
 		let { usersById } = this.index;
 		for (let userData of data.authors) {
 			let { id } = userData;
@@ -53,7 +50,6 @@ export default class PermissionsApi {
 	// Returns whether the user that has made the given stex upload - as stex 
 	// api response - is actually allowed to do this.
 	isUploadAllowed(upload) {
-		if (!this.index) return true;
 		let permission = this.index.usersById.get(String(upload.uid));
 		if (permission?.blocked) return false;
 		return true;
@@ -74,9 +70,7 @@ export default class PermissionsApi {
 	// to create a package of the given format. We could expand this to handle 
 	// DLL permissions etc.
 	assertPackageAllowed(upload, data) {
-		if (!this.index) return true;
-		let permission = this.index.usersById.get(String(upload.uid));
-		if (!permission || permission.blocked) return false;
+		let permission = this.index.usersById.get(String(upload.uid)) || {};
 
 		// Compile all the names that the user is allowed to upload for.
 		let names = [slugify(upload.author), ...permission.groups || []];
@@ -98,7 +92,6 @@ export default class PermissionsApi {
 	// Returns the github username associated with the given upload, so that the 
 	// pr generating action can tag them if needed.
 	getGithubUsername(upload) {
-		if (!this.index) return;
 		let config = this.index.usersById.get(String(upload.uid)) || {};
 		return config.github;
 	}

--- a/actions/fetch/test/api-to-metadata-test.js
+++ b/actions/fetch/test/api-to-metadata-test.js
@@ -190,4 +190,14 @@ describe('#apiToMetadata', function() {
 
 	});
 
+	it('handles vol-one', function() {
+
+		let upload = faker.upload({
+			title: 'Prop Pack Vol. One',
+		});
+		let meta = apiToMetadata(upload);
+		expect(meta.package.name).to.equal('prop-pack-vol-one');
+
+	});
+
 });

--- a/actions/fetch/test/api-to-metadata-test.js
+++ b/actions/fetch/test/api-to-metadata-test.js
@@ -180,4 +180,14 @@ describe('#apiToMetadata', function() {
 
 	});
 
+	it('handles vol-01', function() {
+
+		let upload = faker.upload({
+			title: 'Prop Pack Vol. 01',
+		});
+		let meta = apiToMetadata(upload);
+		expect(meta.package.name).to.equal('prop-pack-vol01');
+
+	});
+
 });

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -968,6 +968,29 @@ describe('The fetch action', function() {
 
 	});
 
+	it('includes an error in the result when the user is not allowed to upload under that group', async function() {
+
+		const upload = faker.upload({
+			author: 'sfbt',
+			files: [
+				{
+					contents: {
+						'metadata.yaml': {
+							group: 'nybt',
+						},
+					},
+				},
+			],
+		});
+		const { run } = this.setup({
+			upload,
+		});
+		let { result } = await run();
+		expect(result.error).to.be.a('string');
+		expect(result.error).to.have.length.above(0);
+
+	});
+
 	it('skips tools', async function() {
 
 		const upload = faker.upload({


### PR DESCRIPTION
This PR adds a few improvements to how the bot generates PRs, as obvserved in #67:

- If there's a permissions error - e.g. a user uploads under a group name they're not allowed to - the PR will still be created, but it won't get merged because and the error will be commented by the bot.
- When new metadata is uploaded for an open PR, the bot no longer reposts the updated metadata as a comment, but rather updates the body of the PR - i.e. the first comment in the PR.
- Titles that would compile to `vol-01` are getting the hyphen removed to pass the linter.