### PR TITLE
feat: don't replace apostrophes with hyphens

### DIFF
--- a/actions/fetch/test/api-to-metadata-test.js
+++ b/actions/fetch/test/api-to-metadata-test.js
@@ -210,4 +210,14 @@ describe('#apiToMetadata', function() {
 
 	});
 
+	it('handles apostrophes', function() {
+
+		let upload = faker.upload({
+			title: 'Andrew\'s Fashion Centre',
+		});
+		let meta = apiToMetadata(upload);
+		expect(meta.package.name).to.equal('andrews-fashion-centre');
+
+	});
+
 });

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -895,7 +895,7 @@ describe('The fetch action', function() {
 		});
 		const { run } = this.setup({ uploads: [upload] });
 		const { result } = await run({ id: upload.id });
-		expect(result.metadata[0].name).to.equal('jast-o-conner-and-cremin');
+		expect(result.metadata[0].name).to.equal('jast-oconner-and-cremin');
 
 	});
 

--- a/actions/fetch/util.js
+++ b/actions/fetch/util.js
@@ -8,6 +8,7 @@ export function slugify(name) {
 	return lc
 		.normalize('NFD')
 		.replaceAll(/[\u0300-\u036f]/g, '')
+		.replaceAll(/'/g, '')
 		.replaceAll(/[^a-z0-9]+/g, '-')
 		.replace(/-$/, '')
 		.replace(/^-/, '');


### PR DESCRIPTION
This PR changes the way apostrophes in the package title are handled when transforming it to the name. Instead of replacing them with a hyphen, they are now simply omitted, so that "Andrew's Fashion Centre" becomes `andrews-fashion-centre` instead of `andrew-s-fashion-centre`.

Related: #103.