### PR TITLE
feat: support `metadata.yaml` in nested folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Currently, the STEX is polled for new content once every hour, meaning if your p
 
 By default, a plugin added to the STEX will not be added to this channel.
 Your plugin needs to be *compatible*.
-In order to do this, you have to add a `metadata.yaml` file **at the root** of one of the .zip folders you are about to upload to the STEX.
-You don't have to add this to every .zip folder, the channel will pick up the first `metadata.yaml` file it finds in the uploaded assets.
+In order to do this, you have to add a `metadata.yaml` file in **one** of the .zip folders you are about to upload to the STEX.
+It doesn't matter where you put this `metadata.yaml` file, but it is advised to put it at the root of your .zip folder.
 
 If your plugin has no dependencies and no specific installation needs, you can leave the `metadata.yaml` file empty (see below), but it is *mandatory* to have it, otherwise it will not be added to the channel.
 
@@ -57,7 +57,7 @@ For example, consider [Magasin Valois by Jasoncw](https://community.simtropolis.
 
 ![image](https://github.com/user-attachments/assets/2487f4fc-d6ec-49a7-a6fc-d656865f862b)
 
-which would be by default be transformed into
+By default, the channel will generate the following metadata for it:
 
 ```yaml
 group: jasoncw
@@ -116,6 +116,7 @@ Also note that Maxisnite and Darknite variants can be handled automatically ([se
 
 If your plugin has other specific installation needs for which you need to be able to customize the metadata, it should also be done within `metadata.yaml`.
 The channel will use anything it finds in here, and fill in the gaps based on the STEX upload.
+
 For example, if you want to upload a package under a different group name - for example because you're part of the NYBT team - and it needs the `nybt:essentials` as a dependency, then this can be done by adding
 ```yaml
 group: nybt
@@ -129,29 +130,24 @@ The channel will automatically fill in the rest of the gaps, such as the package
 Note that you can only override *packages* in your `metadata.yaml` file.
 *Assets* are handled automatically: every folder you upload to the STEX gets added as an asset to the metadata.
 
-If your plugin has very specific needs - for example because it provides a maxisnite and darknite variant *in the same .zip* folder - then you can reference your assets in the `metadata.yaml` as follows:
+If your plugin has very specific needs - for example if you want to split up your package in both a *models & props* part, and *lots* part, which is useful if you expect other people to create re-lots - then you can reference your assets in the `metadata.yaml` as follows:
 
 ```yaml
+name: my-package-models
 assets:
   - assetId: ${{ assets.0.assetId }}
-    exclude:
-      - .SC4Model$
+    include:
+      - \.SC4Model$
+      - \.SC4Desc$
+      - \.dat$
 
-variants:
-  - variant: { nightmode: standard }
-    assets:
-      - assetId: ${{ assets.0.assetId }}
-        include:
-          - maxisnite.SC4Model$
-  - variant: { nightmode: dark }
-    dependencies: [ "simfox:day-and-nite-mod" ]
-    assets:
-      - assetId: ${{ assets.0.assetId }}
-        include:
-          - darknite.SC4Model$
+---
+name: my-package
+assets:
+  - assetId: ${{ assets.0.assetId }}
+    include:
+      - \.SC4Lot$
 ```
-
-Note that there is actually a better approach for providing support for both maxisnite and darknite by uploading two .zips (see below).
 
 This interpolation technique does not only work for the assets.
 You can actually reference any of the automatically generated metadata like that.

--- a/actions/create-prs/create-prs.js
+++ b/actions/create-prs/create-prs.js
@@ -198,8 +198,10 @@ async function createPr(pkg, prs) {
 
 	// If the fetch script already reported errors, make sure to collect them.
 	let errors = [];
-	if (pkg.error) {
-		errors.push(new Error(pkg.error));
+	if (pkg.errors?.length > 0) {
+		for (let message of pkg.errors) {
+			errors.push(new Error(message));
+		}
 	}
 	
 	// Run the linter as well. If it fails, that's another error.

--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -114,13 +114,14 @@ export default class Downloader {
 	// Inspects an extracted asset and extracts information from it, such as all 
 	// the files in it, as well as the metadata, if it exists.
 	async inspectAsset(dir) {
-		let metadata = null;
+		let metadata = [];
 		let glob = new Glob('**/*', { cwd: dir, nodir: true });
 		let files = [];
 		for (let file of glob) {
 			files.push(file);
-			if (file === 'metadata.yaml') {
-				metadata = await readMetadata(path.join(dir, file));
+			let basename = path.basename(file);
+			if (basename === 'metadata.yaml') {
+				metadata.push(await readMetadata(path.join(dir, file)));
 			}
 		}
 		return {

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -248,6 +248,25 @@ describe('The fetch action', function() {
 
 	});
 
+	it('a package with a nested metadata.yaml', async function() {
+
+		let upload = faker.upload({
+			files: [
+				{
+					contents: {
+						'subfolder/metadata.yaml': {
+							name: 'this-name',
+						},
+					},
+				},
+			],
+		});
+		const { run } = this.setup({ upload });
+		const { result } = await run({ id: upload.id });
+		expect(result.metadata[0].name).to.equal('this-name');
+
+	});
+
 	it('a package with custom dependencies', async function() {
 
 		let upload = faker.upload({

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -986,8 +986,7 @@ describe('The fetch action', function() {
 			upload,
 		});
 		let { result } = await run();
-		expect(result.error).to.be.a('string');
-		expect(result.error).to.have.length.above(0);
+		expect(result.errors).to.have.length(1);
 
 	});
 
@@ -1346,6 +1345,54 @@ describe('The fetch action', function() {
 		const { packages, notices } = await run({ id: upload.id });
 		expect(packages).to.have.length(0);
 		expect(notices).to.have.length(1);
+
+	});
+
+	it('handles mutiple metadata.yaml files in the same asset', async function() {
+
+		const upload = faker.upload({
+			files: [
+				{
+					contents: {
+						'metadata.yaml': {
+							name: 'this-one',
+						},
+						'subfolder/metadata.yaml': {
+							name: 'no-this-one',
+						},
+					},
+				},
+			],
+		});
+		const { run } = this.setup({ upload });
+		const { result } = await run({ id: upload.id });
+		expect(result.errors).to.have.length(1);
+
+	});
+
+	it('handles mutiple metadata.yaml files in different assets', async function() {
+
+		const upload = faker.upload({
+			files: [
+				{
+					contents: {
+						'metadata.yaml': {
+							name: 'this-one',
+						},
+					},
+				},
+				{
+					contents: {
+						'metadata.yaml': {
+							name: 'no-this-one',
+						},
+					},
+				},
+			],
+		});
+		const { run } = this.setup({ upload });
+		const { result } = await run({ id: upload.id });
+		expect(result.errors).to.have.length(1);
 
 	});
 


### PR DESCRIPTION
In the wake of #67, this PR adds support for `metadata.yaml` files that are not located in the root of the upload. In order to make this possible, an error will now be logged if multiple `metadata.yaml` files are found in the assets.

TL;DR: From now on, only 1 `metadata.yaml` file can exist, but you can place it anywhere you like.

cc @noah-severyn