### PR TITLE
fix: fix accidental double quoting

### DIFF
--- a/actions/fetch/stylize-doc.js
+++ b/actions/fetch/stylize-doc.js
@@ -1,6 +1,6 @@
 // # stylize-doc.js
 import { visit } from 'yaml';
-const booleans = /(on|off|true|false|yes|no)/i;
+const booleans = /^(on|off|true|false|yes|no)$/i;
 
 // # stylize(doc)
 // Applies an opinionated way on how to stringify the metadata.

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -885,6 +885,8 @@ describe('The fetch action', function() {
 			let prop = doc.getIn(['variants', i, 'variant', 'some-feature'], true);
 			expect(prop.type).to.equal('QUOTE_DOUBLE');
 		}
+		let desc = doc.getIn(['info'], true).items.find(item => item.key.value === 'description').key;
+		expect(desc.type).to.equal('PLAIN');
 
 	});
 


### PR DESCRIPTION
This PR fixes a bug introduced in #146 where keys like `description` would also get quoted because of an incorrect regex.