### PR TITLE
fix: don't generate links without websites

### DIFF
--- a/scripts/list-dependencies.js
+++ b/scripts/list-dependencies.js
@@ -109,9 +109,13 @@ async function generateList(dependencies) {
 		let metadata = await getInfo(def[0]);
 		let {
 			website,
-			websites = [website],
+			websites = website ? [website] : [],
 		} = metadata.info;
-		html += `<li><a href="${websites[0]}">${pkg}</a></li>\n`;
+		if (websites.length > 0) {
+			html += `<li><a href="${websites[0]}">${pkg}</a></li>\n`;
+		} else {
+			html += `<li>${pkg}</li>`;
+		}
 	}
 	html += '</ul>';
 	return html;


### PR DESCRIPTION
This fixes a bug in #93 where a link was shown, even if the package has no website set. While it is preferrable that every package on sc4pac has a website attached to it, not all package do this (some for historical reasons). Hence, if a package has no website, we should render a link so that it's clear incentive to add a website.