### PR TITLE
fix: don't introduce empty dependencies when no `STANDARD_DEPENDENCIES` env variable is found

### DIFF
--- a/scripts/standard-deps.js
+++ b/scripts/standard-deps.js
@@ -7,5 +7,5 @@ export default [
 	'peg:oops-mod',
 	'simmaster07:sc4fix',
 	'simmaster07:extra-cheats-dll',
-	...env.split(','),
+	...env.split(',').map(x => x.trim()).filter(Boolean),
 ];


### PR DESCRIPTION
Fixes #113.