### PR TITLE
metadata: add a part of Pegasus' content

### DIFF
--- a/actions/fetch/scrape.js
+++ b/actions/fetch/scrape.js
@@ -80,6 +80,8 @@ export default async function scrape(url) {
 			subfolder = '620-education';
 		} else if (description.match(/\blandmark\b/i)) {
 			subfolder = '360-landmark';
+		} else if (description.match(/\bparks? menu\b/i)) {
+			subfolder = '660-parks';
 		} else if (description.match(/\bjobs\b/i)) {
 			subfolder = '300-commercial';
 		}

--- a/actions/fetch/scrape.js
+++ b/actions/fetch/scrape.js
@@ -82,8 +82,6 @@ export default async function scrape(url) {
 			subfolder = '360-landmark';
 		} else if (description.match(/\bparks? menu\b/i)) {
 			subfolder = '660-parks';
-		} else if (description.match(/\bjobs\b/i)) {
-			subfolder = '300-commercial';
 		}
 	}
 	return { description, images, subfolder };

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -40,6 +40,10 @@ authors:
       - dk35
       - dk 35
       - cbt
+  - name: Paeng
+    id: 211121
+    prefixes:
+      - Paeng's
   - name: der_gammler
     id: 241465
     prefixes:

--- a/permissions.yaml
+++ b/permissions.yaml
@@ -11,6 +11,11 @@ authors:
     id: 5563
     prefixes:
       - dedwd
+  - name: SimGoober
+    id: 24419
+    alias: sg
+    prefixes:
+      - sg
   - name: kingofsimcity
     id: 33566
     prefixes:

--- a/scripts/prune.js
+++ b/scripts/prune.js
@@ -7,6 +7,7 @@ import { Minimatch } from 'minimatch';
 import yargs from 'yargs/yargs';
 import traverse from './traverse-yaml.js';
 import standardDeps from './standard-deps.js';
+import { styleText } from 'node:util';
 
 const { argv } = yargs(hideBin(process.argv));
 const dist = path.resolve(import.meta.dirname, '../dist/plugins');
@@ -36,10 +37,14 @@ for (let pkg of explicit) {
 	let set = new Set(result.packages);
 	set.delete('simfox:day-and-nite-mod');
 	result.packages = index[pkg] = [...set];
-	results.push(result);
+	results.push({
+		pkg,
+		result,
+	});
 }
 spinner.succeed('Tracked all dependencies');
-for (let result of results) {
+for (let { pkg, result } of results) {
+	console.log(styleText('yellow', pkg));
 	result.dump({ format: 'sc4pac' });
 }
 

--- a/scripts/prune.js
+++ b/scripts/prune.js
@@ -23,8 +23,16 @@ if (matches.length > 0) {
 	});
 }
 
+// Build up an index of the explicit dependencies per package.
+const spinner = ora('Building up package index').start();
+const dependenciesByPackage = {};
+await traverse('**/*.yaml', (pkg) => {
+	if (pkg.assetId) return;
+	let id = `${pkg.group}:${pkg.name}`;
+	dependenciesByPackage[id] = pkg.dependencies;
+});
+
 // Setup the dependency tracker.
