### PR TITLE
fix: handle uploads without files

### DIFF
--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -26,6 +26,21 @@ export default async function handleUpload(json, opts = {}) {
 		};
 	}
 
+	// If the files have been removed - meaning the file name is "null" - then 
+	// we don't include this. This happens for example with packages marked as 
+	// obsolete on the STEX.
+	if (
+		!json.files ||
+		json.files.length === 0 ||
+		json.files.some(file => file.name === null)
+	) {
+		return {
+			skipped: true,
+			type: 'notice',
+			reason: `Package ${json.fileURL} skipped as it has no files`,
+		};
+	}
+
 	// Start by extracting all metadata we can from the api. This should be 
 	// sufficient to look for a `metadata.yaml` file in the downloads. We'll do 
 	// that first before completing the metadata with scraping, because we might 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1333,6 +1333,22 @@ describe('The fetch action', function() {
 
 	});
 
+	it('doesn\'t choke on obsolete packages where the file have been deleted', async function() {
+
+		const upload = faker.upload({
+			files: [
+				{
+					name: null,
+				},
+			],
+		});
+		const { run } = this.setup({ upload });
+		const { packages, notices } = await run({ id: upload.id });
+		expect(packages).to.have.length(0);
+		expect(notices).to.have.length(1);
+
+	});
+
 });
 
 function jsonToYaml(json) {


### PR DESCRIPTION
Apparently the last fetch actions failed because https://community.simtropolis.com/files/file/15582-cogeo-logistics-centre-dependency-pack-v2/ has been made obsolete. This caused the STEX API to return
```json
[
   {
        "id": 15583,
        "cid": 118,
        "uid": 45188,
        "author": "cogeo",
        "category": "Dependencies",
        "title": "Warehouses BATProps Part B",
        "release": "OBSOLETE",
        "submitted": "2006-04-08 16:26:21",
        "updated": "2025-01-10 00:36:20",
        "views": 63147,
        "downloads": 27433,
        "reputation": 10,
        "sizeTotal": "0 bytes",
        "files": [
            {
                "id": 205213,
                "name": null,
                "link": "https:\/\/community.simtropolis.com\/files\/file\/15582-cogeo-logistics-centre-dependency-pack-v2\/",
                "size": "0 bytes"
            }
        ],
        "imageURL": "https:\/\/www.simtropolis.com\/objects\/screens\/0019\/acf131803459f15db092134547827637-WBLeft.jpg",
        "thumbURL": "https:\/\/www.simtropolis.com\/objects\/screens\/monthly_06_2006\/thumb-acf131803459f15db092134547827637-WBLeft.jpg",
        "aliasEntry": "warehouses-batprops-part-b",
        "aliasAuthor": "cogeo",
        "fileURL": "https:\/\/community.simtropolis.com\/files\/file\/15583-warehouses-batprops-part-b\/",
        "===========": "=========================================="
    }
]
```
which made the script choke on the name of the file being `null`.

This PR fixes that by simply skipping those kinds of assets.