### PR TITLE
fix: add variants to `peg:refuse-relocation-kit`

### DIFF
--- a/src/yaml/peg/11129-refuse-relocation-kit.yaml
+++ b/src/yaml/peg/11129-refuse-relocation-kit.yaml
@@ -18,8 +18,35 @@ info:
   website: https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/
   images:
     - https://www.simtropolis.com/objects/screens/0009/4f15b8b2f4bddbf94825c1784c878a1d-product_image.jpg
-assets:
-  - assetId: peg-refuse-relocation-kit
+variants:
+  - variant: { peg:refuse-relocation-kit:garbage-truck-skin: blue }
+    assets:
+      - assetId: peg-refuse-relocation-kit
+        include:
+          - peg_GarbageTruck-Blue_SKIN.dat
+          - PEG_RecycleTruck_SKIN.dat
+          - PEG-GarbageTruck_PROP_206.dat
+  - variant: { peg:refuse-relocation-kit:garbage-truck-skin: green }
+    assets:
+      - assetId: peg-refuse-relocation-kit
+        include:
+          - peg_GarbageTruck-Green_SKIN.dat
+          - PEG_RecycleTruck_SKIN.dat
+          - PEG-GarbageTruck_PROP_206.dat
+  - variant: { peg:refuse-relocation-kit:garbage-truck-skin: orange }
+    assets:
+      - assetId: peg-refuse-relocation-kit
+        include:
+          - peg_GarbageTruck-Orange_SKIN.dat
+          - PEG_RecycleTruck_SKIN.dat
+          - PEG-GarbageTruck_PROP_206.dat
+  - variant: { peg:refuse-relocation-kit:garbage-truck-skin: white }
+    assets:
+      - assetId: peg-refuse-relocation-kit
+        include:
+          - peg_GarbageTruck-White_SKIN.dat
+          - PEG_RecycleTruck_SKIN.dat
+          - PEG-GarbageTruck_PROP_206.dat
 
 ---
 assetId: peg-refuse-relocation-kit

--- a/src/yaml/peg/11210-alley-kit.yaml
+++ b/src/yaml/peg/11210-alley-kit.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: alley-kit
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: Alley Kit
+  description: |-
+    That nasty old alley is back. But this time... it has friends!!  The PEG Alley Kit now includes 4 different alleys for use in Residential, Rural, Industrial & Commercial areas.
+
+    The **Residential Alley** remains very similar to the original. Its ideal to place between rows of homes to provide that classic, established neighborhood look.
+
+    The new **Rural Alley** is almost identical to the Residential alley but takes "grunge" to the next level by ripping up the asphalt and leaving simple packed dirt. It look quite natural in rural settings and "low-value" residential areas.
+
+    The new **Industrial Alley** adds a new twist by visually serving as an industrial parking area as well as functioning as a lower capacity Bus Stop. This promotes the use of mass transit in your cities. It also solves the problem of having to find a single tile in your industrial areas for a normal bus stop where it either prevents a larger industry from developing or blocks the road access to what ever develops behind it.
+
+    The new **Commercial Alley** also pulls extra duty by functioning as a lower capacity Parking Structure that increases the efficiency of nearby mass transit. The COM alley also has small park/plaza effects to promote commercial development and can be used to dress up High Tech industrial areas. It has also been designed to be plopped side-by-side so you can create large, functional parking lots of almost any size.
+
+    \*\* All alleys are transit enabled as streets. Commuter & automata traffic will use them as normal streets. But, remember that transit enabled lots do not provide road access to adjacent lots.
+
+    \*\* The RES, Rural & IND alleys use the PEG Refuse Relocation Mod to randomly have garbage trucks appear at different times. Therefore, those lots do have a dependency on that mod.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11210-peg-alley-kit/
+  images:
+    - https://www.simtropolis.com/objects/screens/0014/7e9e24ff2e011aedb740844179a8338f-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0014/7e9e24ff2e011aedb740844179a8338f-product_image2.jpg
+dependencies:
+  - peg:refuse-relocation-kit
+assets:
+  - assetId: peg-alley-kit
+
+---
+assetId: peg-alley-kit
+version: "1.1"
+lastModified: "2025-01-22T23:36:10Z"
+url: https://community.simtropolis.com/files/file/11210-peg-alley-kit/?do=download&r=205438


### PR DESCRIPTION
When installing `peg:refuse-relocation-kit` you have to choose a color of the Garbage trucks. The metadata did not include this, but does so now.