-const spinner = ora().start();
 const index = {};
 const tracker = new DependencyTracker({
 	plugins: dist,
@@ -33,7 +41,8 @@ const results = [];
 for (let pkg of explicit) {
 	if (standardDeps.includes(pkg)) continue;
 	spinner.text = `Tracking dependencies for ${pkg}`;
-	let result = await tracker.track(pkg);
+	let dependencies = dependenciesByPackage[pkg] ?? [];
+	let result = await tracker.track(pkg, { dependencies });
 	let set = new Set(result.packages);
 	set.delete('simfox:day-and-nite-mod');
 	result.packages = index[pkg] = [...set];
@@ -58,8 +67,9 @@ if (argv.force || argv.f) {
 		let deps = index[id];
 		if (!(deps?.length > 0)) return;
 
-		// If SimFox' day and nite mod was tracked as a dependency, this is because 
-		// a light cone was referenced with the mod active. We exclude this.
+		// If SimFox' day and nite mod was tracked as a dependency, this is 
+		// because a light cone was referenced with the mod active. We exclude 
+		// this.
 		pkg.dependencies = deps;
 		return pkg;
 

--- a/scripts/sc4d.js
+++ b/scripts/sc4d.js
@@ -11,6 +11,11 @@ export default {
 	228: 'bsc:mega-props-rt-vol02',
 	272: 'bsc:mega-props-snm-vol01',
 	283: 'girafe:hedges',
+	285: 'bsc:mega-props-rt-wfk-vol02-wimps',
+	286: [
+		'bsc:mega-props-rt-wfk-vol02-wimps',
+		'bsc:mega-props-rt-wfk-vol01-cds',
+	],
 	294: 'girafe:common-spruces',
 	338: 'bsc:mega-props-jes-vol02',
 	339: 'bsc:mega-props-jes-vol03',

--- a/scripts/tsc.js
+++ b/scripts/tsc.js
@@ -1,5 +1,6 @@
 export default {
 	587: 'bsc:textures-vol02',
+	1335: 'blanco:train-prop-pack-sd',
 	1516: 'blanco:tram-prop-pack',
 	1573: 'blanco:train-prop-pack',
 	1579: 'manchou:houses-ag-models',

--- a/src/yaml/mrbisonm/11769-nexis-wood-pile-props.yaml
+++ b/src/yaml/mrbisonm/11769-nexis-wood-pile-props.yaml
@@ -1,0 +1,27 @@
+group: mrbisonm
+name: nexis-wood-pile-props
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Nexis Wood Pile Props
+  description: |-
+    For those who want to build their own sawmills,construction sites and/or Lumberyards, here are 4 Props ( not lots) for your pleasure to build with the LE. You can pile them on top of each other or use them simply like they are. It's up to you.
+    There will be a BAT soon that I will upload and which uses these BATprops. The props then will be included again with the .lotfile , so you just delete the props and only keep the lot file,when it comes out ,if you already have downloaded these props here.
+
+    4 .desc and 4 .model files, picture and readme text included
+    Have Fun with Nexis.
+    mrb
+
+    Read Nexis .txt for further information on using these props publically.
+  author: mrbisonm
+  website: https://community.simtropolis.com/files/file/11769-nexis-wood-pile-props/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/fc5d3602283cbdc08dd7d407c80eead6-WoodProps.JPG
+assets:
+  - assetId: mrbisonm-nexis-wood-pile-props
+
+---
+assetId: mrbisonm-nexis-wood-pile-props
+version: "1.0"
+lastModified: "2005-02-24T11:06:13Z"
+url: https://community.simtropolis.com/files/file/11769-nexis-wood-pile-props/?do=download&r=32095

--- a/src/yaml/nbvc/23053-ski-lodge.yaml
+++ b/src/yaml/nbvc/23053-ski-lodge.yaml
@@ -1,0 +1,33 @@
+group: nbvc
+name: ski-lodge
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Ski Lodge
+  description: |-
+    A small Ski Lodge.
+
+    Dependencies:
+
+    PEG Ski Resort [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=22995)
+
+    PEG Pine Trail Head [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=11508)
+
+    PEG Snow Mod 2 is required for winter effects. [simpeg.com/forum/index.php](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/forum/index.php?action=tpmod;dl=item1096)
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/23053-ski-lodge/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f8c9afcb8a9d1482fb0ba3a443c6b95d-SkiLodge.jpg
+    - https://www.simtropolis.com/objects/screens/0027/f8c9afcb8a9d1482fb0ba3a443c6b95d-skiLodge2.jpg
+dependencies:
+  - bsc:mega-props-misc-vol02
+  - peg:mtp-super-pack
+  - peg:ski-resort
+assets:
+  - assetId: nbvc-ski-lodge
+
+---
+assetId: nbvc-ski-lodge
+version: "1.0"
+lastModified: "2009-12-28T09:10:15Z"
+url: https://community.simtropolis.com/files/file/23053-ski-lodge/?do=download&r=49731

--- a/src/yaml/nbvc/23054-fences.yaml
+++ b/src/yaml/nbvc/23054-fences.yaml
@@ -1,0 +1,31 @@
+group: nbvc
+name: fences
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Fences
+  description: |-
+    Small fences
+
+    Dependencies:
+
+    [PEG Ski Resort](https://community.simtropolis.com/files/file/22995-peg-ski-resort/)
+
+    [PEG Snow Mod 2](https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/) is recommended for winter effects.
+
+    Staff Edit : Fixed dependency links.
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/23054-fences/
+  images:
+    - https://www.simtropolis.com/objects/screens/0003/109d08e692ebeed6b6a68a5f66e82b2b-fence.jpg
+dependencies:
+  - peg:ski-resort
+  - peg:snow-mod-2
+assets:
+  - assetId: nbvc-fences
+
+---
+assetId: nbvc-fences
+version: "1.0"
+lastModified: "2009-12-28T09:44:32Z"
+url: https://community.simtropolis.com/files/file/23054-fences/?do=download&r=49733

--- a/src/yaml/nbvc/23642-freight-rail-station.yaml
+++ b/src/yaml/nbvc/23642-freight-rail-station.yaml
@@ -1,0 +1,46 @@
+group: nbvc
+name: freight-rail-station
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Freight Rail Station
+  description: |-
+    A Freight Rail Station with size 9x11.
+
+    It has the same properties like the standard freight rail station.
+
+    Capacity: 2000
+
+    Monthly cost: 10
+
+    The rail station is transit enabled at the borders and can be connected to rail roads, but trains cannot drive through the rail station.
+
+    [Larger image](http://www.ld-host.de/uploads/images/48caa87decc97c8e5f52a79a1c4477df.jpg)
+
+    Dependencies:
+
+    PEG\_SecurityFence [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=19338)
+
+    PEG\-CDK3\_RailFleet [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=19786)
+
+    PEG\-CDK3\_SUPER-PAK [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=19880)
+
+    SEAPORT SUPER PAK [www.simtropolis.com/STEX/details.cfm](https://www.simtropolis.com/stex/details.cfm?id=19881)
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/23642-freight-rail-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/0013/74656fc2a1d6d60831e92f9413ef21f1-rail1.jpg
+    - https://www.simtropolis.com/objects/screens/0013/74656fc2a1d6d60831e92f9413ef21f1-rail2.jpg
+dependencies:
+  - peg:cdk3-sp-rail-fleet
+  - peg:cdk3-sp-seaport-super-pak
+  - peg:cdk3-super-pak
+  - peg:security-fencing-kit
+assets:
+  - assetId: nbvc-freight-rail-station
+
+---
+assetId: nbvc-freight-rail-station
+version: "1.0"
+lastModified: "2010-04-04T09:00:47Z"
+url: https://community.simtropolis.com/files/file/23642-freight-rail-station/?do=download&r=50509

--- a/src/yaml/nbvc/23652-warehouse-dock-outer-corner.yaml
+++ b/src/yaml/nbvc/23652-warehouse-dock-outer-corner.yaml
@@ -1,0 +1,38 @@
+group: nbvc
+name: warehouse-dock-outer-corner
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Warehouse Dock Outer Corner
+  description: |-
+    A Warehouse Dock which can be combined with [PEG CDK3 SP Row Warehouses](https://www.simtropolis.com/stex/details.cfm?id=19805). It has size 9x13 and is a outer corner dock with rail connection. It provides manufacturing industry jobs, but has no seaport functionality.
+
+    [Large Image](http://www.ld-host.de/uploads/images/baaacb8fb76b981a211a0267fe54b839.jpg)
+
+    Dependencies:
+
+    [PEG\_SecurityFence](https://www.simtropolis.com/stex/details.cfm?id=19338)
+
+    [PEG\-CDK3\_RailFleet](https://www.simtropolis.com/stex/details.cfm?id=19786)
+
+    [PEG\-CDK3\_SUPER-PAK](https://www.simtropolis.com/stex/details.cfm?id=19880)
+
+    [SEAPORT SUPER PAK](https://www.simtropolis.com/stex/details.cfm?id=19881)
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/23652-warehouse-dock-outer-corner/
+  images:
+    - https://www.simtropolis.com/objects/screens/0023/d0c4d49bc3474fc1859ec459e20ff681-warehousedock1.jpg
+    - https://www.simtropolis.com/objects/screens/0023/d0c4d49bc3474fc1859ec459e20ff681-warehousedock2.jpg
+dependencies:
+  - peg:cdk3-sp-rail-fleet
+  - peg:cdk3-sp-seaport-super-pak
+  - peg:cdk3-super-pak
+  - peg:security-fencing-kit
+assets:
+  - assetId: nbvc-warehouse-dock-outer-corner
+
+---
+assetId: nbvc-warehouse-dock-outer-corner
+version: "1.0"
+lastModified: "2010-04-05T09:27:49Z"
+url: https://community.simtropolis.com/files/file/23652-warehouse-dock-outer-corner/?do=download&r=50523

--- a/src/yaml/nbvc/23954-modular-container-port.yaml
+++ b/src/yaml/nbvc/23954-modular-container-port.yaml
@@ -1,0 +1,59 @@
+group: nbvc
+name: modular-container-port
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Modular Container Port
+  description: |-
+    This is a set of 30 different LOTs which can be used to build custom container ports.
+
+    It contains different docks with ships, cranes and containers.
+    Docks for corners, left and right ends.
+    Rail and truck depots.
+    Fences, roads, containers and more.
+
+    The LOTs don't have a seaport functionality, they are only eye candy.
+
+    Dependencies:
+    [PEG Security Fencing Kit](https://community.simtropolis.com/files/file/19338-peg-security-fencing-kit/)
+    [PEG CDK3 SP Rail Fleet](https://community.simtropolis.com/files/file/19786-peg-cdk3-sp-rail-fleet/)
+    [PEG CDK3 SUPER PAK](https://community.simtropolis.com/files/file/19880-peg-cdk3-super-pak/)
+    [PEG CDK3 SP SEAPORT SUPER PAK](https://community.simtropolis.com/files/file/19881-peg-cdk3-sp-seaport-super-pak/)
+    [Rail Yard and Spur Textures Mega Pack 1](https://community.simtropolis.com/files/file/15976-rail-yard-and-spur-textures-mega-pack-1/)
+    [BSC Mega Props - JES Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+    [BSC Mega Props - JES Vol06](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1416)
+    [BSC Mega Props - JES Vol07](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1495)
+    [BSC Mega Props - JES Vol08](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1778)
+    [BSC BAT Props - T1 Vol3](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1764)
+    [Container Freight Yards](https://community.simtropolis.com/files/file/15402-container-freight-yards/)
+    [PEG CDK3 SP Container Ship Fleet](https://community.simtropolis.com/files/file/19577-peg-cdk3-sp-container-ship-fleet/)
+
+    * * *
+
+    Mod Edit: Fixed broken dependency links.
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/23954-modular-container-port/
+  images:
+    - https://www.simtropolis.com/objects/screens/0003/0e727a571cc065a5f19ac14383f16dd8-containerport1.jpg
+    - https://www.simtropolis.com/objects/screens/0003/0e727a571cc065a5f19ac14383f16dd8-containerport2.jpg
+dependencies:
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol06
+  - bsc:mega-props-jes-vol07
+  - bsc:mega-props-jes-vol08
+  - bsc:mega-props-t1-vol03
+  - ncd:rail-yard-and-spur-mega-pak-1
+  - peg:cdk3-sp-container-ship-fleet
+  - peg:cdk3-sp-rail-fleet
+  - peg:cdk3-sp-seaport-super-pak
+  - peg:cdk3-super-pak
+  - peg:security-fencing-kit
+  - sg:container-freight-yards
+assets:
+  - assetId: nbvc-modular-container-port
+
+---
+assetId: nbvc-modular-container-port
+version: "1.0"
+lastModified: "2010-05-23T01:57:34Z"
+url: https://community.simtropolis.com/files/file/23954-modular-container-port/?do=download&r=50973

--- a/src/yaml/nbvc/25080-water-ploppable-scows.yaml
+++ b/src/yaml/nbvc/25080-water-ploppable-scows.yaml
@@ -1,0 +1,33 @@
+group: nbvc
+name: water-ploppable-scows
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Water ploppable scows
+  description: |-
+    A water ploppable version of the PEG PPond Scows. The scows are only eyecandy.
+
+    They are located in the seaport menu.
+
+    Update:
+
+    Fixed game crash with green scow.
+
+    Dependencies:
+
+    [PEG PPond Scows](https://www.simtropolis.com/stex/details.cfm?id=22893)
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/25080-water-ploppable-scows/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/be19970129e905e8f091b7678f86172f-scow21.jpg
+    - https://www.simtropolis.com/objects/screens/0021/be19970129e905e8f091b7678f86172f-scow11.jpg
+dependencies:
+  - peg:ppond-scows
+assets:
+  - assetId: nbvc-water-ploppable-scows
+
+---
+assetId: nbvc-water-ploppable-scows
+version: "1.0"
+lastModified: "2010-10-17T04:25:00Z"
+url: https://community.simtropolis.com/files/file/25080-water-ploppable-scows/?do=download&r=52629

--- a/src/yaml/nbvc/25531-ski-race.yaml
+++ b/src/yaml/nbvc/25531-ski-race.yaml
@@ -1,0 +1,29 @@
+group: nbvc
+name: ski-race
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Ski Race
+  description: |-
+    The Ski Race contains several Lots to build a ski race track.
+
+    No Dependencies
+
+    The base textures of the Lots are transparent and a snow mod is highly recommended. [https://www.simtropolis.com/STEX/details.cfm?id=20937](https://www.simtropolis.com/stex/details.cfm?id=20937)
+
+    For safety netting and ski lifts, you can have a look here [https://www.simtropolis.com/STEX/details.cfm?id=22995](https://www.simtropolis.com/stex/details.cfm?id=22995)
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/25531-ski-race/
+  images:
+    - https://www.simtropolis.com/objects/screens/0005/24543cdb61ca8c1bbe03f271ad18bbec-SkiRace1.jpg
+    - https://www.simtropolis.com/objects/screens/0005/24543cdb61ca8c1bbe03f271ad18bbec-SkiRace2.jpg
+dependencies:
+  - peg:snow-mod-2
+assets:
+  - assetId: nbvc-ski-race
+
+---
+assetId: nbvc-ski-race
+version: "1.0"
+lastModified: "2010-12-23T07:25:32Z"
+url: https://community.simtropolis.com/files/file/25531-ski-race/?do=download&r=53383

--- a/src/yaml/nbvc/25532-hut-with-snow.yaml
+++ b/src/yaml/nbvc/25532-hut-with-snow.yaml
@@ -1,0 +1,39 @@
+group: nbvc
+name: hut-with-snow
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Hut (With Snow)
+  description: |-
+    This zip-file contains a small hut.
+
+    Lot size is 1x1.
+
+    There is a folder called "zzzNBVCSnowHut" in the zip-file. If you remove this folder, you will have the hut without snow.
+
+    All plopped huts will automatically change to the version without snow.
+
+    The hut is located in the park menu.
+
+    No Dependencies
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/25532-hut-with-snow/
+  images:
+    - https://www.simtropolis.com/objects/screens/0022/c6921f9d850afb592700ec97e593648a-hut1.jpg
+dependencies:
+  - peg:snow-mod-2
+variants:
+  - variant: { peg:snow-mod:season: summer }
+    assets:
+      - assetId: nbvc-hut-with-snow
+        exclude:
+          - /zzzNBVCSnowHut/
+  - variant: { peg:snow-mod:season: winter }
+    assets:
+      - assetId: nbvc-hut-with-snow
+
+---
+assetId: nbvc-hut-with-snow
+version: "1.0"
+lastModified: "2010-12-23T07:48:47Z"
+url: https://community.simtropolis.com/files/file/25532-hut-with-snow/?do=download&r=53385

--- a/src/yaml/nbvc/25596-modular-docks.yaml
+++ b/src/yaml/nbvc/25596-modular-docks.yaml
@@ -1,0 +1,79 @@
+group: nbvc
+name: modular-docks
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Modular Docks
+  description: |-
+    This is a set of 34 Lots to build custom docks.
+
+    It contains some piers, warehouses, cranes, roads, fences and rail depots.
+
+    The docks have no seaport functionality.
+
+    Two of the rail depots have freight rail functionality.
+
+    All Lots are in the seaport menu.
+
+    Dependencies:
+
+    [PEG\_SecurityFence](https://www.simtropolis.com/stex/details.cfm?id=19338)
+
+    [PEG\-CDK3\_RailFleet](https://www.simtropolis.com/stex/details.cfm?id=19786)
+
+    [Rail Yard and Spur Textures](https://www.simtropolis.com/stex/details.cfm?id=15976)
+
+    [BSC MEGA Props - RT WFK Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=286)
+
+    [BSC MEGA Props - RT WFK N Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=285)
+
+    [BSC MEGA Props - Gascooker Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=397)
+
+    [BSC Mega Props - JES Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+
+    [BSC Mega Props - JES Vol03](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=339)
+
+    [BSC Mega Props - JES Vol04](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=791)
+
+    [BSC Mega Props - JES Vol06](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1416)
+
+    [BSC Mega Props - JES Vol07](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1495)
+
+    [BSC Mega Props - JES Vol08](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1778)
+
+    [BSC MEGA Props - Misc Vol02](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1771)
+
+    For the single track rail depot you need RAM - Single track rail
+
+    https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1996
+
+    [**Network Addon Mod**](https://community.simtropolis.com/files/file/26793-network-addon-mod-nam-for-windows-installer/) (most probably, since the RAM now is part of the **NAM**)
+
+    edit: updated dependency link - Tyberius06
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/25596-modular-docks/
+  images:
+    - https://www.simtropolis.com/objects/screens/0019/a964d7e88e4958a9d71bdf221b520acd-docks1.jpg
+    - https://www.simtropolis.com/objects/screens/0019/a964d7e88e4958a9d71bdf221b520acd-dock2.jpg
+dependencies:
+  - bsc:mega-props-gascooker-vol01
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol03
+  - bsc:mega-props-jes-vol04
+  - bsc:mega-props-jes-vol06
+  - bsc:mega-props-jes-vol07
+  - bsc:mega-props-jes-vol08
+  - bsc:mega-props-misc-vol02
+  - bsc:mega-props-rt-wfk-vol01-cds
+  - bsc:mega-props-rt-wfk-vol02-wimps
+  - ncd:rail-yard-and-spur-mega-pak-1
+  - peg:cdk3-sp-rail-fleet
+  - peg:security-fencing-kit
+assets:
+  - assetId: nbvc-modular-docks
+
+---
+assetId: nbvc-modular-docks
+version: "1.0"
+lastModified: "2010-12-29T11:07:39Z"
+url: https://community.simtropolis.com/files/file/25596-modular-docks/?do=download&r=53469

--- a/src/yaml/nbvc/26731-tank-car-filling-station.yaml
+++ b/src/yaml/nbvc/26731-tank-car-filling-station.yaml
@@ -1,0 +1,52 @@
+group: nbvc
+name: tank-car-filling-station
+version: "1.1"
+subfolder: 400-industrial
+info:
+  summary: Tank Car Filling Station
+  description: |-
+    Filling stations for rail tank cars. The set contains an empty, a small and a large filling station. They are designed to fit to the pipes of my
+    [Modular Oil Port](https://community.simtropolis.com/files/file/26365-modular-oil-port/)
+
+    The stations have freight station functionality.
+    The empty and small station have capacity 2500.
+    The large station has capacity 8000.
+    They are all transit enabled.
+
+    The stations are in different folders.
+
+    Dependencies:
+    Empty Filling Station:
+    None
+
+    Small Filling Station:
+    PEG CDK3 SP Rail Fleet 1 [https://community.simtropolis.com/files/file/19786-peg-cdk3\-sp-rail-fleet/](https://community.simtropolis.com/files/file/19786-peg-cdk3-sp-rail-fleet/)
+
+    Large Filling Station:
+    PEG CDK3 SP Rail Fleet 1 (same as above) [https://community.simtropolis.com/files/file/19786-peg-cdk3\-sp-rail-fleet/](https://community.simtropolis.com/files/file/19786-peg-cdk3-sp-rail-fleet/)
+    BSC Mega Props - JES Vol06 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1416](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1416)
+    BSC Mega Props - JES Vol07 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1495](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1495)
+    Train pack blanco\_05 [http://www.toutsimcities.com/downloads/view/1335](http://www.toutsimcities.com/downloads/view/1335)
+
+    If you don't have all dependencies, you will not have all trains and tank cars, but the stations should still work.
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/26731-tank-car-filling-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_09_2011/d4ceb31a4c5d56972a75f0aaaafc9e4a-tankcarfilling1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2011/b782b88a25630ebe3acde9a49a437f01-tankcarfilling2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2011/db9ae51477983842e3f362af188b6140-tankcarfilling4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2011/a2a6787c6927e31a2e9eac20d528bf2b-tankcarfilling3.jpg
+dependencies:
+  - blanco:train-prop-pack-sd
+  - bsc:mega-props-jes-vol06
+  - bsc:mega-props-jes-vol07
+  - nbvc:modular-oil-port
+  - peg:cdk3-sp-rail-fleet
+assets:
+  - assetId: nbvc-tank-car-filling-station
+
+---
+assetId: nbvc-tank-car-filling-station
+version: "1.1"
+lastModified: "2011-09-04T09:44:01Z"
+url: https://community.simtropolis.com/files/file/26731-tank-car-filling-station/?do=download&r=92289

--- a/src/yaml/nbvc/28532-garbage-disposal-facilities.yaml
+++ b/src/yaml/nbvc/28532-garbage-disposal-facilities.yaml
@@ -1,43 +1,41 @@
-# The refuse relocation kit dependency is an .exe installer that can't be 
-# handled by sc4pac, neither cicdec. That's unfortunate, this would be a great 
-# plugin to have.
-# group: nbvc
-# name: garbage-disposal-facilities
-# version: "1.0"
-# subfolder: 700-transit
-# info:
-#   summary: Garbage Disposal Facilities
-#   description: |-
-#     The file contains four garbage disposal facilities.
+group: nbvc
+name: garbage-disposal-facilities
+version: "1.0"
+subfolder: 500-utilities
+info:
+  summary: Garbage Disposal Facilities
+  description: |-
+    The file contains four garbage disposal facilities.
 
-#     -   Large Recycling Center (Capacity 50000, Monthly coast 400)
-#     -   Small Garbage Disposal Yard (Capacity 5000, Monthly coast 50)
-#     -   Garbage Disposal Facility. (Capacity 50000, Monthly coast 400, Rail access)
-#     -   Garbage Disposal Facility. (Capacity 45000, Monthly coast 350, Single track rail access)
+    -   Large Recycling Center (Capacity 50000, Monthly coast 400)
+    -   Small Garbage Disposal Yard (Capacity 5000, Monthly coast 50)
+    -   Garbage Disposal Facility. (Capacity 50000, Monthly coast 400, Rail access)
+    -   Garbage Disposal Facility. (Capacity 45000, Monthly coast 350, Single track rail access)
 
-#     You can use the props in this file for your own custom lots.
+    You can use the props in this file for your own custom lots.
 
-#     Dependencies:
+    Dependencies:
 
-#     [PEG Refuse Relocation Kit](https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/)
+    [PEG Refuse Relocation Kit](https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/)
 
-#     Single Track Rail (only for the garbage disposal with single track rail access) **[Network Addon Mod](https://community.simtropolis.com/files/file/26793-network-addon-mod-nam-for-windows-installer/)** (most probably, since the RAM now is part of the **NAM**)
+    Single Track Rail (only for the garbage disposal with single track rail access) **[Network Addon Mod](https://community.simtropolis.com/files/file/26793-network-addon-mod-nam-for-windows-installer/)** (most probably, since the RAM now is part of the **NAM**)
 
-#     [Maxis Buildings as Props](http://www.simcityplaza.de/index.php/tools-und-andere-downloads/offizielle-downloads/file/446-buildings-as-props-von-maxis)
+    [Maxis Buildings as Props](http://www.simcityplaza.de/index.php/tools-und-andere-downloads/offizielle-downloads/file/446-buildings-as-props-von-maxis)
 
-#     Update 03.10.2019 - Fixed dependency link by **Tyberius06**
-#   author: nbvc
-#   website: https://community.simtropolis.com/files/file/28532-garbage-disposal-facilities/
-#   images:
-#     - https://www.simtropolis.com/objects/screens/monthly_03_2013/beb647f9c92a9eaec910c3d26072cdd4-garbagedisposal1.jpg
-#     - https://www.simtropolis.com/objects/screens/monthly_03_2013/938ddaec43e06c2df373faca5c079ff7-garbagedisposal2.jpg
-# dependencies:
-#   - '"[PEG Refuse Relocation Kit](https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/)"'
-# assets:
-#   - assetId: nbvc-garbage-disposal-facilities
+    Update 03.10.2019 - Fixed dependency link by **Tyberius06**
+  author: nbvc
+  website: https://community.simtropolis.com/files/file/28532-garbage-disposal-facilities/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_03_2013/beb647f9c92a9eaec910c3d26072cdd4-garbagedisposal1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_03_2013/938ddaec43e06c2df373faca5c079ff7-garbagedisposal2.jpg
+dependencies:
+  - peg:refuse-relocation-kit
+  - t-wrecks:maxis-prop-names-and-query-fix
+assets:
+  - assetId: nbvc-garbage-disposal-facilities
 
-# ---
-# assetId: nbvc-garbage-disposal-facilities
-# version: "1.0"
-# lastModified: "2013-03-03T16:13:55Z"
-# url: https://community.simtropolis.com/files/file/28532-garbage-disposal-facilities/?do=download&r=112631
+---
+assetId: nbvc-garbage-disposal-facilities
+version: "1.0"
+lastModified: "2013-03-03T16:13:55Z"
+url: https://community.simtropolis.com/files/file/28532-garbage-disposal-facilities/?do=download&r=112631

--- a/src/yaml/onlyplace4/15246-logging-mill-accomodation.yaml
+++ b/src/yaml/onlyplace4/15246-logging-mill-accomodation.yaml
@@ -1,0 +1,23 @@
+group: onlyplace4
+name: logging-mill-accomodation
+subfolder: 360-landmark
+version: "1.0"
+info:
+  summary: Logging Mill Accomodation
+  description: |-
+    As requested by tomb, ncd and others, here is the accomodation prop that was used on my Slaytfork Mill BAT. No stats but it is nite lite enabled (as you can plainly see!).
+
+    To instal: simply unzip the .dat into your plugins folder.
+  author: onlyplace4
+  website: https://community.simtropolis.com/files/file/15246-logging-mill-accomodation/
+  images:
+    - https://www.simtropolis.com/objects/screens/0007/36f1372286cd5287d41a8949e667a7d6-LMAP_day.jpg
+    - https://www.simtropolis.com/objects/screens/0007/36f1372286cd5287d41a8949e667a7d6-LMAP_night.jpg
+assets:
+  - assetId: onlyplace4-logging-mill-accomodation
+
+---
+assetId: onlyplace4-logging-mill-accomodation
+version: "1.0"
+lastModified: "2006-03-13T03:34:10Z"
+url: https://community.simtropolis.com/files/file/15246-logging-mill-accomodation/?do=download&r=37173

--- a/src/yaml/onlyplace4/15907-slaytfork-mill-revised.yaml
+++ b/src/yaml/onlyplace4/15907-slaytfork-mill-revised.yaml
@@ -1,0 +1,61 @@
+group: onlyplace4
+name: slaytfork-mill-revised
+version: "1.0"
+subfolder: 360-landmark
+info:
+  summary: Slaytfork Mill Revised
+  description: |-
+    For my **100th** upload to the STEX I have decided to revisit my most popular BAT to date, and have rescaled, retextured, and remodelled parts that I thought needed it. Additionally, this time the model is an overhanging model so that it can, as shown in the pictures above, be plopped alongside normal ingame water. As the end of the mill (from the top edge of the power house to the end of the log slide) overhangs it is possible, with some care, to plop the model and then terraform the land underneath it. The 'on land' part of this is a 6x7 Landmark Lot.
+
+    Like the original model, this one produces it's own power but still, for some reason, will not transmit it's power to neighbouring areas. I have not simply updated the original model which is still available on the STEX [**here**](https://www.simtropolis.com/stex/index.cfm?id=15195). This means that you do not need to delete that model should you have it in use. Also, this earlier model is at a much larger scale which, though out of scale with the remaining Maxis buildings, seems to work well in rural areas on it's own, and has proved very popular.
+
+    The best way to position this lot is to terraform your water and then select the plot of land you want to plop the mill onto. Now, flatten the area next to the water until it cannot go any lower. I do this with the normal terraform tools until I have all the squares within the zone just showing water. I then raise a single square a fraction and then smooth the lot using that square as a reference. Basically, the land should be at the lowest level possible for this lot to look right next to the water. I am sure that some trial and error will produce the right effect/positioning.
+
+    I will be releasing the Mill office and the water tower/pump house as seperate lots in the near future.
+
+    * * *
+
+    **Stats:**Plop cost: §25000
+
+    Budget item cost: §500
+
+    Bulldoze cost: §500
+
+    Pollution at centre: 10, 10, 25, 0 (air, water, garbage, radiation)
+
+    Pollution radii: 3, 6, 0, 0
+
+    Landmark Effect: 0 over 0 tiles
+
+    Mayor rating effect: 0 over 0 tiles
+
+    Power consumed: 0
+
+    Power produced: 2500 MWh
+
+    Water consumed: 0
+
+    Wealth: none
+
+    Dependencies: none
+
+    * * *
+
+    **To instal**Simply unzip the required .dat file to your plugins folder.
+
+    If you download and use, please comment and rate.
+
+    Visit my BATs and Lots thread ... [**here**](https://www.simtropolis.com/forum/messageview.cfm?catid=37&threadid=74636).
+  author: onlyplace4
+  website: https://community.simtropolis.com/files/file/15907-slaytfork-mill-revised/
+  images:
+    - https://www.simtropolis.com/objects/screens/0007/384712ff375641d9767621cfc95496b6-day.jpg
+    - https://www.simtropolis.com/objects/screens/0007/384712ff375641d9767621cfc95496b6-night.jpg
+assets:
+  - assetId: onlyplace4-slaytfork-mill-revised
+
+---
+assetId: onlyplace4-slaytfork-mill-revised
+version: "1.0"
+lastModified: "2006-05-10T06:50:38Z"
+url: https://community.simtropolis.com/files/file/15907-slaytfork-mill-revised/?do=download&r=38239

--- a/src/yaml/paeng/26425-grunge-concrete-set.yaml
+++ b/src/yaml/paeng/26425-grunge-concrete-set.yaml
@@ -1,0 +1,78 @@
+group: paeng
+name: grunge-concrete-set
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Grunge Concrete Set
+  description: |-
+    Tired of all the plain, uniform, 'clean' looking concrete? Here is a small set of fillers for your industrial areas with some grungy concrete, broken up slabs with grass sticking out...
+
+    **LIST OF ITEMS**
+
+    The set includes basic paths of grungy concrete with tire tracks -
+
+    -   1x1 straight, curve, tee, cross, end
+    -   1x1 plain filler
+    -   1x1 gated entrance (2 versions, TE'd and eyecandy)
+
+    **BONUS**
+
+    \* a set of Mayor Mode Ploppables (*MMP*) with various industrial props to scatter all over the place ;-)
+
+    **DEPENDENCIES**
+
+    ~ none ~
+
+    **DEVELOPER NOTES**
+
+    You can use the basic set of lots standalone.
+
+    **The pack also contains a set of textures that will be used as a dependency for my future lotting projects**.
+
+    Lotters - you may use the textures for your own projects. However, please do not include them in your uploads - point to this pack as a dependency instead.
+
+    You find the lots at or near the end of the 'Transportation | Miscellaneous' menu with custom icons.
+
+    The MMP of course sits in your Mayor Mode menu.
+
+    **SUPPORT**
+
+    Should you need support for these items please visit the [Paeng Production Forum](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/forum/index.php/board,109.0.html)
+
+    **\-Cori Edit:** Fixed broken formatting.
+  author: paeng
+  website: https://community.simtropolis.com/files/file/26425-paengs-grunge-concrete-set/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_06_2011/83109afaf9026158e3f3e79d786c118a-grunge-concrete_800.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_06_2011/54bef0eb4d89b97cc07d577c7fb5645e-grunge-c02.jpg
+dependencies:
+  - paeng:grunge-concrete-set-resources
+assets:
+  - assetId: paeng-grunge-concrete-set
+    include:
+      - Paeng_Grunge_Concrete/GrungeConcrete/paeng_Grunge_Concrete.dat
+      - Paeng_Grunge_Concrete/GC_Resources/paeng_IND_Grunge_MMP.dat
+      - Paeng_Grunge_Concrete/GC_GatedEntrance/paeng_Gated_Entrance.dat
+
+---
+group: paeng
+name: grunge-concrete-set-resources
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Grunge Concrete Set resources
+  description: |-
+    This package is a resource for `pkg=paeng:grunge-concrete-set`
+  author: paeng
+  website: https://community.simtropolis.com/files/file/26425-paengs-grunge-concrete-set/
+assets:
+  - assetId: paeng-grunge-concrete-set
+    include:
+      - Paeng_Grunge_Concrete/GC_Resources/paeng_Grunge_Resource.dat
+      - Paeng_Grunge_Concrete/GC_Resources/paeng_Grunge_Concrete_Textures.dat
+
+---
+assetId: paeng-grunge-concrete-set
+version: "1.0"
+lastModified: "2011-06-30T13:52:03Z"
+url: https://community.simtropolis.com/files/file/26425-paengs-grunge-concrete-set/?do=download&r=88252

--- a/src/yaml/paeng/27284-mtp-logging-addon-vol02.yaml
+++ b/src/yaml/paeng/27284-mtp-logging-addon-vol02.yaml
@@ -1,0 +1,151 @@
+group: paeng
+name: mtp-logging-addon-vol02
+version: "1.0"
+subfolder: 400-industrial
+info:
+  summary: MTP Logging AddOn Vol02
+  description: |-
+    To further strengthen the logging operations in your region, here is a second MTP\-style addon. It refreshes many previous items and adds a number of new ones as well. Most of it lives off old proven dependencies, but a few new ones had to be added - see the 'checklist' below...
+
+    **LISTING OF ITEMS**
+
+    **Logging Roads v2**
+
+    \* 16 lots with various configurations, stacked log props, timed vehicles
+
+    **Log and Lumber Storage**
+
+    \* 10 lots with various configurations, stacked lumber props, timed vehicles
+
+    **Logging Facilities** (functional)
+
+    \* Storage Headquarter I-D
+
+    \* Poor Old Sawmill I-D
+
+    \* Slaytfork Mill Revisited I-M
+
+    \* Logging Freight Station RR
+
+    \* Container Generator UTIL
+
+    **Miscellaneous Logging Items**
+
+    \* 9 Lots (Fillers) with various configurations, stacked props, timed vehicles
+
+    **Others**
+
+    \* Various Replacement files and Patches for existing items
+
+    **DEPENDENCIES**
+
+    If you are new to 'Logging', you may want to check this very comprehensive ["Cheat Sheet"](https://community.simtropolis.com/omnibus/simcity-4/reference/paengs-cheat-sheet-logging-operations-in-rural-areas-r386/) listing **everything** you need for a successful logging operation!
+
+    This pack is not meant to be a 'standalone' set but was done to enhance and fill out our existing logging collection... If you're a Logger, I'm quite positive that you don't really need to download/install anything... it's all there. So this is more of a checklist ;-)
+
+    \* [**NBVC Logging Set**](https://www.simtropolis.com/forum/files/file/27240-logging-set/)
+
+    **\* [MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **\* [PEG MTP Logging Industry RESOURCE](https://community.simtropolis.com/files/file/20965-peg-mtp-logging-resource/)**
+
+    **\* [PEG MTP LTUSA Cross Roads](https://community.simtropolis.com/files/file/21147-peg-mtp-ltusa-cross-roads/)**
+
+    **\* [PEG MTP TLC Rail Transfer Yard](https://community.simtropolis.com/files/file/21072-peg-mtp-tlc-rail-transfer-yard/)**
+
+    **\* [PEG\-MTP Logging Roads](https://community.simtropolis.com/files/file/21053-peg-mtp-logging-roads/)** (needed: PEG\-MTP\_Logging-Roads\_Textures101.dat)
+
+    **\* [PEG\-MTP LTUSA Container Generator](https://community.simtropolis.com/files/file/21103-peg-mtp-ltusa-container-generator/)**
+
+    \* [**Nexis Woodpile Props**](https://www.simtropolis.com/forum/files/file/11769-nexis-wood-pile-props/)
+
+    **\* [Paeng's Grunge Concrete Set](https://community.simtropolis.com/files/file/26425-paengs-grunge-concrete-set/)**
+
+    **\* [SPOT (Orientation Helpers)](https://community.simtropolis.com/files/file/24509-spot/)**
+
+    \* **MTP\_Logging\_Resource\_ADD.dat** (included)
+
+    \* **zz\_MTP\_Logging\_Patches.dat** (included)
+
+    **OPTIONAL**
+
+    **Poor Old Sawmill**
+
+    \* [**Newman Inc. Props Vol.01**](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=613)
+    (*same as for the sawmills included in 'NBVC Logging Set'*)
+
+    **The Revisited Slaytfork Set**
+
+    \* [**Slaytfork Mill Revised**](https://www.simtropolis.com/forum/files/file/15907-slaytfork-mill-revised/)
+    (*needed: Slaytfork Mill Revised.dat*)
+
+    \* [**Slaytfork Accomodation**](https://www.simtropolis.com/forum/files/file/15246-logging-mill-accomodation/)
+    (*needed: Slaytfork accomodation.dat*)
+
+    **DEVELOPER NOTES**
+
+    The bulk of the lots is found tightly grouped with custom icons in the 'Transport | Miscellaneous' menu. Power and Rail items are in their respective menus.
+
+    **Logging Roads** (partial Replacement)
+
+    Replace OLD \* PEG\-MTP\_Logging-Roads\_101.dat
+
+    with NEW \* MTP\_LoggingRoads\_v200.dat
+
+    Note: The original textures (PEG\-MTP\_Logging-Roads\_Textures101.dat) MUST be kept!
+
+    **Logging Scenes** (Replacement)
+
+    Replace OLD \* PEG\-MTP\_MM7-ForestLogging\_MOD\_103.dat (in: ZZZ PEG Facelift Mods >MTP >MTP MM7 Logging Scenes)
+
+    with NEW \* PEG\-MTP\_MM7-ForestLogging\_MOD\_200.dat
+
+    Note: The replacement file has additional items needing some dependencies/patches as listed above.
+
+    **Logging Patches**
+
+    These patches are optional - there are some adjustments to the included exemplars, but mainly they will assure full 'paintability' of all items (meaning you can brush in MMP flora around and below plopped items). Make sure to keep them in a z-folder in your Plugin's root, insuring that they load AFTER any logging items, regardless of the creator (e.g. PEG, NBVC, NEXIS etc.).
+
+    \* *See also ReadMe files in the corresponding folders.*
+
+    **THANKS!**
+
+    Special khanks go to all who sponsored custom props for this pack - **Nexis, Becca and Murimk**. Unless noted otherwise these items are included in the resource file, with their kind permission.
+
+    **SUPPORT**
+
+    Should you need support for these items please visit the [**Paeng Productions forum**](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/forum/index.php?topic=10049.0). The thread shows many additional images as well.
+
+    **\-Cori Edit:** Fixed formatting and broken linkys.
+  author: paeng
+  website: https://community.simtropolis.com/files/file/27284-paengs-mtp-logging-addon-vol02/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/774583e51c2ef3b38b074bcbc14f6408-log-ops01.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/75d7aba939a42cb9b76f7a98dd90cec8-logroad01.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/4f9c7ce71b4c7ee1edf7b6cd52d20d18-storage02.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/3298458d65544d904ff09aebf12288a7-misc03.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/8fe92eaed06bcdc51795cf1e5446a156-scenes04.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/c268c03ba8ac8143a4b9f56961963f7f-functs05.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_02_2012/21551b1aa55ea6d5a5681224aed8eca0-slayt06.jpg
+dependencies:
+  - bsc:mega-props-newmaninc-vol01
+  - mrbisonm:nexis-wood-pile-props
+  - nbvc:logging-set-resources
+  - onlyplace4:logging-mill-accomodation
+  - onlyplace4:slaytfork-mill-revised
+  - paeng:grunge-concrete-set-resources
+  - peg:mtp-logging-resource
+  - peg:mtp-logging-roads
+  - peg:mtp-ltusa-container-generator
+  - peg:mtp-ltusa-cross-roads
+  - peg:mtp-super-pack
+  - peg:mtp-tlc-rail-transfer-yard
+  - peg:spot
+assets:
+  - assetId: paeng-mtp-logging-addon-vol02
+
+---
+assetId: paeng-mtp-logging-addon-vol02
+version: "1.0"
+lastModified: "2012-02-17T22:21:18Z"
+url: https://community.simtropolis.com/files/file/27284-paengs-mtp-logging-addon-vol02/?do=download&r=97071

--- a/src/yaml/peg/11001-trail-parks-iii.yaml
+++ b/src/yaml/peg/11001-trail-parks-iii.yaml
@@ -1,0 +1,25 @@
+group: peg
+name: trail-parks-iii
+version: "1.1"
+info:
+  summary: Trail Parks III
+  description: |-
+    The PEG Trail Parks have returned with a whole new visual makeover. This initial release introduces the new version of the basic Trail Parks... designed to blend seamlessly with the the [PEG Random Woods](https://community.simtropolis.com/files/file/4526-peg-random-woods-v206/) & the [PEG Stream Kit II](https://community.simtropolis.com/files/file/11083-peg-stream-kit-ii-v205/).
+
+    These new parks feature BAT modeled pathways that replace the old textured paths. This means that the paths now show while you are plopping the lots. This makes them much easier to use.
+
+    These Trail Parks also feature two new trail lots that will allow you to run your trails anywhere. The new EL Transit lot will allow you to extend the trails under elevated rail & highways. The new Pedestrian Tunnel allows you to visually run your trails under any road or rail... or even under entire buildings or blocks.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/
+  images:
+    - https://www.simtropolis.com/objects/screens/0016/8c4309f065ce08a2c18dd286d80a80f0-product_image.jpg
+assets:
+  - assetId: peg-trail-parks-iii
+
+---
+assetId: peg-trail-parks-iii
+version: "1.1"
+lastModified: "2025-01-19T17:58:04Z"
+url: https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/?do=download&r=205368

--- a/src/yaml/peg/11001-trail-parks-iii.yaml
+++ b/src/yaml/peg/11001-trail-parks-iii.yaml
@@ -1,6 +1,7 @@
 group: peg
 name: trail-parks-iii
 version: "1.1"
+subfolder: 660-parks
 info:
   summary: Trail Parks III
   description: |-

--- a/src/yaml/peg/11065-pine-trails.yaml
+++ b/src/yaml/peg/11065-pine-trails.yaml
@@ -1,29 +1,31 @@
-group: peg
-name: pine-trails
-version: "1.1"
-subfolder: 660-parks
-info:
-  summary: Pine Trails
-  description: |-
-    The PEG Pine Trails completes the set Trail Parks. These are a direct replacement for the original Country Roads trail parks... and feature dirt paths that are designed to wind through the PEG Pine Forests.
+# We no longer include this in favor of the mtp-mountain-trails, which is an 
+# override without the pines. Both shouldn't be installed at the same time.
+# group: peg
+# name: pine-trails
+# version: "1.1"
+# subfolder: 660-parks
+# info:
+#   summary: Pine Trails
+#   description: |-
+#     The PEG Pine Trails completes the set Trail Parks. These are a direct replacement for the original Country Roads trail parks... and feature dirt paths that are designed to wind through the PEG Pine Forests.
 
-    This style also uses textures for the paths instead of BAT models.. so they are slope-conforming. The logs outlining the paths are BAT models. They are visible when plopping and serve as a visual guide to  proper lot orientation.
+#     This style also uses textures for the paths instead of BAT models.. so they are slope-conforming. The logs outlining the paths are BAT models. They are visible when plopping and serve as a visual guide to  proper lot orientation.
 
-    Dependencies:
-    \- [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+#     Dependencies:
+#     \- [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
 
-    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
-  author: Pegasus
-  website: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/
-  images:
-    - https://www.simtropolis.com/objects/screens/0025/e3493738bb9178573a34d73cee997102-product_image.jpg
-dependencies:
-  - peg:mtp-super-pack
-assets:
-  - assetId: peg-pine-trails
+#     **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+#   author: Pegasus
+#   website: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/
+#   images:
+#     - https://www.simtropolis.com/objects/screens/0025/e3493738bb9178573a34d73cee997102-product_image.jpg
+# dependencies:
+#   - peg:mtp-super-pack
+# assets:
+#   - assetId: peg-pine-trails
 
----
-assetId: peg-pine-trails
-version: "1.1"
-lastModified: "2025-01-19T15:08:21Z"
-url: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/?do=download&r=205361
+# ---
+# assetId: peg-pine-trails
+# version: "1.1"
+# lastModified: "2025-01-19T15:08:21Z"
+# url: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/?do=download&r=205361

--- a/src/yaml/peg/11065-pine-trails.yaml
+++ b/src/yaml/peg/11065-pine-trails.yaml
@@ -1,0 +1,29 @@
+group: peg
+name: pine-trails
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Pine Trails
+  description: |-
+    The PEG Pine Trails completes the set Trail Parks. These are a direct replacement for the original Country Roads trail parks... and feature dirt paths that are designed to wind through the PEG Pine Forests.
+
+    This style also uses textures for the paths instead of BAT models.. so they are slope-conforming. The logs outlining the paths are BAT models. They are visible when plopping and serve as a visual guide to  proper lot orientation.
+
+    Dependencies:
+    \- [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e3493738bb9178573a34d73cee997102-product_image.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-pine-trails
+
+---
+assetId: peg-pine-trails
+version: "1.1"
+lastModified: "2025-01-19T15:08:21Z"
+url: https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/?do=download&r=205361

--- a/src/yaml/peg/11097-christmas-development-kit.yaml
+++ b/src/yaml/peg/11097-christmas-development-kit.yaml
@@ -1,6 +1,7 @@
 group: peg
 name: christmas-development-kit
 version: "1.1"
+subfolder: 100-props-textures
 info:
   summary: Christmas Development Kit
   description: |-

--- a/src/yaml/peg/11097-christmas-development-kit.yaml
+++ b/src/yaml/peg/11097-christmas-development-kit.yaml
@@ -1,0 +1,41 @@
+group: peg
+name: christmas-development-kit
+version: "1.1"
+info:
+  summary: Christmas Development Kit
+  description: |-
+    Just in time for the Holidays... The PEG Christmas Development Pack contains 10 new seasonal props for developers to use on their lots. Two of the lots, those pictured in the upper images, are year-round props that change during the Holiday season. The other props appear only during the Holidays.
+
+    This kit includes:
+
+    1\. Pine Tree/Christmas Tree. A common pine tree throughout the year... but decorated during the Holidays.
+
+    2\. Billboard/Nativity Scene.  Typical ad hype for 11 months. Redressed with a beautiful nativity scene for Christmas.
+
+    3\. Colored Christmas Lights. A short string of multicolored Christmas lights that can be strung together to decorate your favorite buildings. They only appear during the Holiday season.
+
+    4\. Small Nativity Scene. A common painted plywood decoration. Ideal for use on churches, parks or residential front yards. Appears only during the Holidays.
+
+    5\. Snowmen. Offered in large and Mucho Grande sizes. Appears only during the Holidays.
+
+    6\. Santa Clauses. Two sizes and styles to choose from. Appears only during the Holidays.
+
+    7 Santa's Sleigh. A large and colorful decoration suitable for display in plazas and shopping centers. Appears only during the Holidays.
+
+    8\. Santa's Sleigh & Reindeer. The classic Holiday decoration that can be used almost anywhere. Appears only during the Holidays.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+
+    ***To all of you from all the members and staff at Pegasus Productions... Have a very, merry Holiday and a wonderful  New Year!***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/
+  images:
+    - https://www.simtropolis.com/objects/screens/0014/77235ee54b5b3379d757e58ae1a3c902-product_image.jpg
+assets:
+  - assetId: peg-christmas-development-kit
+
+---
+assetId: peg-christmas-development-kit
+version: "1.1"
+lastModified: "2025-01-19T18:28:02Z"
+url: https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/?do=download&r=205376

--- a/src/yaml/peg/11129-refuse-relocation-kit.yaml
+++ b/src/yaml/peg/11129-refuse-relocation-kit.yaml
@@ -1,0 +1,28 @@
+group: peg
+name: refuse-relocation-kit
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: Refuse Relocation Kit
+  description: |-
+    The PEG Refuse Relocation Kit contains 2 new garbage truck BAT models for use on your lots. These are not static props. They are designed to simulate normal trash pick-up activity by randomly appearing for a short period only.
+
+    Although our trash is normally picked up only once or twice a week, these trucks will show up every day. They will also remain visible for 4 hours. This may not be totally realistic but it works better visually in the game.
+
+    **Also...** This kit contains 4 new 'Skin' DATs that players can use to change the color of the garbage truck automata in the game. The install will put all four in your Plugins folder but only one can be used at a time. You will want to manually remove the 3 Skin DAT files you do not wish to use.
+
+    The game's default Recycling Truck automata has been updated to use the new green garbage truck. The automata skins have all been updated to include the recycling logo as a standard Sanitation Dept. logo.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/
+  images:
+    - https://www.simtropolis.com/objects/screens/0009/4f15b8b2f4bddbf94825c1784c878a1d-product_image.jpg
+assets:
+  - assetId: peg-refuse-relocation-kit
+
+---
+assetId: peg-refuse-relocation-kit
+version: "1.1"
+lastModified: "2025-01-19T15:00:39Z"
+url: https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/?do=download&r=205359

--- a/src/yaml/peg/11508-pine-trail-head.yaml
+++ b/src/yaml/peg/11508-pine-trail-head.yaml
@@ -1,0 +1,27 @@
+group: peg
+name: pine-trail-head
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Pine Trail Head
+  description: |-
+    The Trail Head is a new addition for your Pine hiking and horse trails. Based on typical trail heads found in many National parks, this lot can also be used as a rural roadside rest stop and picnic area.
+
+    **Dependencies:**
+    [PEG Pine Trails](https://community.simtropolis.com/files/file/11065-peg-pine-trails-v305/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11508-peg-pine-trail-head/
+  images:
+    - https://www.simtropolis.com/objects/screens/0013/70f40116f72e4f57c710631d965c691d-product_image.jpg
+dependencies:
+  - peg:pine-trails
+assets:
+  - assetId: peg-pine-trail-head
+
+---
+assetId: peg-pine-trail-head
+version: "1.1"
+lastModified: "2025-01-19T15:17:45Z"
+url: https://community.simtropolis.com/files/file/11508-peg-pine-trail-head/?do=download&r=205363

--- a/src/yaml/peg/11508-pine-trail-head.yaml
+++ b/src/yaml/peg/11508-pine-trail-head.yaml
@@ -16,7 +16,7 @@ info:
   images:
     - https://www.simtropolis.com/objects/screens/0013/70f40116f72e4f57c710631d965c691d-product_image.jpg
 dependencies:
-  - peg:pine-trails
+  - peg:mtp-super-pack
 assets:
   - assetId: peg-pine-trail-head
 

--- a/src/yaml/peg/12426-stream-kit-deluxe-edition.yaml
+++ b/src/yaml/peg/12426-stream-kit-deluxe-edition.yaml
@@ -1,0 +1,39 @@
+group: peg
+name: stream-kit-deluxe-edition
+version: "1.1"
+subfolder: 360-landmark
+info:
+  summary: Stream Kit  Deluxe Edition
+  description: |-
+    ... and to compliment your shiny new Ponds, Pegasus Productions does the "ditto" thing with this **Deluxe Edition** of **The Stream Kit**.
+
+    Improvements in the Deluxe Edition include:
+
+    1\. **NO SEAMS!!**  Again... those pesky hairline seams that appeared between many sections are now gone for good.
+
+    2\. **Improved Slope Tolerance**. It is now possible to build a straight stream up a modest slope. Using roads to predefine & smooth your path, you can now easily wind your streams up almost any slope. And for those slopes that are just too steep, we now have...
+
+    3\. **Improved WATERFALLS!!!** Yes... we finally engineered an improved system for making waterfalls that are easy to plop and nice to look at. Blending old & new... texture and BAT, we now have a waterfall that will flex and stretch to fit any single-tile height slope you create. Unlike the previous Stream Waterfall, the new deluxe version also includes the top, center and bottom of the falls all in a single lot. No more separate top and bottom lots to contend with.
+
+    4\. **Open Modular Architecture**. Like the new Ponds, the new Stream Kit has also been restructured from the ground up to allow easier add-ons. This includes completely new  stream styles that you will be able to change as easily as a rock or water mod style by simply exchanging a single file.
+
+    5\. **Reduced Costs... Reduced Effects**. The plop and maintenance costs have been reduced significantly. Accordingly, the Park & Landmark effects have been reduced as well. Although the cost and effects for each lot was fairly modest, collectively, it all could easily add up to a significant monthly expense and and an easily capped out desirability. The new reductions should make even extensive water systems affordable and viable in rural and agricultural areas.
+
+    6\. **Transparent Texturing!!** All Stream Kit lots now have transparent textures. This allows the the streams to blend better with natural terrain and rocks mods at higher altitudes. This also allows the streams to be used with add-on terrain mods such as the snow/artic mod.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  websites:
+    - https://community.simtropolis.com/files/file/12426-peg-stream-kit-deluxe-edition/
+    - https://community.simtropolis.com/files/file/11083-peg-stream-kit-ii-v205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/dfcb5a71f33fb1c36f5ebf162dd1f4a0-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0025/dfcb5a71f33fb1c36f5ebf162dd1f4a0-PRODUCT_IMAGE2.jpg
+assets:
+  - assetId: peg-stream-kit-deluxe-edition
+
+---
+assetId: peg-stream-kit-deluxe-edition
+version: "1.1"
+lastModified: "2025-01-19T18:31:36Z"
+url: https://community.simtropolis.com/files/file/12426-peg-stream-kit-deluxe-edition/?do=download&r=205378

--- a/src/yaml/peg/12426-stream-kit-deluxe-edition.yaml
+++ b/src/yaml/peg/12426-stream-kit-deluxe-edition.yaml
@@ -31,6 +31,8 @@ info:
     - https://www.simtropolis.com/objects/screens/0025/dfcb5a71f33fb1c36f5ebf162dd1f4a0-PRODUCT_IMAGE2.jpg
 assets:
   - assetId: peg-stream-kit-deluxe-edition
+dependencies:
+  - peg:mtp-super-pack
 
 ---
 assetId: peg-stream-kit-deluxe-edition

--- a/src/yaml/peg/14056-mtp-mountain-trails-rec-pack-1.yaml
+++ b/src/yaml/peg/14056-mtp-mountain-trails-rec-pack-1.yaml
@@ -1,0 +1,51 @@
+group: peg
+name: mtp-mountain-trails-rec-pack-1
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Mountain Trails REC Pack 1
+  description: |-
+    New... for the **PEG Mountain Trails**... this Recreation Pack adds seven new Mountain Trail lots to your off-road toy box. Included is almost everything you would need to create you very own, custom camp grounds. This pack is loaded with many new custom props that will breathe new life into those old dusty trails. Many props shuffle and change to create an active camp ground look while still maintaining that peaceful, easy feeling.
+
+    The seven new lots are:
+
+    **1\. Mountain Trail Tunnel Lot.**
+    By request... this 1x1 lot allows you to visually extend your trails through mountains. Can also be used as a small mine.
+
+    **2\. Mountain Trail Corner Picnic Area.**
+    A 1x1 variation of the standard corner section. The dirt area on this one has been widened to make room for a couple of wooden picnic tables.
+
+    **3\. Mountain Trail Ranger Station.**
+    We re-used the game's Ranger Station prop on this 2x2 lot because... well, because is doesn't suck. With integrated Mountain Trails, this lot looks great as part of a larger camp ground or just about anywhere along the trail.
+
+    **4\.** **Mountain** **Trail Camp Site.**
+    A 1x1 individual camp site lot that plugs in to any trail piece. Used with Tees and 4-ways, you can easily create large camp grounds of almost any design. Each lot displays random tents that are packed up each day as the campers head on down the trail. New tents appear as new campers hike in for the night. And, of course, each camp site has a toasty camp fire each night for cooking up those tasty Smores.  Anymore know the second verse to 'Kumbaya'?
+
+    **5\. Mountain Trail Recreation Area**.
+    A common fixture at larger campsites, this 2x3 Recreation Area features a large above-ground pool, BBQ pits and plenty of space and toys to keep the kiddies busy. With a large patio area and covered tables, this would be the main focal point and social spot of most camp grounds.
+
+    **6\. Mountain Trail General Store & Trading Post**
+    Many large camp grounds have one... in one form or another. Many also serve as the official headquarters or office for the camp ground. Loaded with the usual over-priced groceries, beer, bug spray, beer, camping supplies, bait & beer... many also have a small grill area and serve food to campers who's idea of "roughing it" means 'no cable'.
+
+    **7\. Roadside General Store & Trading Post  (w/ Jobs)**
+    A variation of the Pine Trail store, this one is designed to plop along your road network. Transit enabled and offering jobs, it also includes Mountain Trails and works well as an entrance to a campground or as a trail head.
+
+    **\*\* This lot requires the following dependencies:
+    [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0005/215d183c341430b708d82d6279f2ce32-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0005/215d183c341430b708d82d6279f2ce32-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-mountain-trails-rec-pack-1
+
+---
+assetId: peg-mtp-mountain-trails-rec-pack-1
+version: "1.1"
+lastModified: "2025-01-20T15:08:40Z"
+url: https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/?do=download&r=205394

--- a/src/yaml/peg/14116-mtp-mid-wealth-growable-res-aframes.yaml
+++ b/src/yaml/peg/14116-mtp-mid-wealth-growable-res-aframes.yaml
@@ -1,0 +1,46 @@
+group: peg
+name: mtp-mid-wealth-growable-res-aframes
+version: "1.1"
+subfolder: 200-residential
+info:
+  summary: MTP Mid Wealth Growable RES AFrames
+  description: |-
+    This second offering of mountain-specific, growable RES lots for the **MTP** features 4 variations of the popular A-Frame styled log cabins. There are 16 new lots in this collection... all of them Medium Wealth with varying densities that your low-wealth cabins will eventually grow into.
+
+    These are definitely more "up-scale" than the basic log cabins... but not quite to the "we're so rich, we crap money" stage. That will come in the third release of High-Wealth growable MTP lots. But in the mean time, these are pretty nice and really add a mountain "feel" to the area.
+
+    In order to have growable lots specific to the Mountain Theme, we have used 2x5, 3x5 & 5x5 custom lot sizes. Ordinary, game-default RES lots will not grow on custom lots of this size. The player must create custom zones of this size... which is easy to do by holding down the CTRL key while using the mouse to drag out the zone size.
+
+    Because larger, custom lot sizes are required, several cabins are spaced out on the lot to represent several homes occupying the area. The resident values have been adjusted upwards to reflect the number of homes on each lot.
+
+    Additionally, these lots are designed to accommodate the sloped terrain of mountainous areas. The cabin models are designed with extended foundations that merge into sloped terrain.... so instead of a building on top of a concrete block, you get cabins that merge realistically into the  hillside. These a-frame cabins also feature elevated decks supported by pilings that adjust to almost any degree of slope.
+
+    The lots use random building & prop families so the cabins will always be different on each lot. The cabins also use the  new  Random Smoke feature... so you will see smoke coming from their chimneys at different times of the day.
+
+    *\* The MTP Growable RES lots are part of a much larger & expanding theme. These are not just simple "install and hope they grow" lots.  These lots are part of a full-cycle residential community spanning all density types... that will grow and update into newer, wealthier versions of themselves.*
+
+    *They are not intended to supplement the existing array of residential RCI lots. They are designed to fully replace them.. but only in areas or cities controlled by the player via use of custom zoning sizes. In this way, they will not affect normal/default RES lots & development zoned in normal & conventional sizes.*
+
+    **\*\* This lot requires the following dependencies:**
+
+    **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **[PEG - MTP Mountain Trails - Rec Pack 1](https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5e9384e91df52dbec4db286d82d79ae4-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5e9384e91df52dbec4db286d82d79ae4-product_image2.jpg
+dependencies:
+  - peg:mtp-mountain-trails-rec-pack-1
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-mid-wealth-growable-res-aframes
+
+---
+assetId: peg-mtp-mid-wealth-growable-res-aframes
+version: "1.1"
+lastModified: "2025-01-20T15:03:12Z"
+url: https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/?do=download&r=205391

--- a/src/yaml/peg/18539-cdk3-fred-ginger-fishery.yaml
+++ b/src/yaml/peg/18539-cdk3-fred-ginger-fishery.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: cdk3-fred-ginger-fishery
+version: "1.0"
+subfolder: 300-commercial
+info:
+  summary: CDK3 Fred Ginger Fishery
+  description: |-
+    As vast as the oceans are, they still do not contain enough fish to sustain man's ever-expanding appetite. Commercial fish farms are the planet's best hope to feed its citizens while preventing the natural fish supply from being depleted. The age old profession of fisherman is being replaced by the equally as old profession of farmer.
+
+    Although commonly referred to as "fish farms, they are technically fish ranches. Like cattle or sheep, fish are bred in captivity and harvested for food. And being grown in a controlled environment, they have no natural predators and are protected from diseases and pollutants that could reduce their numbers.
+
+    The costs of maintaining the fish and farms is more than offset by the reduced cost of harvesting. No expensive fishing fleets to purchase and maintain. No excessive use of petrol fuels consumed while trolling the oceans in search of fish. No risk of losing boats and crews to storms and other nautical dangers. Plus... no freakin' Greenpeace rubber boats to "accidentally" run over.
+
+    This lot is s standard CDK3 lot that is 4x6 tiles in size. The lot must be plopped out over the water... with either 2 or 3 rows of tiles on dry land. It provides Industrial Resource (farming) jobs in areas where that normally would not be possible. The lot is located in the Water Transportation menu along with the other CDK3 lots. The single lot file contains all required custom material so the lot can be used without installing the CDK3.
+
+    **\*\* This lot has no dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/18539-peg-cdk3-fred-ginger-fishery/
+  images:
+    - https://www.simtropolis.com/objects/screens/0020/b3ae0cfb46646fa6a6a0596d452c3985-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0020/b3ae0cfb46646fa6a6a0596d452c3985-ss-10.jpg
+assets:
+  - assetId: peg-cdk3-fred-ginger-fishery
+
+---
+assetId: peg-cdk3-fred-ginger-fishery
+version: "1.0"
+lastModified: "2007-08-13T07:35:16Z"
+url: https://community.simtropolis.com/files/file/18539-peg-cdk3-fred-ginger-fishery/?do=download&r=42539

--- a/src/yaml/peg/19577-cdk3-sp-container-ship-fleet.yaml
+++ b/src/yaml/peg/19577-cdk3-sp-container-ship-fleet.yaml
@@ -1,0 +1,25 @@
+group: peg
+name: cdk3-sp-container-ship-fleet
+version: "101"
+subfolder: 100-props-textures
+info:
+  summary: CDK3 SP Container Ship Fleet
+  description: |-
+    This is a collection of 7 container ship props to be used with the upcoming PEG\-CDK3 Seaport (CDK3\-SP) series of lots. It is a required dependency, specifically, for the Container Ship Seaport lot and may be used with other CDK3\-SP lots.
+
+    \* Players and developers may use these props on their own lots... subject to the terms of the EULA that is documented in the included readme file.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/19577-peg-cdk3-sp-container-ship-fleet/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/9a57e91e92c954ee460896c165554887-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0017/9a57e91e92c954ee460896c165554887-product_image1.jpg
+assets:
+  - assetId: peg-cdk3-sp-container-ship-fleet
+
+---
+assetId: peg-cdk3-sp-container-ship-fleet
+version: "101"
+lastModified: "2008-03-26T21:51:47Z"
+url: https://community.simtropolis.com/files/file/19577-peg-cdk3-sp-container-ship-fleet/?do=download&r=44375

--- a/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
+++ b/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
@@ -1,0 +1,43 @@
+group: peg
+name: cdk3-sp-row-warehouses
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: CDK3 SP Row Warehouses
+  description: |-
+    The CDK3\-SP Row Warehouses is a collection of 5 lots that are designed for use with the CDK3\-SP Seaport series. Styled along the lines of older break-bulk freight warehouses that string along the docks of many harbors, these lots are all modular and designed to join together to form warehouses of any length and can even wrap around corners.
+
+    Available in 2x, 3x, 4x, Inner & Outer Corner varieties, the lots can be used by themselves or linked together to wrap around any terrain. The lots can also be plopped fully on dry land for use along your railways or part of a larger rail-freight facility.
+
+    All of the lots are ploppable. All are IND-M lots with jobs, except for the Outer Corner lot which can be difficult to provide road access to. All of the lots are fully compatible with other CDK3\-SP lots and can be used anywhere within your CDK3\-SP harbor project.
+
+    The Inner Corner & 4x lots are transit enabled for rail. The other lots are not and therefor can easily be plopped next to each other. The 3x lot features a transit-enabled central driveway that is visually enabled only. It will allow a connection to an adjacent roadway but will not impair traffic flow in anyway.
+
+    All of the lots feature a multitude of random, timed props that appear and disappear throughout the day to simulate activity. The randomness of the props should allow you to plop numerous lots together without it appearing too repeatitive.
+
+    Again, sorry for the rather long list of dependencies but as stated before, if you are using these lots with your other CDK3\-SP Seaport lots, you should already have all of these files installed.
+
+    **\*\* This lot requires the following CDK3 dependency files:**PEG\-CDK3 SUPER PAK
+    PEG\-CDK3\-SP SEAPORT SUPER PAK
+    PEG\-CDK3\-SP Rail Fleet
+    PEG Security Fencing Kit
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/19805-peg-cdk3-sp-row-warehouses/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image1.jpg
+dependencies:
+  - peg:cdk3-rail-fleet
+  - peg:cdk3-sp-seaport-super-pak
+  - peg:cdk3-super-pak
+  - peg:security-fencing
+assets:
+  - assetId: peg-cdk3-sp-row-warehouses
+
+---
+assetId: peg-cdk3-sp-row-warehouses
+version: "1.0"
+lastModified: "2008-05-16T17:25:14Z"
+url: https://community.simtropolis.com/files/file/19805-peg-cdk3-sp-row-warehouses/?do=download&r=44769

--- a/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
+++ b/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
@@ -29,10 +29,10 @@ info:
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image.jpg
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image1.jpg
 dependencies:
-  - peg:cdk3-rail-fleet
+  - peg:cdk3-sp-rail-fleet
   - peg:cdk3-sp-seaport-super-pak
   - peg:cdk3-super-pak
-  - peg:security-fencing
+  - peg:security-fencing-kit
 assets:
   - assetId: peg-cdk3-sp-row-warehouses
 

--- a/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
+++ b/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
@@ -1,3 +1,6 @@
+# Looks like this package is actually replaced by 
+# https://community.simtropolis.com/files/file/
+# 19881-peg-cdk3-sp-seaport-super-pak/, so we use that asset.
 group: peg
 name: cdk3-sp-row-warehouses
 version: "1.0"
@@ -29,15 +32,9 @@ info:
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image.jpg
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image1.jpg
 dependencies:
-  - peg:cdk3-sp-rail-fleet
-  - peg:cdk3-sp-seaport-super-pak
   - peg:cdk3-super-pak
   - peg:security-fencing-kit
 assets:
   - assetId: peg-cdk3-sp-row-warehouses
-
----
-assetId: peg-cdk3-sp-row-warehouses
-version: "1.0"
-lastModified: "2008-05-16T17:25:14Z"
-url: https://community.simtropolis.com/files/file/19805-peg-cdk3-sp-row-warehouses/?do=download&r=44769
+    include:
+      - PEG-CDK3-SP_RowWarehouses_110.dat

--- a/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
+++ b/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
@@ -36,6 +36,6 @@ dependencies:
   - peg:cdk3-super-pak
   - peg:security-fencing-kit
 assets:
-  - assetId: peg-cdk3-sp-row-warehouses
+  - assetId: peg-cdk3-sp-seaport-super-pak
     include:
       - PEG-CDK3-SP_RowWarehouses_110.dat

--- a/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
+++ b/src/yaml/peg/19805-cdk3-sp-row-warehouses.yaml
@@ -32,6 +32,7 @@ info:
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image.jpg
     - https://www.simtropolis.com/objects/screens/0011/5df4446d696c39a1be51608273ea44b6-product_image1.jpg
 dependencies:
+  - peg:cdk3-sp-seaport-super-pak
   - peg:cdk3-super-pak
   - peg:security-fencing-kit
 assets:

--- a/src/yaml/peg/19880-cdk3-super-pak.yaml
+++ b/src/yaml/peg/19880-cdk3-super-pak.yaml
@@ -1,0 +1,49 @@
+group: peg
+name: cdk3-super-pak
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: CDK3 SUPER PAK
+  description: |-
+    This is a compilation of the primary CDK3 dependency files. If you already have the dependency files listed below, you will not have to download and install this file. However, all future CDK3 lots requiring any of the listed dependencies, will list this file instead. There also may be a slight game load time reduction having all the dependencies combined into a single file.
+
+    This SUPER PAK replaces the following CDK3 dependency files:
+
+    > 1\. CDK3 Resource Pack 1 ( PEG\-CDK3\_Resource-Pack\_01.dat )
+
+    2\. CDK3 Ship Pack 1 ( PEG\-CDK3\_PropPack\_Ships\_01.dat )
+
+    3\. CDK3 Vehicle Pack 1 ( PEG\-CDK3\_PropPack\_Vehicles\_01.dat )
+
+    4\. CDK3 Trawler Pack 1 ( CDK3\_Trawlers\_RESOURCE.dat )
+
+    5\. CDK3 REC Boats Pack ( PEG\-CDK3\_Rec-Boats\_RESOURCE\_101.dat )
+
+    6\. CDK3 Basics\* ( PEG\-CDK3\_Basics\_100.dat )
+
+    Once the CDK3 SUPER PACK is installed, you can safely remove the files listed above.
+
+    IMPORTANT: The original CDK3 Basics file contained lots as well as dependency data. That dependency data only has been moved into the CDK3 SUPER PAK. The lot data only has been repackaged into a new file (version 1.10) which is included with this download. If you remove the original CDK3 Basics file, you should move the new version ( PEG\-CDK3\_Basics\_110.dat ) into the CDK3 Basics folder.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  websites:
+    - https://community.simtropolis.com/files/file/19880-peg-cdk3-super-pak/
+    - https://community.simtropolis.com/files/file/19265-peg-cdk3-resource-pack-1/
+    - https://community.simtropolis.com/files/file/19268-peg-cdk3-ship-pack-1/
+    - https://community.simtropolis.com/files/file/18657-peg-cdk3-trawlers-pack-1/
+    - https://community.simtropolis.com/files/file/18774-peg-cdk3-rec-boats-pack-1/
+    - https://community.simtropolis.com/files/file/19266-peg-cdk3-basics/
+    # The vehicle pack is apparently available on the default channel. We might 
+    # want to use this one as a dependency for that one.
+    # - https://community.simtropolis.com/files/file/19267-peg-cdk3-vehicle-pack-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e1b1c9d53f9b6fc379ec8bf0195776fd-product_image.jpg
+assets:
+  - assetId: peg-cdk3-super-pak
+
+---
+assetId: peg-cdk3-super-pak
+version: "1.0"
+lastModified: "2008-06-07T08:05:49Z"
+url: https://community.simtropolis.com/files/file/19880-peg-cdk3-super-pak/?do=download&r=44891

--- a/src/yaml/peg/19881-cdk3-sp-seaport-super-pak.yaml
+++ b/src/yaml/peg/19881-cdk3-sp-seaport-super-pak.yaml
@@ -27,6 +27,10 @@ info:
 assets:
   - assetId: peg-cdk3-sp-seaport-super-pak
 
+    # This pack also includes the row warehouses for some reason.
+    exclude:
+      - PEG-CDK3-SP_RowWarehouses_110.dat
+
 ---
 assetId: peg-cdk3-sp-seaport-super-pak
 version: "1.0"

--- a/src/yaml/peg/19881-cdk3-sp-seaport-super-pak.yaml
+++ b/src/yaml/peg/19881-cdk3-sp-seaport-super-pak.yaml
@@ -1,0 +1,34 @@
+group: peg
+name: cdk3-sp-seaport-super-pak
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: CDK3 SP SEAPORT SUPER PAK
+  description: |-
+    This is a compilation of the primary CDK3\-SP Seaport dependency files. If you already have the dependency files listed below, this SUPER PAK is not mandatory to support the currwent CDK3\-SP lots. However, the SUPER PAK  also contains a lot of new material used in many new lots & will be listed as the primary dependency for all futher CDK3\-SP material. To avoid missing dependency issues, you should install this SUPER PACK and, for optimum performance, remove the dependency files it replaces listed below.I
+
+    This SUPER PAK replaces the following CDK3 dependency files:
+
+    > 1\. CDK3\-SP Container Seaport (PEG\-CDK3\_Seaport\_RESOURCE.dat )
+
+    2\. CDK3\-SP Row Warehouses\* (PEG\-CDK3\-SP\_RowWarehouses\_101.dat )
+
+    Once the CDK3\-SP SEAPORT SUPER PACK is installed, you can safely remove the files listed above.
+
+    IMPORTANT: The original CDK3\-SP Row Warehouses file contained lots as well as dependency data. That dependency data only has been moved into the CDK3\-SP SEAPORT SUPER PAK. The lot data only has been repackaged into a new file (version 1.10) which is included with this download. If you remove the original CDK3\-SP Row Warehouses file, you should move the new version ( PEG\-CDK3\-SP\_RowWarehouses\_110.dat ) into the CDK3/SEAPORT/Row Warehouses folder.
+
+    **\*\*This dependency has no dependencies**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/19881-peg-cdk3-sp-seaport-super-pak/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5e54434cb76cfd9a9e4da90ed3649d5a-product_image.jpg
+assets:
+  - assetId: peg-cdk3-sp-seaport-super-pak
+
+---
+assetId: peg-cdk3-sp-seaport-super-pak
+version: "1.0"
+lastModified: "2008-06-07T08:10:36Z"
+url: https://community.simtropolis.com/files/file/19881-peg-cdk3-sp-seaport-super-pak/?do=download&r=44893

--- a/src/yaml/peg/21053-mtp-logging-roads.yaml
+++ b/src/yaml/peg/21053-mtp-logging-roads.yaml
@@ -1,0 +1,55 @@
+group: peg
+name: mtp-logging-roads
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: MTP Logging Roads
+  description: |-
+    The **MTP Logging Roads** is a collection of 12 ploppable lots that can be connected together to form a non-functional Logging or Fire Road network throughout your remote and mountainous regions. The collection is very similar to the PEG Scenic Drive Kit, the MTP Access Roads and even the MTP Pine Trails lots. However, this kit has some new toys tossed in to give your roads a more natural & realistic "winding road" appearance.
+
+    These Logging Roads lots are technically parks with almost no park values... but they are located in your Misc. Transportation Menu. Being non-functional, they will provide the look of a rural road extending to remote logging operations, fire watch towers, campgrounds, etc... without the roads getting clogged up with the game's automata. None of these lots require power or water... or access to a functional road network. You can freely plop them anywhere that you like.
+
+    All of these lots are texture-based and will conform to the shape and slope of the existing terrain. This means that you can use them with little or no terrain editing... although better results can often be obtained by preparing the terrain beforehand.
+
+    *\*Using the game's functional roads to lay out a path beforehand is both fast & easy... and levels & smooths the tiles that the roads will be plopped on. This method was used to create the switchbacks shown in the picture.. although the wider, sweeping curves required some manual terrain editing.*
+
+    The lots included in this package are:
+
+    1.  1x Straight section.
+    2.  1x Corner section
+    3.  1x "Tee" section.
+    4.  1x 4-way Intersection.
+    5.  1x  Road-End section.
+    6.  1x Street Transition section. *(connects to your functional street or road network)*
+    7.  1x Pulloff section.
+    8.  1x Parking Area section.
+    9.  1x Rail Road Crossing. *(functionally transit enabled for both passenger & freight rail)*
+    10.  2x2 Sweeping Curve section. *(for more natural, wider curves)*
+    11.  2x2 S-Turn Right section. *(jogs the road 1 tile to the right)*
+    12.  2x2 S-Turn Left section. *(jogs the road 1 tile to the left)*
+
+    \* The [MTP Terrain Mod](https://community.simtropolis.com/files/file/20986-peg-mtp-terrain-modd-1/) is not required for these lots... but it is recommended. These lots use the default MTP grassy texture that was designed to blend with the game default textures... which are also used by the MTP Terrain Mod.
+
+    \*\* This lot requires the following dependencies:
+    [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+    [PEG MTP Logging RESOURCE](https://community.simtropolis.com/files/file/20965-peg-mtp-logging-resource/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made deps clickable linkys.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/21053-peg-mtp-logging-roads/
+  images:
+    - https://www.simtropolis.com/objects/screens/0012/64838378b0839a1ca7140db46b8b4b56-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0012/64838378b0839a1ca7140db46b8b4b56-product_image1.jpg
+dependencies:
+  - peg:mtp-logging-resource
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-logging-roads
+
+---
+assetId: peg-mtp-logging-roads
+version: "1.0"
+lastModified: "2009-01-27T19:34:15Z"
+url: https://community.simtropolis.com/files/file/21053-peg-mtp-logging-roads/?do=download&r=46911

--- a/src/yaml/peg/21072-mtp-tlc-rail-transfer-yard.yaml
+++ b/src/yaml/peg/21072-mtp-tlc-rail-transfer-yard.yaml
@@ -1,0 +1,50 @@
+group: peg
+name: mtp-tlc-rail-transfer-yard
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: MTP TLC Rail Transfer Yard
+  description: |-
+    So... lets take inventory. We have the central **Saw Mill** with both trucks and rail bringing in logs for processing. We have **Logging Roads** to bring the logs down from the local mountains. What's missing? Oh yeah... Where the heck do the logs on the railcars come from? I'm glad you asked...
+
+    The **MTP TLC Rail Transfer Yard** is a typical marshalling area where Logging Road meets Rail.The logs from the trucks are transferred to rail logging cars by HLDs (Heavy Lifting Devices) for transport to distant mills that are generally too far away for economical transport by truck. This type of operation is really more of a convenient location... than an actual facility.... pretty much wherever a road can be run down to the nearest rail. If there is also a nearby water source... so much the better.
+
+    So what's with all the log dumping into the water... you ask. Good question. Its all about making a hard job a bit easier. Wherever possible, the logging industry has relied on conveniently located water sources for 2 primary reasons;  1. Logs are really heavy... and  2. Logs float. You can round up 20 really Brawny guys (yes, like on the paper towel commercials) and get them to move a log for you. They won't be able to roll it more than a foot or so before you hear the 'roids a-poppin'. Yet... one guy... with a long stick... can move a log on the water anywhere he wants with very little effort.
+
+    So... when operations get a bit backed up or the trucks roll in but the trains out of Yuma aren't due in 'till 3:10... the logs just get dumped in the pond. No profit in holding up the trucks and the HLDs can pull logs from the water easier & faster than from the ground or the back of a truck. And that's why.
+
+    Because the need for 2 types of this lot may arise... we have conveniently included two types of lots:
+
+    1\. An RCI ploppable with IND-M jobs and transit-enabled for street entrance to form a visual connection to your road network. Like any lot with jobs, this version requires power & water, road access and a local workforce.
+
+    2\. A Logging Road version that has no jobs & requires no power, water or functional road access. Just plop it anywhere & run Logging Roads up to it
+
+    Both lots are 4x5 tiles in size... and both have non-functional transit-enabled connections on both ends of the lot for a visual-only connection to rail. Both have a gated side entrance for optional access to a Logging Road. The RCI version cost $500 to plop... but nothing to maintain. The Logging Road version cost almost nothing to plop... but $10 per month to maintain. Most of that 10 bucks is for porta-crapper chemicals & TP.
+
+    Both lots have a custom query sound-effect... and are extensively not nite lighted in any way. The RCI version can be found in your Landmarks menu while the Logging Road version is with the other Logging Road lots in your Misc Transportation menu. Each lot is in a separate file so you can remove either one if you prefer not to use it.
+
+    **\*** *The Logging Industry lots were designed for the **MTP** but have been engineered to have a minimal dependence on it. The goal is to allow players to use these lots in any non-urban setting/city without the need to move the required files in and out of the Plugins folder when switching between different city types or styles. These lotsand the MTP dependency files can remain in your Plugins folder without affecting non-MTP themed cities.*
+
+    **\*\* This lot requires the following dependencies:**
+    [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+    [PEG MTP Logging RESOURCE](https://community.simtropolis.com/files/file/20965-peg-mtp-logging-resource/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made deps clickable linkys.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/21072-peg-mtp-tlc-rail-transfer-yard/
+  images:
+    - https://www.simtropolis.com/objects/screens/0026/e9265df35c60d418def5c76a71bd9184-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0026/e9265df35c60d418def5c76a71bd9184-product_image1.jpg
+dependencies:
+  - peg:mtp-logging-resource
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-tlc-rail-transfer-yard
+
+---
+assetId: peg-mtp-tlc-rail-transfer-yard
+version: "1.0"
+lastModified: "2009-01-31T11:05:22Z"
+url: https://community.simtropolis.com/files/file/21072-peg-mtp-tlc-rail-transfer-yard/?do=download&r=46939

--- a/src/yaml/peg/21103-mtp-ltusa-container-generator.yaml
+++ b/src/yaml/peg/21103-mtp-ltusa-container-generator.yaml
@@ -1,0 +1,41 @@
+group: peg
+name: mtp-ltusa-container-generator
+version: "1.0"
+subfolder: 500-utilities
+info:
+  summary: MTP LTUSA Container Generator
+  description: |-
+    The first lot in the upcoming **LOG TOWN USA** series is, appropriately enough, the very lot that will used to power it. Yes... its the classic generator in an old shipping container. Juice... in a box.
+
+    This diesel powered generator lot is the same size and has identical properties to the game-wind turbine... except that it creates a very small amount of air pollution. A bit more rustic looking, its the type of creative, slapped-together power source you'd expect to see powering a remote logging camp or small isolated community. Cheap to build, cheap to run... and easy to maintain.
+
+    Although decidedly designed for use with the MTP, this power plant can be used anywhere you need a small amount of cheap power for remote buildings and facilities.
+
+    *\* The lot features a custom diesel engine throbbing background sound effect that you can hear when you cursor near the lot. I feel compelled to mention it here because its so subtle, you'd probably never notice it if I didn't.*
+
+    **\*** *The Logging Industry lots were designed for the **MTP** but have been engineered to have a minimal dependence on it. The goal is to allow players to use these lots in any non-urban setting/city without the need to move the required files in and out of the Plugins folder when switching between different city types or styles. These lotsand the MTP dependency files can remain in your Plugins folder without affecting non-MTP themed cities.*
+
+    \*\* This lot requires the following dependencies:
+    [MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+    [MTP Logging Industry RESOURCE](https://community.simtropolis.com/files/file/20965-peg-mtp-logging-resource/)
+    [PEG Security Fencing Kit](https://community.simtropolis.com/files/file/19338-peg-security-fencing-kit/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made dep linkys clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/21103-peg-mtp-ltusa-container-generator/
+  images:
+    - https://www.simtropolis.com/objects/screens/0015/84a8326028058534a63d3dfd834024f1-product_image.jpg
+dependencies:
+  - peg:mtp-logging-resource
+  - peg:mtp-super-pack
+  - peg:security-fencing-kit
+assets:
+  - assetId: peg-mtp-ltusa-container-generator
+
+---
+assetId: peg-mtp-ltusa-container-generator
+version: "1.0"
+lastModified: "2009-02-13T08:14:27Z"
+url: https://community.simtropolis.com/files/file/21103-peg-mtp-ltusa-container-generator/?do=download&r=46993

--- a/src/yaml/peg/21147-mtp-ltusa-cross-roads.yaml
+++ b/src/yaml/peg/21147-mtp-ltusa-cross-roads.yaml
@@ -1,0 +1,51 @@
+group: peg
+name: mtp-ltusa-cross-roads
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: MTP LTUSA Cross Roads
+  description: |-
+    **LOG TOWN USA**... is a new series for the **MTP** that allows you to sandbox a rustic, remote village without the concern of providing jobs, road access, fire & police or schools & hospitals. Just like modeling the scenery on a model railroad layout, Log Town allows you to focus on the visual... and not worry about the functional. Ideal for sandboxers and CJers.... or anyone who just wants to add a little life to any remote and undeveloped area of your cities.
+
+    All Log Town lots require power and water... but nothing else. They were designed for use with the non-functional PEG Logging Roads but can be used with any custom set of roads or trails... or even the game default functional roads. All of the lots are nite-lited, feature custom 4-combo rotating query sounds, custom background sound effects... and custom queries that simulate functional lots.
+
+    Our first set of lots is the **Cross Roads** collection... a set of 4 corner lots that can be used to create the center of your village... or just plopped anywhere you want to add a bit of older, rustic ambiance. There are 5 lots in this package... which include the following:
+
+    **1\. Logging Road - Cross Roads section**. Adds a new Logging Road section to your menu that is more suited for use with the Log Town lots. Similar to the 4-way section, but with the grass edges removed.
+
+    **2\. Corner General Store**. A classic structure that provides everything from groceries (ie beer) to hardware... to local loggers, miners or residents.
+
+    **3\. The Fuel Depot**. Similar to a gas station. It could be owned and operated by the local logging company to refuel its vehicles... but could also sell retail to local residents and tourists that wander by.
+
+    **4\. The Corner Diner**. Standard greasy spoon... open from breakfast through dinner... and offering everything from the standard truck-stop slop to the latest road kill.
+
+    **5\. The Village Center**. An old-school strip-mall consisting of a barber shop, Dandy's Drugs, the No-tell Hotel and Grady's Tavern. Pretty much the Happenin' Hot Spot for this little berg.
+
+    The **Cross Roads** lots each cost §50 to plop... but nothing to maintain. They are located in the Misc Transportation Menu just above the Logging Roads.
+
+    *\* The Log Town series is a more viable and flexible alternative to the classic logger's camp. It represents a more realistic approach to modern logging and mining operations where companies rely more on contract labor and independent commercial ventures would naturally spring up to service the needs of those employed in the area. By not being specific to any one industry or purpose, they can be used in your cities in any fashion that you choose. Standard RCI Ploppable and Growable versions will be released separately.*
+
+    \*\* This lot requires the following dependencies:
+
+    [MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+    [MTP Logging Industry RESOURCE](https://community.simtropolis.com/files/file/20965-peg-mtp-logging-resource/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Added linkys to deps.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/21147-peg-mtp-ltusa-cross-roads/
+  images:
+    - https://www.simtropolis.com/objects/screens/0005/289239b12d3e12a5274c4c9e6b289e68-st-1.jpg
+    - https://www.simtropolis.com/objects/screens/0005/289239b12d3e12a5274c4c9e6b289e68-st-2.jpg
+dependencies:
+  - peg:mtp-logging-resource
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-ltusa-cross-roads
+
+---
+assetId: peg-mtp-ltusa-cross-roads
+version: "1.0"
+lastModified: "2009-02-22T13:38:41Z"
+url: https://community.simtropolis.com/files/file/21147-peg-mtp-ltusa-cross-roads/?do=download&r=47069

--- a/src/yaml/peg/22893-ppond-scows.yaml
+++ b/src/yaml/peg/22893-ppond-scows.yaml
@@ -1,0 +1,28 @@
+group: peg
+name: ppond-scows
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: PPond Scows
+  description: |-
+    This is a revised version of the CSK2 Scows Prop Pack.... and replaces that file. The Scow models have been re-scaled and re-textured to appear more weathered. They have also been modified to use considerably less resources.
+
+    Once this file is installed and the old file is removed, all scows already in your cities will be updated automatically. There is no need to replop any lots.
+
+    *\* The Scows appear in several PPond Canal lots... and can be used with the PPond ploppable water as well.*
+
+    **\*\* No Dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/22893-peg-ppond-scows/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/947fc777819b3c759c79fc04293d8db8-product_image-st1.jpg
+assets:
+  - assetId: peg-ppond-scows
+
+---
+assetId: peg-ppond-scows
+version: "1.0"
+lastModified: "2009-11-25T02:05:29Z"
+url: https://community.simtropolis.com/files/file/22893-peg-ppond-scows/?do=download&r=49493

--- a/src/yaml/peg/22925-snow-mod-2.yaml
+++ b/src/yaml/peg/22925-snow-mod-2.yaml
@@ -1,0 +1,73 @@
+group: peg
+name: snow-mod-2
+version: "1.0"
+subfolder: 900-overrides
+info:
+  summary: SNOW MOD 2
+  description: |-
+    Let it snow, Let it snow... Let it Snow!! The **PEG Snow Mod** has been completely revamped and updated to turn your cities into Winter Wonderlands. All the old separate mods have been updated and combined into a single download that will install everything into a single folder. Just move that folder in or out of your Plugins folder to turn the snow on or off. Everything is automatic. No need to bulldoze or replop. Just install the mod, fire up the game... and see your cities instantly transformed with a completely new look.
+
+    There's plenty of new mojo under the hood, Boys & Girls. Not only has the number of converted textures tripled, the mod now turns off or changes many props and lots to snow covered versions. Trees get covered in snow, ponds freeze over to ice... and seasonal flowers and shrubs go away until you decide that Winter is over and Spring should be sprung.
+
+    A large part of the mod is dedicated to converting MTP material. But if you do not use the MTP, fear not. Everything is in separate files and you can easily remove any part of the mod that you don't need or want to use.
+
+    The mod focuses on soft textures (grass & dirt, etc) and leaves most of the hard surfaces (concrete & asphalt, etc) as they are to create that "snowed on but shoveled" look. The game will remain fully playable as you can still see roadways and other transit routes... and undeveloped zones will still be visible.
+
+    Lets unwrap this puppy and see what you get:
+
+    **1.  The Main Mod.**
+    *Contains  snow versions of the game default textures and terrain textures.*
+
+    **2\. The MTP Patch Mod.**
+    *Contains snow versions of custom MTP textures. Also includes some extra mojo to modify certain MTP props and lots.*
+
+    **3\.  The Flora Fix.**
+    *Turns off various game-default flowers you normally wouldn't see in the snow. Changes bushes to snow covered versions. Also converts game-default trees to winter versions; pines to snow covered pines and leafy trees to snowy leafless winter trees. Palm trees are converted to snowy pines.*
+
+    **4\. Snow Covered Trees.**
+    *Turns the PEG Pines into snow covered versions. Separate files for both the old and new  versions of the trees.*
+
+    **5\. Seasonal Tree Patch.**
+    *Forces the PEG Seasonal Trees to remain in their winter state.*
+
+    **6\. Mayor Flora Patch.**
+    *Hides many of the PEG Mayor Flora menu ploppable props, such as super-detailing terrain textures, that do not look good with snow. It also hides the menu icons so you can't accidental plop what you can't see.*
+
+    **7\. MTP Rural Avenue, Road & Street  Patches.**
+    *Separate patch files to make the MTP Rural Avenue, Road & Street mods blend better with the snow.*
+
+    **8\. MTP Plaza Patch.**
+    *Replaces the lot-sized plaza models with snow-covered versions. Iced over fountains, snowy trees & planters. Even the fence posts and rails are topped with snow*.
+
+    **9\. OWW2 Patch.**
+    *Converts the trees and parkways of the OWW2, Marina and Seaport Village lots to snow covered versions.*
+
+    **10\. Diagonal Network Patch.**
+    *Converts the straight sections of diagonal roads and avenues to not have the "zig-zag" staircase appearance when lots or zones are placed next to them.*
+
+    \* Please consult the included readme file for more detailed information about each file included in the mod.
+
+    *\* Please note that the Snow Mod creates a snow-covered effect by converting game ground textures to snow versions. While this mod converts all game-default and PEG custom textures to snow versions, it is not possible to also include snow versions of custom textures provided by other developers. However, the required base & overlay textures required to convert other textures can be copied from the mod and used by any developer who wishes to make compatible snow versions of their own textures.*
+
+    **\*\* This file has no direct dependencies. However...**
+
+    **the MTP patches require the installation of the
+    various MTP components they modify.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/
+  images:
+    - https://www.simtropolis.com/objects/screens/0022/cc371aa0dfbc1a18ab147bbb883fde25-product_image_st.jpg
+    - https://www.simtropolis.com/objects/screens/0022/cc371aa0dfbc1a18ab147bbb883fde25-product_image_st1.jpg
+variants:
+  - variant: { peg:snow-mod:season: summer }
+  - variant: { peg:snow-mod:season: winter }
+    assets:
+      - assetId: peg-snow-mod-2
+
+---
+assetId: peg-snow-mod-2
+version: "1.0"
+lastModified: "2009-12-03T10:36:14Z"
+url: https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/?do=download&r=49535

--- a/src/yaml/peg/22995-ski-resort.yaml
+++ b/src/yaml/peg/22995-ski-resort.yaml
@@ -1,0 +1,88 @@
+group: peg
+name: ski-resort
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: SKI RESORT
+  description: |-
+    The **PEG Ski Resort** is a collection of semi-modular lots & accessories that allows you to build a realistic Ski Resort Complex in your cities. The Ski resort is designed to supplement the new PEG Snow Mod 2**.** However, these are bi-seasonal lots that remain year round. They automatically change to a snowy, active ski resort when the Snow Mod in installed...  and revert back to a largely empty off-season snowless look when the Snow Mod is removed.
+
+    *\* The **Snow Mod** is not actually required to use these lots. They can remain in the snowless "summer mode"  all year round.*
+
+    *\* This collection was also designed to supplement the* MTP*. But again, the MTP is not required. The collection is fully self-contained with no outside dependencies.*
+
+    * * *
+
+    ***From the Staff & Members of SimPeg.Com to our Friends & Brothers In Sim at Simtropolis...
+    Merry Christmas !!***
+
+    * * *
+
+    This all started with a discussion at SimPeg about whether it was possible to make a Ski Resort Chair Lift for the game that actually had cables running from tower to tower, top to bottom... and could be plopped up a sloped hillside. Well, it turns that it is indeed possible.
+
+    The heart of the resort is, of course, the Chair Lifts.  There are two... one that runs straight up the mountain and one that runs up diagonally. Each Chair Lifts uses a single, extended model that is approx. 22 tiles long. Yet, they reside on a 2x2 lot. This means that there is actually no lot under the majority of the Chair Lift and you can freely raise or lower the terrain to match the towers, add Mayor Flora props... or even plop other lots.
+
+    Beyond what we can see on the surface, the real heart of this collection is the "mojo" that goes on under the hood. Everything is bi-seasonal... snow and no-snow... and automatically transformed when you install or remove the Snow Mod. When installed, the roofs are covered with snow and icicles, skiers are everywhere, parking lots are full... and the resort is alive with activity.  When  the Snow Mod is removed, the snow is gone... and the skiers and cars in the lot along with it. But the resort's facilities remain... in a closed down, boarded-up state as they wait patiently for the next ski season.
+
+    Lets unwrap this monster and see what you get:
+
+    **1.  The Chair Lifts.**
+    *There are 2, normal & diagonal. Complete with base and upper stations. They slope steadily up the mountain and can be used anywhere on your resort.
+    In Winter, roofs are snow covered,   the chairs are full of skiers.... and there are queue lines of skiers at the base station.*
+
+    **2\. The Ticket Sales Booth.**
+    *A combination of ticket sales windows, some admin offices and a small maintenance area. This lot contains a significant number of jobs to represent all the employees that work throughout the resort. Having jobs, it must be plopped at the base or the resort with road access. Has it's own modular parking area.
+    In  Winter, the roof is snow covered, skiers are lined up to buy tickets... and the parking lot is full during the day.*
+
+    **3\.  The Base Lodge.**
+    *A large resort Lodge with snack & dining facilities, restrooms, lockers and all the normal lodge-type facilities. The basic starting point, lunch stop and Apres Ski hangout for all the skiers. Like many real-world resort lodges, the bar & restaurant remain open year-round to extend profitability into the off-season. Also has lots of jobs and modular parking area.
+    In Winter, the roof is snow covered as are several other horizontal surfaces & bushes, etc, the ski racks are full of skis, skiers are everywhere... and the parking lot is full.*
+
+    **4\. The Ski School.**
+    *aka... Snow Plow City. Where newbies and novices learn to become even more dangerous. A 2x2 lot that can be plopped anywhere on or around the Ski Resort.
+    In Winter, the roof & fence rails are snow covered and skiers line up to learn how to fall down.*
+
+    **5\. Safety Netting.**
+    *Three 1x1 lots with the classic orange-red safety netting you see on virtually all ski resorts. The 3 lots include a straight,, a diagonal and a curved netting section. The netting orients to the slope. These lots are year-round and can be plopped anywhere on your resort.*
+
+    **6\. Ploppable Skiers.**
+    *Can't have a ski resort without skiers. There are two 1x1 lots that allow you to plop skiers anywhere on your resort. One lot uses the animated skateborder props from the game's skate park so you can have snow boarders carving up the slopes. The other lot uses random static skier props with random chance factors to increase the variations from lot to lot.
+    In Summer, these lots remain but have no terrain texture and no skier props are visible. The lot menu icons are also hidden when the Snow Mod is not installed.*
+
+    **7\. Snow Paths.**
+    *For extra continuity, a new Mayor Flora menu ploppable path textured has been added. The path texture matches the paths used on the various resort lots so you can visually connect them with pathways. This is one of the first, newly developed Terrain Intuitive Textures (T.I.T.s ) that adapts to the underlying terrain. In Summer, the path is dirt. In Winter, it adapts to the snow and becomes a barely visible snow tract.*
+
+    **8\. Ponds & Streams.**
+    *Another new Mayor Flora menu ploppable T.I.T texture ... similar to the PPond small water plop.  Can be used to create small ponds and streams. Turns to ice in the Winter.*
+
+    **9\. Player Selectable Resort Signs.**
+    *You can choose 1 of 4 different resort signs to be displayed anywhere a sign is used in your resort. BATers can easily design and add their own. Two additional 1x1 lots are provided that use the same selected resort sign style and can be used to plop the resort's main sign anywhere you want... or a billboard version along roadways leading to your resort.*
+
+    *\* All of these lots are Park lots. Some provide Civic Jobs. The Menu icons are all grouped together near the bottom of the Park's Menu.*
+
+    *\* Please consult the included readme file for more detailed information on using this collection.*
+
+    *\* Additional lots for the collection are in development... including Ski Rentals & the essential Half-Way Hut.*
+
+    ***\*  Special thanks to the PCG and members of SimPeg.Com for the initial idea & inspiration for this project...***  ***and for the continuous contribution of ideas & laborious testing.***
+
+    **\*\* This file has no direct dependencies. However...**
+
+    **the** **PEG Snow Mod 2** **is required to switch on all the Winter effects.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/22995-peg-ski-resort/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/bc2ab2abb5939177a923535f6237bbf5-product_image1_st.jpg
+    - https://www.simtropolis.com/objects/screens/0021/bc2ab2abb5939177a923535f6237bbf5-product_image2_st.jpg
+dependencies:
+  - peg:snow-mod-2
+assets:
+  - assetId: peg-ski-resort
+
+---
+assetId: peg-ski-resort
+version: "1.0"
+lastModified: "2009-12-20T11:03:22Z"
+url: https://community.simtropolis.com/files/file/22995-peg-ski-resort/?do=download&r=49647

--- a/src/yaml/peg/23018-ski-resort-half-way-hut.yaml
+++ b/src/yaml/peg/23018-ski-resort-half-way-hut.yaml
@@ -1,0 +1,42 @@
+group: peg
+name: ski-resort-half-way-hut
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: SKI RESORT Half Way Hut
+  description: |-
+    There is a top and there is a bottom... and somewhere around the half-way point in between. there is a spot that is aptly named... The Half-Way Point. And somewhere around this point is where your will find a **Half-Way Hut** on the more astute ski resorts that realize that skiers usually carry cash & credit cards when they ski.
+
+    "Half-Way Hut" is a common reference to a rest and snack area that can be found on many larger ski resorts. These rest areas provide a convenient place for skiers to warm up by a fire, purchase extremely marked-up food and beverages, and take a break before heading back out to carve up the slopes. Some are very simple little shacks... and some are larger and fancier. Ours is one of the fancier ones.
+
+    The **Half-Way Hut** is a 4x3 lot that can be plopped anywhere on your PEG Ski Resort. It does not require road-acess. However, it does have nitelites in the Winter mode and will require power. The resort's 1x1 skier & safety netting lots are usually all that is needed to extend power up the mountain.
+
+    Like all Ski Resort lots, when in Winter mode, the roof is covered with snow & the lot is active with skiers. The ski racks are full by day and smoke can be seen coming from the chimney.  In Summer mode, the snow and skiers are gone. The racks are empty... and the windows are boarded up to prevent those pesky bears from ran-sacking the place.
+
+    *\* The structure has an extended foundation and can optionally be plopped over a slope to give the appearance of having been built into the mountainside. The rear of the lot should be plopped on a row of level tiles.*
+
+    *\* The* PEG Ski Resort *collection was designed for use with the* PEG Snow Mod*. However, the Snow Mod is not mandatory. The resort can stay open year-round at high altitude using a snow-capped terrain mod... or can optionally be used with any mod that provides a snow-covered terrain.*
+
+    **\*\* This lot is an add-on to the**  **[PEG Ski Resort](https://community.simtropolis.com/files/file/22995-peg-ski-resort/)** **collection which is required to use this lot.
+
+    Installation of the**  **[PEG Snow Mod 2](https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/)** **is also recommended for full Winter effects.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made dep linkys clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/23018-peg-ski-resort-half-way-hut/
+  images:
+    - https://www.simtropolis.com/objects/screens/0006/291969e3f363100ff6d81d6a95a5bc40-product_image_st1.jpg
+    - https://www.simtropolis.com/objects/screens/0006/291969e3f363100ff6d81d6a95a5bc40-product_image_st2.jpg
+dependencies:
+  - peg:ski-resort
+  - peg:snow-mod-2
+assets:
+  - assetId: peg-ski-resort-half-way-hut
+
+---
+assetId: peg-ski-resort-half-way-hut
+version: "1.0"
+lastModified: "2009-12-24T07:07:42Z"
+url: https://community.simtropolis.com/files/file/23018-peg-ski-resort-half-way-hut/?do=download&r=49681

--- a/src/yaml/peg/23131-ski-resort-ski-rentals.yaml
+++ b/src/yaml/peg/23131-ski-resort-ski-rentals.yaml
@@ -1,0 +1,38 @@
+group: peg
+name: ski-resort-ski-rentals
+version: "1.0"
+subfolder: 300-commercial
+info:
+  summary: SKI RESORT SKI RENTALS
+  description: |-
+    Every Ski Resort has some sort of facility that rents skis & related equipment to those who need them. This is also where skiers can have their own skis tuned-up, waxed, bindings checked and adjusted, etc...  In this case, the MTP Outfitters sporting goods chain (of MTP COM Replacement Mod fame) got the call to provide rental and pro shop services at the resort.
+
+    The **Ski Pro & Rental Shop** was designed for use with the PEG Ski Resort... but can be used anywhere in your city. In the *Real World*, it is not uncommon to see several ski rental shops lining every road that leads to a ski resort.
+
+    The 3x3 lot provides jobs... and uses the same modular parking area that the other Ski Resort lots use. Has nitelites, custom query, custom query sound, etc... For best results, the lot should be plopped on level ground.
+
+    *\* The* PEG Ski Resort *collection was designed for use with the* PEG Snow Mod*. However, the Snow Mod is not mandatory. The resort can stay open year-round at high altitude using a snow-capped terrain mod... or can optionally be used with any mod that provides a snow-covered terrain.*
+
+    **\*\* This lot is an add-on to the**  [PEG Ski Resort](https://community.simtropolis.com/files/file/22995-peg-ski-resort/) **collection which is required to use this lot.
+
+    Installation of the**  [PEG Snow Mod 2](https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/) **is also recommended for full Winter effects.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made dep linkys clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/23131-peg-ski-resort-ski-rentals/
+  images:
+    - https://www.simtropolis.com/objects/screens/0016/928ad4b4161f7f4210b5f941fd5d7fe7-product_image_st1.jpg
+    - https://www.simtropolis.com/objects/screens/0016/928ad4b4161f7f4210b5f941fd5d7fe7-product_image_st2.jpg
+dependencies:
+  - peg:ski-resort
+  - peg:snow-mod-2
+assets:
+  - assetId: peg-ski-resort-ski-rentals
+
+---
+assetId: peg-ski-resort-ski-rentals
+version: "1.0"
+lastModified: "2010-01-15T10:56:56Z"
+url: https://community.simtropolis.com/files/file/23131-peg-ski-resort-ski-rentals/?do=download&r=49847

--- a/src/yaml/peg/30680-mtp-mountain-trails.yaml
+++ b/src/yaml/peg/30680-mtp-mountain-trails.yaml
@@ -1,6 +1,7 @@
 group: peg
 name: mtp-mountain-trails
 version: "1.0"
+subfolder: 660-parks
 info:
   summary: MTP Mountain Trails
   description: |-

--- a/src/yaml/peg/30680-mtp-mountain-trails.yaml
+++ b/src/yaml/peg/30680-mtp-mountain-trails.yaml
@@ -1,0 +1,49 @@
+group: peg
+name: mtp-mountain-trails
+version: "1.0"
+info:
+  summary: MTP Mountain Trails
+  description: |-
+    **PEG MTP Mountain Trails
+    By Pegasus**
+
+    As part of the MTP upgrade, the classic Pine Trails have been modified to be "tree-type indifferent". In other words, you can now use them with any trees types you choose. Based upon requests on the support site, the pine tree props have been removed and these new Mountain Trails are now more flexible than ever.
+
+    Other modifications include the use of the new blended MTP forest floor texturing along with a new & more subtle 'dirtier' dirt path. These are the same textures used in other MTP lots so they will all blend together quite well. Also, there has been an overall reduction in YIMBY effects  to avoid blowing over caps... and the plop prices have been reduced accordingly. All other aspects of the lots remain the same and they still adapt to sloped terrain extremely well..
+
+    This Trail Park pack contains these lots:
+
+    1\. A 1x1 Straight section.  (§10/§1)
+    \* The standard straight piece.
+
+    2\. A 3x1 straight section. (§15/§2)
+    \* A 3x1 version of the standard straight piece.
+
+    3\. A Corner section. (§20/§1)
+    \* A standard 90 degree turn or corner section.
+
+    4.  A Tee section. (§25/§1)
+    \* A standard 'Tee' or 3-way intersection.
+
+    5.  A 4-way section. (§30/§1)
+    \* A standard 4-way intersection
+
+    **Dependency**
+
+    [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here.](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/30680-peg-mtp-mountain-trails/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_07/product_image.jpg.95f23fd42bc7a88cc5eb69f778a32881.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-mountain-trails
+
+---
+assetId: peg-mtp-mountain-trails
+version: "1.0"
+lastModified: "2015-07-17T09:57:42Z"
+url: https://community.simtropolis.com/files/file/30680-peg-mtp-mountain-trails/?do=download&r=158371

--- a/src/yaml/peg/30680-mtp-mountain-trails.yaml
+++ b/src/yaml/peg/30680-mtp-mountain-trails.yaml
@@ -35,7 +35,11 @@ info:
 
     **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here.](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**
   author: Pegasus
-  website: https://community.simtropolis.com/files/file/30680-peg-mtp-mountain-trails/
+  websites:
+    - https://community.simtropolis.com/files/file/30680-peg-mtp-mountain-trails/
+    # Note: we link the pine trails to this package because this package is 
+    # actually an upgrade of it and *overrides* it.
+    - https://community.simtropolis.com/files/file/11065-peg-pine-trails-v306/
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2015_07/product_image.jpg.95f23fd42bc7a88cc5eb69f778a32881.jpg
 dependencies:

--- a/src/yaml/peg/30681-mtp-parking-lots.yaml
+++ b/src/yaml/peg/30681-mtp-parking-lots.yaml
@@ -1,6 +1,7 @@
 group: peg
 name: mtp-parking-lots
 version: "1.0"
+subfolder: 700-transit
 info:
   summary: MTP Parking Lots
   description: |-

--- a/src/yaml/peg/30681-mtp-parking-lots.yaml
+++ b/src/yaml/peg/30681-mtp-parking-lots.yaml
@@ -1,0 +1,35 @@
+group: peg
+name: mtp-parking-lots
+version: "1.0"
+info:
+  summary: MTP Parking Lots
+  description: |-
+    **PEG MTP Parking Lots
+    By Pegasus**
+
+    This is a collection of 4 small parking lots designed for the **MTP** and/or use in rural areas. Two of the lots are asphalt... and two have a dirt surface. Both styles are offered in a 1x1 and a 2x1 lot size.
+
+    All 4 lots are transit enabled and all 4 function as Parking Structures with their capacities reduced from the default 5,000 down to 500. The plop costs and maintenance are also reduced.
+
+    In the game, Parking Structures increase the efficiency of nearby Mass Transit stations primarily in residential areas. These parking lots can be used for that purpose but are so cheap to plop and maintain, you can easily afford to use them just about anywhere for eye candy. They also look great in urban areas, particularly next to parks and other 'green' areas.
+
+    These parking lots will appear in your Misc. Transportation Menu right above the default Parking Structure. Each parking lot is installed as a separate file so you can easily remove any ones you won't use after installation.
+
+    **Dependency:**
+    [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here.](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/30681-peg-mtp-parking-lots/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_07/product_image.jpg.f069dec8e2adc7ce7b4a91ddf66877ea.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-parking-lots
+
+---
+assetId: peg-mtp-parking-lots
+version: "1.0"
+lastModified: "2015-07-17T10:04:21Z"
+url: https://community.simtropolis.com/files/file/30681-peg-mtp-parking-lots/?do=download&r=158373

--- a/src/yaml/sg/15402-container-freight-yards.yaml
+++ b/src/yaml/sg/15402-container-freight-yards.yaml
@@ -1,0 +1,57 @@
+group: sg
+name: container-freight-yards
+version: "1.0"
+info:
+  summary: Container Freight Yards
+  description: |-
+    A pair of freight yard lots, which are designed to handle large cargo containers. They are transit enabled for rail, though block passenger traffic. Please allow an alternate route for any passenger traffic.
+
+    Larger pictures of these lots can be seen in my Building Thread
+
+    Lot Details and Information
+
+    Building: Transportation
+
+    Lot sizes: 6 x 4 tiles, 8x4 tiles
+    Lot Wealth : Low Wealth
+    Jobs: Jobs $ : 40,Jobs $$ : 5,Jobs $$$ : 0,R-$ : 40,R-$$ : 5,R-$$$ : 0
+    Plop cost : § 1,500 & 1,800
+    Freight Capacity: 5,000
+    Monthly cost: § 10 & 25
+    Max. Fire Stage: 3
+    Flammability: 25 of 256
+    Power consumption: 3 MWh/month
+    Water consumption: 5 Gallons/month
+    Air pollution: 1 over 1 tiles
+    Water pollution: 1 over 2 tiles
+    Garbage pollution: 4 over 0 tiles
+
+    **Dependencies:**
+    [BSC Essentials](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=443)
+    [BSC Textures Vol 01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+    [Railyard and Spur Textures, Mega Pack 1.02](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2177)
+    [BSC Mega Props SG Vol 01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=746)
+    [BSCMegaProps JES Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+    [BSC MEGA Props Gascooker Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=397)
+
+    2014-12-19 - Prens: Added up-to-date links + tags.
+  author: SimGoober
+  website: https://community.simtropolis.com/files/file/15402-container-freight-yards/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_12_2014/288bb42b4809c1c721c27d40b3afc305-sg_freightyards01.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_12_2014/76738ae7170886336687ad451d7af468-sg_freightyards02.jpg
+dependencies:
+  - bsc:essentials
+  - bsc:mega-props-gascooker-vol01
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:textures-vol01
+  - ncd:rail-yard-and-spur-mega-pak-1
+assets:
+  - assetId: sg-container-freight-yards
+
+---
+assetId: sg-container-freight-yards
+version: "1.0"
+lastModified: "2006-03-27T08:08:08Z"
+url: https://community.simtropolis.com/files/file/15402-container-freight-yards/?do=download&r=146033

--- a/src/yaml/sg/15402-container-freight-yards.yaml
+++ b/src/yaml/sg/15402-container-freight-yards.yaml
@@ -1,6 +1,7 @@
 group: sg
 name: container-freight-yards
 version: "1.0"
+subfolder: 700-transit
 info:
   summary: Container Freight Yards
   description: |-
@@ -55,3 +56,6 @@ assetId: sg-container-freight-yards
 version: "1.0"
 lastModified: "2006-03-27T08:08:08Z"
 url: https://community.simtropolis.com/files/file/15402-container-freight-yards/?do=download&r=146033
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/simmer2/31129-rail-service-yard-1.yaml
+++ b/src/yaml/simmer2/31129-rail-service-yard-1.yaml
@@ -91,7 +91,7 @@ dependencies:
   - bsc:mega-props-cp-vol01
   - bsc:mega-props-cp-vol02
   - namspopof:props-pack-vol2
-  - peg:cdk3-vehicle-pack-1
+  - peg:cdk3-super-pak
 assets:
   - assetId: simmer2-rail-service-yard-1
 

--- a/src/yaml/train-prop-pack-sd.yaml
+++ b/src/yaml/train-prop-pack-sd.yaml
@@ -1,0 +1,16 @@
+group: blanco
+name: train-prop-pack-sd
+version: "2.0"
+subfolder: 100-props-textures
+assets:
+  - assetId: blanco-train-prop-pack-sd
+info:
+  summary: Train Prop Pack
+  author: blanco
+  website: https://www.toutsimcities.com/downloads/view/1335
+
+---
+assetId: blanco-train-prop-pack-sd
+version: "2.0"
+lastModified: "2008-12-01T12:00:00Z"
+url: https://www.toutsimcities.com/downloads/start/1335


### PR DESCRIPTION
This PR adds a bunch of Pegasus' content.

The state of Pegasus' content is quite unfortunate though. There's an extreme amount of files, but they often have overlapping content, some files override textures from the bsc textures, some files are considered legacy and are replaced by other files, where it's not always clear what the latest file is. On top of that, a lot of the files are still installers that can't be handled by sc4pac.

Hence, adding all of Pegasus' content to the channel is going to require a monumental effort.