### PR TITLE
feat: allow additional standard dependencies in `.env`

### DIFF
--- a/scripts/sc4pac.js
+++ b/scripts/sc4pac.js
@@ -9,6 +9,7 @@ import yargs from 'yargs/yargs';
 import { parseAllDocuments } from 'yaml';
 import { Minimatch } from 'minimatch';
 import standardDeps from './standard-deps.js';
+import standardVariants from './standard-variants.js';
 
 // Parse the regular expressions for the packages
 const { argv } = yargs(hideBin(process.argv));
@@ -44,7 +45,9 @@ const json = {
 		pluginsRoot,
 		cacheRoot,
 		tempRoot: `.${path.sep}temp`,
-		variant: {},
+		variant: {
+			...standardVariants,
+		},
 		channels: [
 			'https://memo33.github.io/sc4pac/channel/',
 			pathToFileURL(path.resolve(import.meta.dirname, '../dist/channel'))+'/',

--- a/scripts/standard-deps.js
+++ b/scripts/standard-deps.js
@@ -1,4 +1,5 @@
 // # standard-deps.js
+const env = process.env.STANDARD_DEPENDENCIES ?? '';
 export default [
 	'memo:essential-fixes',
 	'memo:transparent-texture-fix-dll',
@@ -6,4 +7,5 @@ export default [
 	'peg:oops-mod',
 	'simmaster07:sc4fix',
 	'simmaster07:extra-cheats-dll',
+	...env.split(','),
 ];

--- a/scripts/standard-deps.js
+++ b/scripts/standard-deps.js
@@ -1,6 +1,9 @@
 // # standard-deps.js
 export default [
 	'memo:essential-fixes',
+	'memo:transparent-texture-fix-dll',
+	'memo:region-thumbnail-fix-dll',
+	'peg:oops-mod',
 	'simmaster07:sc4fix',
 	'simmaster07:extra-cheats-dll',
 ];

--- a/scripts/standard-variants.js
+++ b/scripts/standard-variants.js
@@ -1,0 +1,9 @@
+// # standard-variants.js
+const variants = process.env.STANDARD_VARIANTS ?? '';
+export default {
+	driveside: 'right',
+	...Object.fromEntries(variants.split(',').map(line => {
+		let [key, value] = line.trim().split('=');
+		return [key, value];
+	})),
+};


### PR DESCRIPTION
Following a discussion in #104, this PR adds `peg:oops-mod` to the standard dependencies, and also allows you to specify additional ones as a comma-separated list in a variable `STANDARD_DEPENDENCIES` in your `.env` file.

On top of that, it also allows you to specify the default variants with `STANDARD_VARIANTS`. That way you don't always have to specify the different variants manually when running `npm run sc4pac`.

Example `.env` file:

```.env
STANDARD_DEPENDENCIES=memo:submenus-dll,lowkee33:appalachian-terrain-mod-complete
STANDARD_VARIANTS=nightmode=dark,driveside=right,sfbt:essentials:tree-family=Maxis-deciduous-trees
```

cc @noah-severyn