### PR TITLE
feat: add `npm run list` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "sc4pac": "node --env-file=.env scripts/sc4pac.js",
     "prune": "node --env-file=.env scripts/prune.js",
     "symlink": "node --env-file=.env scripts/symlink.js",
+    "list": "node scripts/list-dependencies.js",
     "fetch": "gh workflow run add-packages.yaml",
     "deploy": "gh workflow run deploy.yaml",
     "lint": "eslint actions/**/*.js",

--- a/scripts/list-dependencies.js
+++ b/scripts/list-dependencies.js
@@ -1,0 +1,78 @@
+// # list-dependencies.js
+import fs from 'node:fs';
+import ora from 'ora';
+
+// const pkg = 'kergelen:parkings-on-slope';
+const pkg = 'simmer2:victoria-park-station';
+
+async function buildIndex() {
+	let spinner = ora('Building up package index').start();
+	let index = {};
+	await Promise.all([
+		buildChannelIndex('https://memo33.github.io/sc4pac/channel/', index),
+		buildChannelIndex('https://sc4pac.simtropolis.com/', index),
+	]);
+	spinner.succeed();
+	return index;
+}
+
+async function buildChannelIndex(channel, index = {}) {
+	let url = new URL('./sc4pac-channel-contents.json', channel);
+	let res = await fetch(url);
+	let json = await res.json();
+	for (let pkg of json.packages) {
+		let id = `${pkg.group}:${pkg.name}`;
+		index[id] = {
+			...pkg,
+			channel,
+		};
+	}
+	return index;
+}
+
+async function getInfo(pkg) {
+	let { group, name, channel } = pkg;
+	let url = new URL(`./metadata/${group}/${name}/latest/pkg.json`, channel);
+	let res = await fetch(url);
+	return await res.json();
+}
+
+async function getDependencies(pkg, index) {
+	let def = index[pkg];
+	if (!def) throw new Error(`Package ${pkg} not found in any of the channels.`);
+	let info = await getInfo(def);
+	let dependencies = [...new Set(info.variants
+		.map(variant => variant.dependencies)
+		.flat()
+		.map(pkg => `${pkg.group}:${pkg.name}`)
+		.sort(),
+	)];
+	let html = '<ul>';
+	for (let pkg of dependencies) {
+		let def = index[pkg];
+		let metadata = await getInfo(def);
+		let {
+			website,
+			websites = [website],
+		} = metadata.info;
+		html += `<li><a href="${websites[0]}">${pkg}</a></li>\n`;
+	}
+	html += '</ul>';
+	html += '<div><button>Copy</button></div>';
+	html += `<script>document.querySelector('button').addEventListener('click', async () => {
+		let html = document.querySelector('ul').outerHTML;
+		let text = [...document.querySelectorAll('ul > li a')].map(a => {
+			return '- '+a.textContent.trim();
+		}).join('\\n');
+		await navigator.clipboard.write([new ClipboardItem({
+			'text/html': new Blob([html], { type: 'text/html' }),
+			'text/plain': new Blob([text], { type: 'text/plain' }),
+		})]);
+	});</script>`;
+	let url = new URL('../dist/copy.html', import.meta.url);
+	await fs.promises.writeFile(url, html);
+	console.log(`Written output to ${url}`);
+}
+
+let index = await buildIndex();
+await getDependencies(pkg, index);


### PR DESCRIPTION
This PR adds a new script `npm run list`. It can be used to generate a list of dependencies in [standardized format](https://github.com/sebamarynissen/simtropolis-channel/issues/2). It will generate an `.html` file in `dist/copy.html`, which shows the dependency list as an html `<ul>` list. Click "Copy" to copy it to the clipboard.

When pasting it inside a wysiwyg editor - such as the description edit box on the STEX, or in an e-mail client - it will paste it as an actual html list. If pasting inside something that only supports text - such as text editors - it will paste the list in sc4pac format.

Example usage:

```
npm run list mattb325:ikea-superstore
```

Which results in the generated html:

#### Dependencies:

- [bsc:mega-props-cp-vol02](https://www.sc4evermore.com/index.php/downloads/download/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
- [bsc:mega-props-sg-vol01](https://www.sc4evermore.com/index.php/downloads/download/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
- [supershk:mega-parking-textures](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/)

#### Dark nite only:
- [simfox:day-and-nite-mod](https://community.simtropolis.com/files/file/23089-simfox-day-and-nite-modd/)

and generated text:

```
- bsc:mega-props-cp-vol02
- bsc:mega-props-sg-vol01
- simfox:day-and-nite-mod
- supershk:mega-parking-textures
```

