### PR TITLE
build: remove install button from extensions

### DIFF
--- a/extensions/build/build.js
+++ b/extensions/build/build.js
@@ -10,7 +10,6 @@ const srcDir = path.resolve(import.meta.dirname, '../src');
 const outDir = path.resolve(import.meta.dirname, '../dist');
 
 const files = [
-	'stex.js',
 	'background.js',
 	'copy.js',
 ];
@@ -39,7 +38,7 @@ try {
 } catch {}
 
 for (let [browser, options] of Object.entries(config)) {
-	let outDir = path.resolve(import.meta.dirname, '../dist', browser);
+	let outDir = path.resolve(import.meta.dirname, '../../dist/extensions', browser);
 	let { files } = options;
 	for (let file of files) {
 		await esbuild.build({

--- a/extensions/build/build.js
+++ b/extensions/build/build.js
@@ -1,6 +1,7 @@
 // # build.js
 import path from 'node:path';
 import fs from 'node:fs';
+import cp from 'node:child_process';
 import { createRequire } from 'node:module';
 import * as esbuild from 'esbuild';
 import { Glob } from 'glob';
@@ -76,3 +77,11 @@ await esbuild.build({
 	outfile: path.join(outDir, 'scripts/stex.js'),
 	minify: true,
 });
+
+// Pack up as .zip.
+for (let browser of Object.keys(config)) {
+	cp.execSync(`7z a ../${browser}.zip *`, {
+		cwd: path.join(outDir, browser),
+		stdio: 'inherit',
+	});
+}

--- a/extensions/src/manifest.json
+++ b/extensions/src/manifest.json
@@ -23,10 +23,6 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://community.simtropolis.com/files/file/*"],
-      "js": ["stex.js"]
-    },
-    {
       "matches": ["https://community.simtropolis.com/*"],
       "js": ["copy.js"]
     }


### PR DESCRIPTION
Now that the "Install with sc4pac" button is live on Simtropolis, we no longer need it as part of the extensions. The only thing the extension still needs to do is copying the credentials to the clipboard. The script that is added on Simtropolis is now built separately as part of `npm run build:extensions`.