### PR TITLE
feat: support `--darknite-only` flag

### DIFF
--- a/actions/fetch/api-to-metadata.js
+++ b/actions/fetch/api-to-metadata.js
@@ -8,7 +8,7 @@ import { slugify } from './util.js';
 // # apiToMetadata(json)
 // Transforms a single json results from the STEX api to the basic metadata 
 // structure.
-export default function apiToMetadata(json) {
+export default function apiToMetadata(json, opts = {}) {
 	let pkg = {
 		group: slugify(json.group || json.author),
 		name: slugifyTitle(json.title),
@@ -30,7 +30,11 @@ export default function apiToMetadata(json) {
 	// separate loop so that we can find how many buildings there are without 
 	// tags to determine if the assets need to be suffixed with "part-0", 
 	// "part-1" etc.
-	let allTags = json.files.map(file => getFileTags(file));
+	let allTags = json.files.map(file => {
+		let tags = getFileTags(file);
+		if (opts.darkniteOnly) tags.push('darknite');
+		return [...new Set(tags)];
+	});
 	let tagAmounts = Object.groupBy(allTags, arr => arr.length);
 	let defaultSuffix = (tagAmounts[0] ?? []).length < 2 ?
 		() => '' :

--- a/actions/fetch/fetch-all.js
+++ b/actions/fetch/fetch-all.js
@@ -42,7 +42,9 @@ export default async function fetchAll(urls, opts = {}) {
 	let result = [];
 	for (let upload of json) {
 		let cleaned = permissions.transform(upload);
-		let metadata = apiToMetaData(cleaned);
+		let metadata = apiToMetaData(cleaned, {
+			darkniteOnly: opts.darkniteOnly,
+		});
 		for (let asset of metadata.assets) {
 			await downloader.handleAsset(asset);
 		}

--- a/scripts/manual-add.js
+++ b/scripts/manual-add.js
@@ -37,7 +37,10 @@ async function run(urls, argv) {
 	});
 
 	// Cool, now perform the actual fetching.
-	let results = await fetchAll(urls, { split: argv.split });
+	let results = await fetchAll(urls, {
+		split: argv.split,
+		darkniteOnly: argv.darkniteOnly,
+	});
 	for (let result of results) {
 		let [pkg] = result.metadata;
 		let deps = parseDependencies(index, pkg);


### PR DESCRIPTION
See #121. This PR adds a `--darknite-only` flag to the `npm run add` script so that every asset is forcibly tagged as darknite, so that the correct variants get generated. This is useful in case an author uploaded a plugin as darknite-only, but did not label the asset as such.

cc @noah-severyn 