### PR TITLE
fix: add clickteam metadata for `deadwoods:highway-walls`

### DIFF
--- a/src/yaml/deadwoods/16556-highway-walls.yaml
+++ b/src/yaml/deadwoods/16556-highway-walls.yaml
@@ -1,6 +1,6 @@
 group: deadwoods
 name: highway-walls
-version: "1.01"
+version: "1.01-1"
 subfolder: 700-transit
 info:
   summary: Highway Walls
@@ -114,7 +114,7 @@ assets:
 
 ---
 assetId: deadwoods-highway-walls
-version: "1.01"
+version: "1.01-1"
 lastModified: "2006-08-05T00:40:31Z"
 url: https://community.simtropolis.com/files/file/16556-dedwd-highway-walls/?do=download&r=39325
 archivetType:

--- a/src/yaml/deadwoods/16556-highway-walls.yaml
+++ b/src/yaml/deadwoods/16556-highway-walls.yaml
@@ -117,3 +117,6 @@ assetId: deadwoods-highway-walls
 version: "1.01"
 lastModified: "2006-08-05T00:40:31Z"
 url: https://community.simtropolis.com/files/file/16556-dedwd-highway-walls/?do=download&r=39325
+archivetType:
+  format: Clickteam
+  version: "20"


### PR DESCRIPTION
`deadwoods:highway-walls` apparently uses a clickteam installer. This PR fixes that.