### PR TITLE
Update 36707-universal-sea-level-mod.yaml

### DIFF
--- a/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
+++ b/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
@@ -65,8 +65,6 @@ variants:
         include:
           - /2000m.dat
   - variant: { smf-16:universal-sea-level-mod:height: "off" }
-assets:
-  - assetId: smf-16-universal-sea-level-mod
 
 ---
 assetId: smf-16-universal-sea-level-mod

--- a/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
+++ b/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
@@ -1,6 +1,6 @@
 group: smf-16
 name: universal-sea-level-mod
-version: "1.0.3"
+version: "1.0.3-1"
 subfolder: 150-mods
 info:
   summary: Universal Sea Level Mod
@@ -68,6 +68,6 @@ variants:
 
 ---
 assetId: smf-16-universal-sea-level-mod
-version: "1.0.3"
+version: "1.0.3-1"
 lastModified: "2025-02-13T22:38:53Z"
 url: https://community.simtropolis.com/files/file/36707-universal-sea-level-mod/?do=download&r=205902


### PR DESCRIPTION
There's a bug in the code for custom variant generation because it still keeps the original assets from the autogenerated metadata, which is something we don't want. We should fix this in the code, but we'll also fix this now already.