### PR TITLE
metadata: add more of Peg's content

### DIFF
--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -238,7 +238,7 @@ export default async function handleUpload(json, opts = {}) {
 	// However, if the asset does not have a persistent url and it contains a 
 	// DLL, then we should generate an error.
 	for (let asset of filterAssets(metadata)) {
-		let files = asset[kFileNames];
+		let files = asset[kFileNames] ?? [];
 		if (asset.nonPersistentUrl) {
 			let info = await downloader.handleAsset(asset);
 			if (info.checksums?.length > 0) {

--- a/scripts/standard-deps.js
+++ b/scripts/standard-deps.js
@@ -4,6 +4,7 @@ export default [
 	'memo:essential-fixes',
 	'memo:transparent-texture-fix-dll',
 	'memo:region-thumbnail-fix-dll',
+	'null-45:startup-performance-optimization-dll',
 	'peg:oops-mod',
 	'simmaster07:sc4fix',
 	'simmaster07:extra-cheats-dll',

--- a/src/yaml/peg/10897-rtk3-recreational-style.yaml
+++ b/src/yaml/peg/10897-rtk3-recreational-style.yaml
@@ -1,0 +1,28 @@
+group: peg
+name: rtk3-recreational-style
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: RTK3 Recreational Style
+  description: |-
+    Curved lots in Squaresville? Oh Shirley... you jest!! Don't bother pinching yourself...you're not dreaming. With the use of an innovative, highly sophisticated process I call "mojo", you can now break up that monotonous squared look prevalent in your cities with some seductive curves!
+
+    There have been numerous requests for rounded & curved lots... and quite a few for single-tile high wall sea walls as well. Two birds... one rock... BAM!! Most of the normal rules governing lot development were broken with this new approach. Its a bit like saying, "Screw gravity... I want to go up!"
+
+    But the end result bears fruit. Single tile lots covering 2 or three tiles and a collection of 21 new custom BAT models all combine to make the impossible... possible. I decided to make this style the new RTK... because it plops like the RTKs. Unlike the CDK sea walls, you must level the terrain at the top of the bank for these lots to work.
+
+    However, unlike the older RTKs, you don't need to worry about having even slopes or the water depth. Just level the Top... and Plop!! You can even control how high the walls are by raising or lowering the level of the lot above the water. New in Version 2.05: The repetitive gazebos on every outer corner have been replaced with a random prop family to add some variety. Every outer corner will now have either the gazebo or 1 of 3 new statue props.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10897-peg-rtk3-recreational-style/
+  images:
+    - https://www.simtropolis.com/objects/screens/0024/ddfbd0f26246a51e54a51281628ad152-product_image.jpg
+assets:
+  - assetId: peg-rtk3-recreational-style
+
+---
+assetId: peg-rtk3-recreational-style
+version: "1.1"
+lastModified: "2025-02-08T17:46:43Z"
+url: https://community.simtropolis.com/files/file/10897-peg-rtk3-recreational-style/?do=download&r=205676

--- a/src/yaml/peg/10934-rtk3-rec-addon1.yaml
+++ b/src/yaml/peg/10934-rtk3-rec-addon1.yaml
@@ -1,0 +1,26 @@
+group: peg
+name: rtk3-rec-addon1
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: RTK3 REC AddOn1
+  description: |-
+    \* This add-on pack includes updated versions of lots in the original Add-On 1 & Add-On 2 packs.
+
+    Here is a collection of new lots for your RTK3 REC style collection. The END sections are the most functional in this add-on. They will allow you to add curved, finished looking ends to your Plaza-style sea walls. Because of the nature of the offset-rendering method used to create this style, separate Left & Right End sections/lots are required.
+
+    If you've ever been asked to take a long walk off a short pier... now you can do it. Included in this pack, is a short walking pier as well as a separate stairway lot that can be used for visual variety as well as access between tiered levels. The fixed height of the stairs will require leveling the terrain to a matching height for proper appearance. This is more of an "advanced" section for those who are comfortable with altering their terrain.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10934-peg-rtk3-rec-addon1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0012/6bd5a821fc3abb48ee764c3ac76d9e18-product_image.jpg
+assets:
+  - assetId: peg-rtk3-rec-addon1
+
+---
+assetId: peg-rtk3-rec-addon1
+version: "1.1"
+lastModified: "2025-02-08T17:47:52Z"
+url: https://community.simtropolis.com/files/file/10934-peg-rtk3-rec-addon1/?do=download&r=205678

--- a/src/yaml/peg/11054-seasonal-trail-parks.yaml
+++ b/src/yaml/peg/11054-seasonal-trail-parks.yaml
@@ -1,0 +1,26 @@
+group: peg
+name: seasonal-trail-park
+version: "3.0.5"
+subfolder: 660-parks
+info:
+  summary: Seasonal Trail Parks
+  description: |-
+    The PEG Seasonal Trail Parks are very similar to the normal trail parks with one major exception; seasonal trees. Where the original style of trail park was designed to blend with the [PEG Random Woods](https://community.simtropolis.com/files/file/4526-peg-random-woods-v206/) lots and the game's default trees... the Seasonal Trail Parks are designed to compliment the [PEG Seasonal Woods](https://community.simtropolis.com/files/file/4515-peg-seasonal-woods-v206b/).
+
+    These new parks feature BAT modeled pathways that replace the old textured paths. This means that the paths now show while you are plopping the lots. This makes them much easier to use.
+
+    \*\* There are no Plaza or Snack Bar lots included in this style as the ones from the normal Trail Parks are interchangeable with this style.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11054-peg-seasonal-trail-parks-v305/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e1699c0fc7209954277fa21b44c8d654-product_image.jpg
+assets:
+  - assetId: peg-seasonal-trail-parks-v305
+
+---
+assetId: peg-seasonal-trail-parks-v305
+version: "3.0.5"
+lastModified: "2025-02-08T18:02:34Z"
+url: https://community.simtropolis.com/files/file/11054-peg-seasonal-trail-parks-v305/?do=download&r=205682

--- a/src/yaml/peg/11334-observation-tower.yaml
+++ b/src/yaml/peg/11334-observation-tower.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: observation-tower
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Observation Tower
+  description: |-
+    For those of us who think we're above it all... or would like to be... PEG Productions proudly presents... the Observation Tower. Modified from a public domain mesh, this new tower is designed for use with the PEG Random Woods, Pine Forest & Seasonal Woods packages. Situated on a 2x2 lot and nestled between the appropriate tree types, this tower can be used as a fire watch tower, a bird watching platform, or a deer blind for those of you who are compelled to pop a cap upside Bambi's head.
+
+    The lot has the same park-like properties as a 2x2 Forest/Woods lot. For each style, there are textured and transparent ground versions. (6 lots in total) Each lot has been sanctioned by the NTHA (National Tree Huggers Association)... a non-profit and totally fictional organization.
+
+    **Dependencies:  
+    [PEG Seasonal Woods](https://community.simtropolis.com/files/file/4515-peg-seasonal-woods-v206b/)**   
+    **[PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11334-peg-observation-tower/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/bf3fda51bd77ad828b497b68cf15a998-product_image.jpg
+dependencies:
+  - peg:mtp-seasonal-woods
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-observation-tower
+
+---
+assetId: peg-observation-tower
+version: "1.1"
+lastModified: "2025-02-08T16:32:05Z"
+url: https://community.simtropolis.com/files/file/11334-peg-observation-tower/?do=download&r=205640

--- a/src/yaml/peg/11775-cdk-rec-prop-pack-1.yaml
+++ b/src/yaml/peg/11775-cdk-rec-prop-pack-1.yaml
@@ -1,0 +1,51 @@
+group: peg
+name: cdk-rec-prop-pack-1
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: CDK-REC Prop Pack 1
+  description: |-
+    This is the first volume of props designed for exclusive use with the PEG\-CDK REC style lots. Intended primarily for use as a dependency file, the props it contains can also be used by lot developers. Used in conjunction with the PEG\-CDK REC Seawall Kit, developers can now create their own CDK REC styled lots.
+
+    These props are all "**offset-rendered**". This means that they can visually extend beyond the edges of the lot for placement out over the water. The props included in this volume are:
+
+    **\* Trawlers**
+
+    \- Two variations of the classic commercial fishing boat... generic enough for use as any type of small work or fishing industry boat.
+
+    **\* Commercial Pier**
+
+    \- A short but rugged wooden pier suitable for a variety of commercial, industrial & recreational purposes.
+
+    **\* Water Taxi**
+
+    \- Built from a mesh of the famous African Queen and now used as a novel water taxi that is popular with tourists & locals alike, this boat has been featured in several water lots.
+
+    **\* Freight Shuttle**
+
+    \- A variation of the Water Taxi,  small boats such as this are commonplace around harbors and waterfronts as they ferry freight, supplies and passengers around the port and out to anchored ships.
+
+    **\* Fish Stand**
+
+    \- A modelrama of an active fresh fish stand... a fairly common sight in one form or another around an active fishing industry.
+
+    **\* Peeps**
+
+    \- A group of 3 people that can be placed out on a dock, pier or seawall. The game's props, including the animated people props, can not be extended beyond the lots borders. This prop allows you to put a little life out over the water.  
+
+    Lot developers may use the props contained in this product to enhance the development of their own lots by referencing this material as a "Dependency" only. The contents of this product file may not be altered, removed or copied into any other file. This file may not be redistributed or included with any other lots or material.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11775-peg-cdk-rec-prop-pack-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0006/2c6a6dfba60bda263d2c43c7cb3b43c8-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0006/2c6a6dfba60bda263d2c43c7cb3b43c8-product_image2.jpg
+assets:
+  - assetId: peg-cdk-rec-prop-pack-1
+
+---
+assetId: peg-cdk-rec-prop-pack-1
+version: "1.1"
+lastModified: "2025-02-06T02:39:58Z"
+url: https://community.simtropolis.com/files/file/11775-peg-cdk-rec-prop-pack-1/?do=download&r=205554

--- a/src/yaml/peg/12007-cdk-oww-development-pack-vol1.yaml
+++ b/src/yaml/peg/12007-cdk-oww-development-pack-vol1.yaml
@@ -1,0 +1,80 @@
+group: peg
+name: cdk-oww-development-pack-vol1
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: CDK-OWW Development Pack Vol 1
+  description: |-
+    Although this file is intended primarily as a dependency for future PEG\-CDK OWW (Old Wooden Waterfront) lots, it can also be used by lot developers to create their own CDK styled lots. The official CDK\-OWW lots use these component props as do other lots designed to be compatible with this style.
+
+    The kit contains the following props:
+
+    1\. Front Facade - Basic 2-post, no fascia.  
+    2\. Front Facade - Basic 2-post, board fascia.  
+    3\. Front Facade - Basic 2-post, brick fascia.  
+    4\. Front Facade - Basic 2-post, stone fascia.
+
+    \* Basic 2-post facades do not have the center pilings extended above the deck area. These are designed for use with the Chain Rail prop to act as a stanchion or safety rail which would be suitable for REC and COM related lots.
+
+    5\. Front Facade - Basic 4-post, no fascia.  
+    6\. Front Facade - Basic 4-post, board fascia.  
+    7\. Front Facade - Basic 4-post, brick fascia.  
+    8\. Front Facade - Basic 4-post, stone fascia.  
+      
+    \* Basic 4-post facades have the center pilings extended above the deck area. These are not designed for use with the Chain Rail prop and would be more suited to IND applications.
+
+    \*\* All Facade props can also be used on the side and rear of the seawall if desired.
+
+    9\. 16x16 (single tile) Outer Corner Deck Platform. This is the same 1x1 deck included in the CDK\-REC pack except that the wood decking is angled for use on outer corners.
+
+    10\. 16x16 (single tile) Inner Corner Deck Platform. This is the same 1x1 deck included in the CDK\-REC pack except that the wood decking is angled for use on inner corners.
+
+    11\. 1x1 Deck Platform with Stairs. Similar to the standard deck prop, but with inset stairs intended for use on the backside of the seawall.
+
+    12\. 14x1 Chain Rail. A nautical styled safety rail intended for use with the Basic 2-post facades.
+
+    13\. Public Pier. A long slender wooden pier that extends beyond the lot out into the water.
+
+    14\. Wood Ramp. Intended to be placed on the backside of a seawall to provide access from the area below.
+
+    **MISSION CRITICAL:**  
+    Also included are 4 STYLE files. **One of these STYLE files must be installed somewhere in your Plugins folder.** The STYLE files define which facade style fascia/facade (Brick, Boards, Stone, or none.) the seawalls will use globally throughout the game. **Only one STYLE file can be installed at a time.** You can easily change styles at any time by removing the existing STYLE file from your Plugins folder and installing a different one.
+
+    \*\* The game's Shadows should be set to High when using the Pilings (no fascia) style. The shadows conceal the lack of visual texture behind the pilings which can expose the underlying game grid when the game's water graphics bug is tripped off.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12007-peg-cdk-oww-development-pack-vol-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0007/3643b2cfda5fed1a7d9f9e19520b6993-product_image.jpg
+assets:
+  - assetId: peg-cdk-oww-development-pack-vol1
+    include:
+      - /PEG-OWW_Development-Kit_Vol1b.dat
+variants:
+  - variant: { peg:cdk-oww-development-pack-vol1:facade: boards }
+    assets:
+      - assetId: peg-cdk-oww-development-pack-vol1
+        include:
+          - /PEG_CDK-OWW_STYLE_Boards.dat
+  - variant: { peg:cdk-oww-development-pack-vol1:facade: bricks }
+    assets:
+      - assetId: peg-cdk-oww-development-pack-vol1
+        include:
+          - /PEG_CDK-OWW_STYLE_Bricks.dat
+  - variant: { peg:cdk-oww-development-pack-vol1:facade: pilings }
+    assets:
+      - assetId: peg-cdk-oww-development-pack-vol1
+        include:
+          - /PEG_CDK-OWW_STYLE_Pilings.dat
+  - variant: { peg:cdk-oww-development-pack-vol1:facade: stone }
+    assets:
+      - assetId: peg-cdk-oww-development-pack-vol1
+        include:
+          - /PEG_CDK-OWW_STYLE_Stone.dat
+
+---
+assetId: peg-cdk-oww-development-pack-vol1
+version: "1.1"
+lastModified: "2025-02-06T02:33:25Z"
+url: https://community.simtropolis.com/files/file/12007-peg-cdk-oww-development-pack-vol-1/?do=download&r=205552

--- a/src/yaml/peg/13059-trail-park-fountain-plaza.yaml
+++ b/src/yaml/peg/13059-trail-park-fountain-plaza.yaml
@@ -1,0 +1,27 @@
+group: peg
+name: trail-park-fountain-plaza
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Trail Park Fountain Plaza
+  description: |-
+    This large (3x3) deluxe plaza is an add-on for the [PEG Trail Parks](https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/). It can be used with both the standard Trail Parks or the [PEG Seasonal Trail Parks](https://community.simtropolis.com/files/file/11054-peg-seasonal-trail-parks-v305/) version. It can also be used stand-alone as a normal large plaza.
+
+    It is fully self-contained (no external dependencies) with all required elements contained in the accompanying resource file. The lot has the same properties as a normal large plaza. It is Transit Enabled for pedestrians and features a custom soft waterfall background sound-effect. It will appear ion the Parks menu next to the game's default large plaza.
+
+    **\*\*This lot has no dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/13059-peg-trail-park-fountain-plaza/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/b8ed67ebc94ce4b446b1fa360e3c1cca-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0021/b8ed67ebc94ce4b446b1fa360e3c1cca-product_image2.jpg
+assets:
+  - assetId: peg-trail-park-fountain-plaza
+
+---
+assetId: peg-trail-park-fountain-plaza
+version: "1.1"
+lastModified: "2025-02-08T18:03:47Z"
+url: https://community.simtropolis.com/files/file/13059-peg-trail-park-fountain-plaza/?do=download&r=205684

--- a/src/yaml/peg/14026-mtp-random-pine-forest.yaml
+++ b/src/yaml/peg/14026-mtp-random-pine-forest.yaml
@@ -1,0 +1,30 @@
+group: peg
+name: mtp-random-pine-forest
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Random Pine Forest
+  description: |-
+    This is a **MTP** compliant update to the [PEG Random Pine Forest](https://community.simtropolis.com/files/file/4523-peg-random-forest/) lots which provides a fast & flexible means of adding realistic woodlands to your cities and surrounding rural areas. The Random Pine Forests are ploppable lots, in 1x1 & 2x2 sizes, that blend together to form large, forests of custom pines trees. They are fully slope conforming and can be plopped almost anywhere. Their YIMBY effects have also been reduce substantially to avoid blowing out caps.
+
+    The new Pine Forests feature pine trees with an upgraded appearance and one new pine tree model. They feature the same pines trees used in the PEG God & Mayor mode Pine Tree Mods.
+
+    Two versions are included... one with transparent textures which allow the game's natural terrain to show through... and a textured version that uses the new MTP Forest Floor texture and blends well with other MTP lots. The two versions are included in separate files so after installation, you can remove either one if you do not intend to use that style.
+
+    **\*\* This lot requires the following dependency: [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14026-peg-mtp-random-pine-forest/
+  images:
+    - https://www.simtropolis.com/objects/screens/0001/0500ebbc800d7548ef918d294c72eb91-product_image.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-random-pine-forest
+
+---
+assetId: peg-mtp-random-pine-forest
+version: "1.1"
+lastModified: "2025-02-08T16:57:15Z"
+url: https://community.simtropolis.com/files/file/14026-peg-mtp-random-pine-forest/?do=download&r=205659

--- a/src/yaml/peg/14055-mtp-mountain-trail-rail-crossing.yaml
+++ b/src/yaml/peg/14055-mtp-mountain-trail-rail-crossing.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: mtp-mountain-trail-rail-crossing
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: MTP Mountain Trail Rail Crossing
+  description: |-
+    \*\* This is a **MTP** update to the original lot. Like the new Mountain Trails, it can now be used with any tree set.
+
+    Created by request, the original Pine Trail Railroad Crossing was a simple, 1x1  lot that visually extends the Pine Trails over railroad tracks. In effect, it is no more than a single tile lot that is transit enabled for both freight & passenger rail.
+
+    However, with the game's default "dirt" underlying the rail road tracks everywhere in the game, there was no way to get this lot to look quite right. Thus spawned a collective effort at the support site for a means to improve the appearance of the railroad tracks.
+
+    The result of that collective effort, is the SWAMPER-PEG No Rail Dirt Mod, which was initially released on the STEX along with Swamper77's OneWay Railroad Crossings Mod ... and is also included in this archive. As is pictured above, the No Rail Dirt Mod eliminates the dirt texture under the railway tracks... which doesn't look bad on straight sections, but looked like chunky Hell on diagonal sections and turns and turnouts.
+
+    The side effect to this mod is that is also removes the underlying dirt that appears on streets adjacent to farm and landfill zones. On those tiles, between the road and the sidewalk,  the true underlying terrain (usually grass) is visible instead of the dirt. Its barely noticeable and not objectionable in appearance, but a side effect none-the-less.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14055-peg-mtp-mountain-trail-rail-crossing/
+  images:
+    - https://www.simtropolis.com/objects/screens/0015/807ed414041c6a54fec2a8da71f0498e-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0015/807ed414041c6a54fec2a8da71f0498e-product_image2.jpg
+assets:
+  - assetId: peg-mtp-mountain-trail-rail-crossing
+
+---
+assetId: peg-mtp-mountain-trail-rail-crossing
+version: "1.1"
+lastModified: "2025-02-08T16:41:34Z"
+url: https://community.simtropolis.com/files/file/14055-peg-mtp-mountain-trail-rail-crossing/?do=download&r=205645

--- a/src/yaml/peg/14058-mtp-mountain-trail-fire-circle.yaml
+++ b/src/yaml/peg/14058-mtp-mountain-trail-fire-circle.yaml
@@ -1,0 +1,35 @@
+group: peg
+name: mtp-mountain-trail-fire-circle
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Mountain Trail Fire Circle
+  description: |-
+    Kumbaya, My Friends... Kumbaya!!  The translation of this Gullah word was made famous by the popular campfire song, and  means "***come by here***". And that is certainly the message that campgrounds want to get out to campers on the trail.
+
+    No self-respecting campground is with out the classic fire circle/amphitheater where the campers gather at night to hear tales from the rangers of local folklore and the history of the surrounding area. A raging fire, a good show by the rangers and plenty of group sing-along songs before hiking back to the campsite and bedding down for the night.
+
+    The Campfire Circle / Amphitheater lot is designed for use with the [PEG Mountain Trails](https://community.simtropolis.com/files/file/30680-peg-mtp-mountain-trails/) and fits right in with the other campground lots included in the [Mountain Trail Recreation Pack](https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/)**.** It features a dual-model amphitheater prop that is largely empty by day. But when the sun sets, the amphitheater fills up with campers, the fire is lit, and the fire glow sets the mood for the often haunting, but always fun & humorous show put on by the rangers.
+
+    \* The lot also contains a custom audio track. If you listen carefully, you can hear the crickets and occasional owls hooting in the distance.
+
+    Like the other Mountain Trail campground lots, the Fire Circle has minor YIMBY effects... somewhat less than a small park. Its very affordable to maintain and quite cheap to build. "Someone's Plopping, Lord... Kumbaya...".
+
+    **\*\* This lot requires the following dependencies: [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14058-peg-mtp-mountain-trail-fire-circle/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e65ca25a88edce4278a092e8b0903054-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0025/e65ca25a88edce4278a092e8b0903054-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-mountain-trail-fire-circle
+
+---
+assetId: peg-mtp-mountain-trail-fire-circle
+version: "1.1"
+lastModified: "2025-02-08T16:35:37Z"
+url: https://community.simtropolis.com/files/file/14058-peg-mtp-mountain-trail-fire-circle/?do=download&r=205642

--- a/src/yaml/peg/14097-mtp-forest-pack-1.yaml
+++ b/src/yaml/peg/14097-mtp-forest-pack-1.yaml
@@ -1,0 +1,41 @@
+group: peg
+name: mtp-forest-pack-1
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Forest Pack 1
+  description: |-
+    This is an MTP update to the previous Forest Pack 1. It has been upgraded to use the MTP blended forest floor texture on the textured version of each lot. Additionally, the Loggers lot has been converted to be the initial step/lot in the upcoming LOgging Industry reward chain.
+
+    This Forest Add-On pack includes several lots to add visual variety & realism to your woodlands. All lots include both textured and transparent ground versions and can be used with any woods/forest styles. All lots act as small parks and are conveniently grouped together in your Parks menu above the Random Woods lots.
+
+    The Meadow lots, with both 1x1 and 2x2 sized versions, can be very useful to stagger the edges of your tree lines and add those open areas and clearings that are common in real world woodlands.
+
+    The Logger lots add a visual sense of function and purpose to your woodlands and will serve as part of the reward chain for several Logging Industry lots.
+
+    The Hot Springs (rated PG-13 for Brief Nudity) adds a soothing and restful secret spot for your Sims to shed their everyday troubles... as well as their clothing.
+
+    The Hunting Lodges (Yes, plural. There are three in a random prop family), utilize a modeling technique that allows the building to adapt more realistically to sloped terrain. The cabin's foundation and stairways will adjust to the slope of the lot without the use of a separate foundation model or relying on the game's forced lot leveling or big, ugly  concrete blocks under the structure.
+
+    The Hunting Lodges use lanterns for night lighting and do not require power... so you can plop them way out in the boonies. You will also see gentle wisps of smoke rising from their chimneys.
+
+    All PEG Mountain Theme Pack lots are PEG PCG tested & Tree-Hugger approved. Each lot has properties similar to a small green park with slightly improved air pollution qualities. These lots are also 'Slope Conforming' so you can place them almost anywhere.
+
+    **\*\* This lot requires the following dependency: [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14097-peg-mtp-forest-pack-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0012/66b7cd57897938929fd9ef522a38fe69-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0012/66b7cd57897938929fd9ef522a38fe69-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-forest-pack-1
+
+---
+assetId: peg-mtp-forest-pack-1
+version: "1.1"
+lastModified: "2025-02-08T15:54:51Z"
+url: https://community.simtropolis.com/files/file/14097-peg-mtp-forest-pack-1/?do=download&r=205637

--- a/src/yaml/peg/14107-mtp-low-wealth-growable-res-cabins.yaml
+++ b/src/yaml/peg/14107-mtp-low-wealth-growable-res-cabins.yaml
@@ -1,0 +1,46 @@
+group: peg
+name: mtp-low-wealth-growable-res-cabins
+version: "1.1"
+subfolder: 200-residential
+info:
+  summary: MTP Low Wealth Growable RES Cabins
+  description: |-
+    **The Problem:** You have developed a nice mountain terrain complete with beautiful trees & flowing streams... and not a soul in sight. Nor will there ever be unless you want suburban tract houses or urban tenements cluttering up the mountainside. There are very few growable RCI lots in the game that look right in a mountain or rural community... and no way to guaranty that those lots will develop in any zones you lay down.
+
+    **The Solution:** The **PEG Mountain Theme Growable Lots**. These are a series of RES, COM & IND growable lots designed specifically for mountain/rural communities. By using unique, custom sized lots, we can assure that only these lots will grow in the zones you lay down in your mountains. Now you can create mountain communities with functional & occupied buildings that look like they belong in the mountains. Cut back on the eye-candy and let some real RCI go to work in them thar' hills.
+
+    In order to have growable lots specific to the Mountain Theme, we have used 2x5, 3x5 & 5x5 custom lot sizes. Ordinary, game-default RES lots will not grow on custom lots of this size. The player must create custom zones of this size... which is easy to do by holding down the CTRL key while using the mouse to drag out the zone size.
+
+    This first set is a collection of **9** new lots that are primarily low wealth, zoned for various densities and feature 4 random log cabins. Because larger, custom lot sizes are required, several cabins are spaced out on the lot to represent several homes occupying the area. The resident values have been adjusted upwards to reflect the number of homes on each lot.
+
+    Additionally, these lots are designed to accommodate the sloped terrain of mountainous areas. The cabin models are designed with extended foundations that merge into sloped terrain.... so instead of a building on top of a concrete block, you get cabins that merge realistically into the  hillside.
+
+    The lots use random building & prop families so the cabins will always be different on each lot. The cabins also use a new feature, Random Smoke... so you will see smoke coming from their chimneys at different times of the day.
+
+    *\* The MTP Growable RES lots are part of a much larger & expanding theme. These are not just simple "install and hope they grow" lots.  These lots are part of a full-cycle residential community spanning all density types... that will grow and update into newer, wealthier versions of themselves.*
+
+    *They are not intended to supplement the existing array of residential RCI lots. They are designed to fully replace them.. but only in areas or cities controlled by the player via use of custom zoning sizes. In this way, they will not affect normal/default RES lots & development zoned in normal & conventional sizes.*
+
+      
+    **\*\* This lot requires the following dependencies:**
+
+    **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori edit:** Made dep linky clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f3e9b640f9e94f428092a0842799882c-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0027/f3e9b640f9e94f428092a0842799882c-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-low-wealth-growable-res-cabins
+
+---
+assetId: peg-mtp-low-wealth-growable-res-cabins
+version: "1.1"
+lastModified: "2025-02-08T15:43:37Z"
+url: https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/?do=download&r=205625

--- a/src/yaml/peg/14158-mtp-high-wealth-growable-res-lodges.yaml
+++ b/src/yaml/peg/14158-mtp-high-wealth-growable-res-lodges.yaml
@@ -1,0 +1,43 @@
+group: peg
+name: mtp-high-wealth-growable-res-lodges
+version: "1.1"
+subfolder: 200-residential
+info:
+  summary: MTP High Wealth Growable RES Lodges
+  description: |-
+    Our third offering of mountain-specific, growable RES lots for the **MTP** completes the wealth range with 8 new High Wealth lots. Featured on the lots are combinations of 3 variations of a deluxe mountain lodge. The lots are custom sized at 3x5 & 5x5 and there are versions specific to low, medium and high density zones.
+
+    These lots, when combined with the **MTP** R$ Cabins & R$$ A-Frames, complete the full wealth/growable cycle. Your mountain-zoned RES lots will grow and upgrade to match the wealth of the area... from humble Cabins to stylish A-Frames... to impressive mountain Mansions. With luck, you may even grow the elusive high-wealth, high density Alpine Inn as pictured above.
+
+    There are no 2x5 lot size variations for these high wealth lots. The lodges are just too large for lots that small. Also note that these R$$$ lots are not nearly as slope tolerant as their R$ & R$$ counterparts. Again, the large size of the lodges prevent their use on very steep zones. However, they will handle mild slopes fairly well... especially if the lower 2 rows of tiles are close to level. They are also designed to either level off the zone or not grow at all on zones that are too steep.  
+    **\*** In order to have growable lots specific to the Mountain Theme, we have used 2x5, 3x5 & 5x5 custom lot sizes. Ordinary, game-default RES lots will not grow on custom lots of this size. The player must create these custom sized zones... which is easy to do by holding down the CTRL key while using the mouse to drag out the zone size.
+
+    Because larger, custom lot sizes are required, several cabins are spaced out on the lot to represent several homes occupying the area. The resident values have been adjusted upwards to reflect the number of homes on each lot.
+
+    Additionally, these lots are designed to accommodate the sloped terrain of mountainous areas. Most of the cabin models are designed with extended foundations that merge into sloped terrain.... so instead of a building on top of a concrete block, you get cabins that merge realistically into the  hillside.
+
+    The lots use random building & prop families so the cabins will always be different on each lot. The cabins also use the  new  Random Smoke feature... so you will see smoke coming from their chimneys at different times of the day.
+
+    **\*\* This lot requires the following dependencies:  
+    [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**  
+    **[PEG\-MTP Mountain Trails - Rec Pack 1](https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made dep linkys clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5f261502a665b64f9dbaf2fe143db941-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5f261502a665b64f9dbaf2fe143db941-product_image2.jpg
+dependencies:
+  - peg:mtp-mountain-trails-rec-pack-1
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-high-wealth-growable-res-lodges
+
+---
+assetId: peg-mtp-high-wealth-growable-res-lodges
+version: "1.1"
+lastModified: "2025-02-08T15:45:23Z"
+url: https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/?do=download&r=205628

--- a/src/yaml/peg/14241-mtp-urgent-care-clinic.yaml
+++ b/src/yaml/peg/14241-mtp-urgent-care-clinic.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: mtp-urgent-care-clinic
+version: "1.1"
+subfolder: 630-health
+info:
+  summary: MTP Urgent Care Clinic
+  description: |-
+    Next on the **MTP** Hit Parade is this small, Urgent Care Clinic designed for use in remote, mountainous & rural areas. As with all MTP civic 'alternatives', it has an expanded coverage range to more realistically represent the type of coverage provided in large, sparsely populated areas.
+
+    All other properties are identical to the game's default medical clinic. The lot remains at the default 1x2 lot size... and should be plopped  on fairly flat land for best appearance.
+
+    The model is 'nite-lited' and contains some interior detailing. The lot uses the random cabin smoke prop and introduces a new custom parking lot texture.
+
+    **\*\* This lot requires the following dependency: [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14241-peg-mtp-urgent-care-clinic/
+  images:
+    - https://www.simtropolis.com/objects/screens/0016/89ce0ee241b487d9d33b50105affbf89-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0016/89ce0ee241b487d9d33b50105affbf89-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-urgent-care-clinic
+
+---
+assetId: peg-mtp-urgent-care-clinic
+version: "1.1"
+lastModified: "2025-02-08T17:05:04Z"
+url: https://community.simtropolis.com/files/file/14241-peg-mtp-urgent-care-clinic/?do=download&r=205666

--- a/src/yaml/peg/14250-mtp-old-school-house.yaml
+++ b/src/yaml/peg/14250-mtp-old-school-house.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: mtp-old-school-house
+version: "1.1"
+subfolder: 620-education
+info:
+  summary: MTP Old School House
+  description: |-
+    Bringing new meaning to the modern term, "Old School"... this **Old School House** was designed for the **MTP** and can be used in any mountainous or rural area. This small elementary school is typical of thousands of  schools built in remote communities... some well over 100 years ago. Many are still in operation today.
+
+    The Old School House sits on a slightly larger lot; 2x3 as opposed to 2x2. It is a functional alternative to the game's default small/elementary school. It share's the same costs, capacities and other properties... except for coverage range, which has been increased significantly to more realistically represent the larger areas that schools in remote communities cover. Ideally, we would also have reduced the number of students it could handle.... but the game makes it non-functional if the capacity is altered.
+
+    The lot also features modified playground props that appear several times per day instead of just once. You will see lots of activity & play before school starts, during lunch recess, and after school.
+
+    The school itself will handle a modest degree of slope. However, the playground props will not so the lot should be plopped on a prepared site of fairly level land.
+
+    **\*\* This lot requires the following dependency: [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **The [PEG One Flag - Many Nations Mod](https://community.simtropolis.com/files/file/27711-peg-one-flag-many-nations-mod/) is required to display the  
+    national flag of your choice. Without it, no flag will be displayed.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14250-peg-mtp-old-school-house/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5d2b9dceeaa744565c013803d2eff12d-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5d2b9dceeaa744565c013803d2eff12d-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+  - peg:one-flag-many-nations
+assets:
+  - assetId: peg-mtp-old-school-house
+
+---
+assetId: peg-mtp-old-school-house
+version: "1.1"
+lastModified: "2025-02-08T16:54:06Z"
+url: https://community.simtropolis.com/files/file/14250-peg-mtp-old-school-house/?do=download&r=205656

--- a/src/yaml/peg/14379-mtp-santas-village-alternate-audio.yaml
+++ b/src/yaml/peg/14379-mtp-santas-village-alternate-audio.yaml
@@ -1,0 +1,79 @@
+group: peg
+name: santas-village-alternate-audio
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: Santas Village Alternate Audio
+  description: |-
+    This package contains four alternate background music sound effect files for the ***[PEG Santa's Village](https://community.simtropolis.com/files/file/30651-peg-santas-village/)*** lot. These are the sound effects that are played when you scroll near the lot... as if the music was playing from loud speakers in the Village... not the game's default background music.
+
+    The four files are:
+
+    1.PEG\-MTP\_SV-AUDIO2\_GM-JB.dat
+
+    *\*Swing version of*
+
+    ***Jingle Bells***
+
+    *by Glenn Miller*  
+     
+
+    2.PEG\-MTP\_SV-AUDIO3\_CB-LFC.dat
+
+    *\***Looking for Christmas***
+
+    *by Clint Black. Not very upbeat but it sure is pretty.*  
+     
+
+    3.PEG\-MTP\_SV-AUDIO4\_NSP-SR.dat
+
+    *\***Sleigh Ride***
+
+    *by the Nashville SuperPickers. Yee Haw!!*  
+     
+
+    4.PEG\-MTP\_SV-AUDIO5\_JTTW.dat
+
+    *\* **Joy To The World***
+
+     *(Instrumental)*
+
+    The install will place all four files into the default PEG Santa's Village folder. These are Highlander files... "There Can Be Only One!  
+    You must remove which ever AUDIO files, including the default AUDIO installed with the lot, that don't want to use. You can easily sample the various songs by just switching the files.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here.](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**
+
+    ***Have a Very, Merry Christmas !!!***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14379-peg-mtp-santas-village-alternate-audio/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/dffe5a729dea48ed55a0df252fdb1eeb-product_image.jpg
+dependencies:
+  - peg:santas-village
+variants:
+  - variant: { peg:santas-village:audio: jingle-bells }
+    assets:
+      - assetId: peg-mtp-santas-village-alternate-audio
+        include:
+          - /PEG-MTP_SV-AUDIO2_GM-JB.dat
+  - variant: { peg:santas-village:audio: looking-for-christmas }
+    assets:
+      - assetId: peg-mtp-santas-village-alternate-audio
+        include:
+          - /PEG-MTP_SV-AUDIO3_CB-LFC.dat
+  - variant: { peg:santas-village:audio: sleigh-ride }
+    assets:
+      - assetId: peg-mtp-santas-village-alternate-audio
+        include:
+          - /PEG-MTP_SV-AUDIO4_NSP-SR.dat
+  - variant: { peg:santas-village:audio: joy-to-the-world }
+    assets:
+      - assetId: peg-mtp-santas-village-alternate-audio
+        include:
+          - /PEG-MTP_SV-AUDIO5_JTTW.dat
+
+---
+assetId: peg-mtp-santas-village-alternate-audio
+version: "1.1"
+lastModified: "2025-02-08T17:02:52Z"
+url: https://community.simtropolis.com/files/file/14379-peg-mtp-santas-village-alternate-audio/?do=download&r=205664

--- a/src/yaml/peg/14586-mtp-no-roadway-junk-mod.yaml
+++ b/src/yaml/peg/14586-mtp-no-roadway-junk-mod.yaml
@@ -1,0 +1,34 @@
+group: peg
+name: mtp-no-roadway-junk-mod
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: MTP No Roadway Junk MOD
+  description: |-
+    Designed for use with the MTP, rural themed or industrial cities, this mod removes all the "roadway junk" from streets, roads, on-way roads and avenues. This "junk" includes mailboxes, benches, trees, flower planters... and most of the other small props that line the sidewalks in the city.
+
+    Most of these little props look great in a large urban city or even in "the burbs"...  but they look out of place in a rural, mountainous, or industrial city. The mod was originally designed to compliment the mods that removed sidewalks for the MTP... but it can be useful anywhere you don't want those big city props cluttering up your sidewalks.
+
+    The mod removes all sidewalk props, except for people props and the fire hydrants,  which are appropriate for all types of cities. Also, all street lights have been replaced with the more rural/industrial looking wooden pole street lights. For the avenues, all the center barriers & foliage have been removed. This provides a more realistic look for rural themed cities.
+
+    The mod is broken down into 4 separate files; one each for streets, roads, one-way roads and avenues. After installation, you can easily remove any of the files you do not wish to use. For example, if you like the way the mod works for your streets and roads, but prefer to keep your avenues the way they are, just remove the files for the avenues.
+
+    Collectively, these mods remove a substantial number of props from your city. Depending on the power of your computer system, the size of the city and the detail level selected, you may experience a notable performance increase.
+
+    IMPORTANT:  Because the mod changes props on the network tiles, you will not notice any changes on existing roadways until you re-plop them. Fortunately, re-plopping just a single roadway tile will often update a very large area... so you do not have to re-plop all your roadways. Also, the roadways will update automatically any time there is growth or a change in a nearby zoned tile.
+
+    **\*\* This mod has no dependencies and is designed for use with the [MTP Mountain Theme Pack](https://community.simtropolis.com/files/category/35-mtp-mountain-theme-pack/) .**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14586-peg-mtp-no-roadway-junk-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0015/874be37b5933639e505a4901d3881624-product_image-MOD.jpg
+assets:
+  - assetId: peg-mtp-no-roadway-junk-mod
+
+---
+assetId: peg-mtp-no-roadway-junk-mod
+version: "1.1"
+lastModified: "2025-02-08T16:51:48Z"
+url: https://community.simtropolis.com/files/file/14586-peg-mtp-no-roadway-junk-mod/?do=download&r=205654

--- a/src/yaml/peg/14620-mtp-rural-roadways-mod.yaml
+++ b/src/yaml/peg/14620-mtp-rural-roadways-mod.yaml
@@ -1,0 +1,35 @@
+group: peg
+name: mtp-rural-roadways-mod
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: MTP Rural Roadways Mod
+  description: |-
+    Add a new and more rustic/rural look to your cities with the Rural Roadways Mod. Designed for use with the MTP but certainly useful in any city where you'd rather have a slightly less developed look, this mod changes the appearance of your streets and roads in several ways.
+
+    For starters, all sidewalks are removed and replaced with dirt edges or shoulders. In place of the wealth/density generated colored sidewalks & grassy parkways, the streets and roads themselves now change to match the surrounding wealth. Intersections change from having simple stop lines in non-developed and low density areas... to having crosswalks in medium wealth/density zones... and brick in-laid crosswalks in the upscale areas.
+
+    For the streets, you now have three options to choose from for the lowest wealth/density zones which include the streets around farmlands. You have the choice of asphalt streets,  gravel roads or dirt roads. Again, these are only in the lowest wealth/density zones so the normal asphalt streets will still appear in normally developed areas. Its almost like adding a new street/road type.
+
+    The mod is broken down into several files so you can easily choose which features you want installed. Streets and roads are broken down into 2 basic files so you can install either one... or both. For both the road & street mods, there are separate & optional "No Text" mods which removes the "STOP" text from the intersections. Obviously, if you live in a Spanish speaking country you would prefer to have El Stoppo or whatever the Spanish word for 'stop' is. In France, "Ceasez-Vous" might be preferable... although a tad hard to squeeze into the limited space. The No-Text mod simply removes the text... the next best thing.
+
+    For the streets, the default mod uses asphalt streets in all wealth & density zones. The optional Dirt & Gravel mods change only the type of street used in undeveloped, low wealth/density & farmland zones. The Dirt streets really look great in and around farms but have a more abrupt transition to paved surfaces. The Gravel roads blend well with all other roadway types and work best in areas where the road surface type changes frequently.
+
+    \* For optimum effect, it is recommended that the *RoadsNoGrass.dat file from the* **Swamper77** [Street and Road Sidewalk Mod](https://community.simtropolis.com/files/file/11674-street-and-road-sidewalk-mod/) also be installed. Swamper's mod will remove the sidewalks from the diagonal road tiles... which the Rural Roadways mod does not cover.
+
+    **\*\* This mod has no dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14620-peg-mtp-rural-roadways-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0015/817ac9f032726af2d1f88815d00917fd-product_image1.jpg
+    - https://www.simtropolis.com/objects/screens/0015/817ac9f032726af2d1f88815d00917fd-product_image2.jpg
+assets:
+  - assetId: peg-mtp-rural-roadways-mod
+
+---
+assetId: peg-mtp-rural-roadways-mod
+version: "1.1"
+lastModified: "2025-02-08T17:01:12Z"
+url: https://community.simtropolis.com/files/file/14620-peg-mtp-rural-roadways-mod/?do=download&r=205661

--- a/src/yaml/peg/14809-mtp-scenic-views.yaml
+++ b/src/yaml/peg/14809-mtp-scenic-views.yaml
@@ -1,0 +1,35 @@
+group: peg
+name: mtp-scenic-views
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Scenic Views
+  description: |-
+    "Down in the valley... the valley so low.   Hang your head over.... Let your lunch go!!"
+
+    By request... we have added 4 new MTP style lots to add along your remote roadways or incorporate into your Mountain Trail system. These scenic look-outs will add an extra realistic feel to your blossoming mountainous and rural regions. No detail has been "overlooked" \[drum hit\]... including the prerequisite stone mounted plaque (recycled ranger station sign) that always recounts that here, on this spot, at some time, long ago, someone, did something note worthy. Thus, the plaque!
+
+    The lots are designed to be plopped along the top of moderately steep cliffs. The viewing decks will extend over the edge  and their foundations/supports will blend in with the face of the cliff. There are 4 lots in total; 2 for use with the PEG Mountain Trails and 2 for general use along any roadways. Additionally, there are 2 different styles of viewing decks; a standard straight deck and an "L" shaped deck for use on corners. The straight decks are part of a random prop family that includes 5 different styles of  foundations/supports.
+
+    Most of the lots provide some sort of rest-stop/picnic facilities. The straight roadside lot features an asphalt parking area that is transit enabled for a seamless connection to any adjacent roadway. All of the lots are very similar to a normal Mountain Trail lot with mild park & landmark properties and very little monthly maintenance costs. Lot sizes range from 1x1 to 2x2.
+
+    \* The 2 different types of lots, Roadside & Mountain Trail, are contained in separate files so can easily remove either one if you choose not to use it. The Mountain Trail lots will appear in the Parks Menu, along with the other Mountain Trail lots. The roadside lots will appear in the Misc. Transportation Menu below the MTP Parking Lot lots..
+
+    **\*\* This file requires the following dependency:** [PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14809-peg-mtp-scenic-views/
+  images:
+    - https://www.simtropolis.com/objects/screens/0007/3290f30934ff476be4b189b76ea03df8-product_image1.jpg
+    - https://www.simtropolis.com/objects/screens/0007/3290f30934ff476be4b189b76ea03df8-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-scenic-views
+
+---
+assetId: peg-mtp-scenic-views
+version: "1.1"
+lastModified: "2025-02-08T16:42:54Z"
+url: https://community.simtropolis.com/files/file/14809-peg-mtp-scenic-views/?do=download&r=205648

--- a/src/yaml/peg/14810-mtp-sway-bridge.yaml
+++ b/src/yaml/peg/14810-mtp-sway-bridge.yaml
@@ -1,0 +1,34 @@
+group: peg
+name: mtp-sway-bridge
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: MTP Sway Bridge
+  description: |-
+    This latest addition to the MTP allows you to extend your Pine Trail over narrow canyons and ravines with the classic (and always scarier than Hell) Sway or Rope bridge. Yes, now you too can have one of those rickety old rope bridges you've seen in almost every adventure movie.
+
+    The actual lot is a 1x1 Pine Trail section that includes an offset rendered rope bridge that extends out and crosses any 3 tile wide canyon. (1 level wide at the bottom, plus the 2 sloped tiles). On the opposite side, the bridge will visually connect with any other normal Pine Trail lot.
+
+    You do not have to worry about any fussy terrain editing as the bridge will accommodate canyons of any height... provided that the total span is 3 tiles wide. The readme file includes some basic terrain editing tips for those who are unfamiliar with it.
+
+    As the bridge is actually just an extended prop, you can plop anything you want under the bridge. It will not interfere with road or rail traffic and looks especially good spanning rivers and streams. Vicious, man-eating Crocodiles not included.
+
+    **\*\* This file requires the following dependency:**   
+    **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14810-peg-mtp-sway-bridge/
+  images:
+    - https://www.simtropolis.com/objects/screens/0004/1baabfb99dc6c4c3b4fd0fa9a926343b-product_image1.jpg
+    - https://www.simtropolis.com/objects/screens/0004/1baabfb99dc6c4c3b4fd0fa9a926343b-product_image2.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-sway-bridge
+
+---
+assetId: peg-mtp-sway-bridge
+version: "1.1"
+lastModified: "2025-02-08T16:44:43Z"
+url: https://community.simtropolis.com/files/file/14810-peg-mtp-sway-bridge/?do=download&r=205651

--- a/src/yaml/peg/15794-mtp-res-replacement-mod.yaml
+++ b/src/yaml/peg/15794-mtp-res-replacement-mod.yaml
@@ -1,45 +1,47 @@
-group: peg
-name: mtp-res-replacement-mod
-version: "1.1"
-subfolder: 200-residential
-info:
-  summary: MTP RES Replacement Mod
-  description: |-
-    This is the first complete or "Mondo" Mod for the **MTP** that completely replaces the game's default Residential Lots with Mountainous/Rural versions designed for the MTP Theme. **Every** game-default Residential lot has been modified or replaced with MTP styled lots and buildings. Similar to a new tile set, this mod goes beyond by actually changing the appearance of the lots as well and giving your game a completely different look.
+# Something's wrong with the R$ part of this mod. The lots don't reference the 
+# proper buildings apparently.
+# group: peg
+# name: mtp-res-replacement-mod
+# version: "1.1"
+# subfolder: 200-residential
+# info:
+#   summary: MTP RES Replacement Mod
+#   description: |-
+#     This is the first complete or "Mondo" Mod for the **MTP** that completely replaces the game's default Residential Lots with Mountainous/Rural versions designed for the MTP Theme. **Every** game-default Residential lot has been modified or replaced with MTP styled lots and buildings. Similar to a new tile set, this mod goes beyond by actually changing the appearance of the lots as well and giving your game a completely different look.
 
-    Like SimMars, the **MTP** is a full, new **Theme** for your game. And with the new Start-Up Manager, playing multiple themes is no longer a nasty chore of having to manually rename and remove files & folders. That means you can easily switch between your normal cities and regions and any new Theme, like the MTP.
+#     Like SimMars, the **MTP** is a full, new **Theme** for your game. And with the new Start-Up Manager, playing multiple themes is no longer a nasty chore of having to manually rename and remove files & folders. That means you can easily switch between your normal cities and regions and any new Theme, like the MTP.
 
-    The MTP is being released in bits & pieces as they become available. This will allow you to easily choose which components to install or not. You also will not have to wait until the entire theme is complete in order to enjoy it. In its entirety, the MTP Theme will completely change the appearance of your game as well as how you play it.
+#     The MTP is being released in bits & pieces as they become available. This will allow you to easily choose which components to install or not. You also will not have to wait until the entire theme is complete in order to enjoy it. In its entirety, the MTP Theme will completely change the appearance of your game as well as how you play it.
 
-    To conserve game resources, game-default props and buildings have been re-used wherever possible, Still, scores of new props & textures and no less than 20 new, custom residential buildings have been included in this mod. In total, the mod includes **over 330 new residential lots** that replace the game-default lots.
+#     To conserve game resources, game-default props and buildings have been re-used wherever possible, Still, scores of new props & textures and no less than 20 new, custom residential buildings have been included in this mod. In total, the mod includes **over 330 new residential lots** that replace the game-default lots.
 
-    **\*\* This mod was authored by Pegasus & BarbyW.**
+#     **\*\* This mod was authored by Pegasus & BarbyW.**
 
-    **\*\* This mod requires the following dependency:**
+#     **\*\* This mod requires the following dependency:**
 
-    **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+#     **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
 
-    **Also required are the 3 PEG\-MTP Growable RES Mods:**  
-    [PEG\-MTP Growable Low Wealth RES](https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/)  
-    [PEG\-MTP Growable Medium Wealth RES](https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/)  
-    [PEG\-MTP Growable High Wealth RES](https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/)
+#     **Also required are the 3 PEG\-MTP Growable RES Mods:**  
+#     [PEG\-MTP Growable Low Wealth RES](https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/)  
+#     [PEG\-MTP Growable Medium Wealth RES](https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/)  
+#     [PEG\-MTP Growable High Wealth RES](https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/)
 
-    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
-  author: Pegasus
-  website: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/
-  images:
-    - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image1.jpg
-    - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image2.jpg
-dependencies:
-  - peg:mtp-high-wealth-growable-res-lodges
-  - peg:mtp-low-wealth-growable-res-cabins
-  - peg:mtp-mid-wealth-growable-res-aframes
-  - peg:mtp-super-pack
-assets:
-  - assetId: peg-mtp-res-replacement-mod
+#     **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+#   author: Pegasus
+#   website: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/
+#   images:
+#     - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image1.jpg
+#     - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image2.jpg
+# dependencies:
+#   - peg:mtp-high-wealth-growable-res-lodges
+#   - peg:mtp-low-wealth-growable-res-cabins
+#   - peg:mtp-mid-wealth-growable-res-aframes
+#   - peg:mtp-super-pack
+# assets:
+#   - assetId: peg-mtp-res-replacement-mod
 
----
-assetId: peg-mtp-res-replacement-mod
-version: "1.1"
-lastModified: "2025-02-08T15:49:17Z"
-url: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/?do=download&r=205631
+# ---
+# assetId: peg-mtp-res-replacement-mod
+# version: "1.1"
+# lastModified: "2025-02-08T15:49:17Z"
+# url: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/?do=download&r=205631

--- a/src/yaml/peg/15794-mtp-res-replacement-mod.yaml
+++ b/src/yaml/peg/15794-mtp-res-replacement-mod.yaml
@@ -1,0 +1,45 @@
+group: peg
+name: mtp-res-replacement-mod
+version: "1.1"
+subfolder: 200-residential
+info:
+  summary: MTP RES Replacement Mod
+  description: |-
+    This is the first complete or "Mondo" Mod for the **MTP** that completely replaces the game's default Residential Lots with Mountainous/Rural versions designed for the MTP Theme. **Every** game-default Residential lot has been modified or replaced with MTP styled lots and buildings. Similar to a new tile set, this mod goes beyond by actually changing the appearance of the lots as well and giving your game a completely different look.
+
+    Like SimMars, the **MTP** is a full, new **Theme** for your game. And with the new Start-Up Manager, playing multiple themes is no longer a nasty chore of having to manually rename and remove files & folders. That means you can easily switch between your normal cities and regions and any new Theme, like the MTP.
+
+    The MTP is being released in bits & pieces as they become available. This will allow you to easily choose which components to install or not. You also will not have to wait until the entire theme is complete in order to enjoy it. In its entirety, the MTP Theme will completely change the appearance of your game as well as how you play it.
+
+    To conserve game resources, game-default props and buildings have been re-used wherever possible, Still, scores of new props & textures and no less than 20 new, custom residential buildings have been included in this mod. In total, the mod includes **over 330 new residential lots** that replace the game-default lots.
+
+    **\*\* This mod was authored by Pegasus & BarbyW.**
+
+    **\*\* This mod requires the following dependency:**
+
+    **[PEG MTP Super Pack](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **Also required are the 3 PEG\-MTP Growable RES Mods:**  
+    [PEG\-MTP Growable Low Wealth RES](https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/)  
+    [PEG\-MTP Growable Medium Wealth RES](https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/)  
+    [PEG\-MTP Growable High Wealth RES](https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image1.jpg
+    - https://www.simtropolis.com/objects/screens/0003/0ceefe632de17a93341b07c74c38fa7b-product_image2.jpg
+dependencies:
+  - peg:mtp-high-wealth-growable-res-lodges
+  - peg:mtp-low-wealth-growable-res-cabins
+  - peg:mtp-mid-wealth-growable-res-aframes
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-res-replacement-mod
+
+---
+assetId: peg-mtp-res-replacement-mod
+version: "1.1"
+lastModified: "2025-02-08T15:49:17Z"
+url: https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/?do=download&r=205631

--- a/src/yaml/peg/30651-santas-village.yaml
+++ b/src/yaml/peg/30651-santas-village.yaml
@@ -1,0 +1,44 @@
+group: peg
+name: santas-village
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Santa's Village
+  description: |-
+    This non-conditional reward is a special Christmas gift from the staff & members at Pegasus Production to you and the entire SC4 Community. Like so many of the ***Santa's Villages*** that exist in mountain areas, our Village mixes tourist trap with amusement park... and theme-related shopping. Its all here... the shops, the rides, the reindeer petting zoo, the Polar Express train ride... and, of course, the kids running crazy on sugar highs and natural adrenalin fueled by the expectation of spending a little suck-up time with Santa.
+
+    This sprawling 10x10 lot was designed for use with the **MTP**. Its a reward... but also offers over 600 jobs to your local residents. Its transit enabled, of course... and puts on quite a light show at night. In fact, its only fair to warn you that between the lights and the seasonal background music, you just might find yourself getting sucked-in while spending long periods reliving Christmases Past & imagining that you are there.
+
+    The lot was too large & complex for the BAT so it was assembled modular style with numerous models designed to fit together. Still, considering its size & complexity, the overall file size and resource usage is fairly small. One of the advantages of modular design is the repeated use of models to conserve game resources.
+
+    For some reason, the snow never seems to melt around Santa's Village. Some say they have refrigeration coils buried in the ground... while others suspect that they truck it in from higher elevations each night. The kids, of course, believe otherwise. But however it gets there, it sure is a popular attraction during the warmer summer months.
+
+    \* The snow texture matches the PEG\-MTP Snow Mod textures.... but does not require that mod. The snow texture on the lot remains year-round, even without the Snow Mod installed.
+
+    **\*\* This lot requires the following dependencies:**
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp\-super-pack/](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    **and the** **PEG Christmas Development Pack:**
+
+    [https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/](https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+
+    ***From the Staff & Crew at Pegasus Productions...  
+    Have a Very, Merry Christmas !!!***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/30651-peg-santas-village/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2015_07/product_image.jpg.cd50d7bc2461c0c316e6a4f631bc58b4.jpg
+dependencies:
+  - peg:christmas-development-kit
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-santas-village
+
+---
+assetId: peg-santas-village
+version: "1.0"
+lastModified: "2015-07-10T23:32:23Z"
+url: https://community.simtropolis.com/files/file/30651-peg-santas-village/?do=download&r=158202

--- a/src/yaml/peg/4515-mtp-seasonal-woods.yaml
+++ b/src/yaml/peg/4515-mtp-seasonal-woods.yaml
@@ -1,0 +1,70 @@
+group: peg
+name: mtp-seasonal-woods
+version: "2.0.8"
+subfolder: 660-parks
+info:
+  summary: MTP Seasonal Woods
+  description: |-
+    Prepare for the onslaught as hoards of Leafers besiege your city every Fall to take in the beauty of the Autumn leaves. The Seasonal Woods lots are very similar to the PEG Random Woods... except these trees change with the seasons. Winter, Spring, Summer & Fall... the trees change to reflect the time of year in your cities. The Seasonal Woods also shuns the game's default "lolly-pop" trees and introduces 18 new BATed trees for greater realism.
+
+    The Seasonal Woods provides you with a fast & flexible means of adding realistic woodlands to your cities and surrounding rural areas. The Seasonal Woods randomly generates different types of trees as you plop the lot. This eliminates the need of constantly rotating the lot when plopping for a random look... and provides a more natural & realistic look when covering large areas.
+
+    The Seasonal Woods includes 4 new lots: A 1x1 lot with full ground texture. A 2x2 lot with full ground texture. A 1x1 lot with transparent ground texture. A 2x2 lot with transparent ground texture.
+
+    The Random Forest is PEG tested & Tree-Hugger approved. Each lot has properties similar to a small green park with slightly improved air pollution qualities. This lot is also 'Slope Conforming' so you can place it almost anywhere.
+
+    \*\* This lot was designed for seamless integration with the PEG Trail Parks and the PEG Stream Kit. Obviously, it can be used by itself, singularly or in groups, anywhere in your cities where you need a little flourish of flora.
+
+    \*\*\* This is a **MTP** complian update (the former v207 aka MTP Patch) which now has the version number **v208** to the former PEG Seasonal Woods (\_206). It is a complete update of the product and it is a replacement of the original/previous version. This update will replace the former *PEG\_Seasonal-Tree-Pack\_206b.dat* file which contains the 18 original tree models with a new **PEG\_Seasonal-Tree-Pack\_208.dat**.
+
+    \*\*\*\* Bear in mind, that the former Seasonal Woods v2.07 (aka MTP Patch Update) has not been available officially since the original SIMPEG site went down and that particular version was never re-hosted on the Simtropolis Exchange. This v2.08 version replaces both the original v2.06 version (which was still available on STEX until this current update, that effectively replaces it on the download site) and the v2.07 version, which was only available on the original SIMPEG site.
+
+    Installing this pack will install two new versions of the original files containing the lot data. The files...
+
+    ***PEG\_Seasonal-Woods\_208.dat*** and ***PEG\_Seasonal-Woods-t\_208.dat***
+
+    ...will be installed to a new installation path: **PEGPROD/Mountain Theme Pack/Seasonal Woods/**. The previous versions of these files...
+
+    ***PEG\_Seasonal-Woods\_206a.dat*** and ***PEG\_Seasonal-Woods-t\_206a.dat***
+
+    ***PEG\_Seasonal-Woods\_207.dat*** and ***PEG\_Seasonal-Woods-t\_207.dat***
+
+    and the ***PEG\_Seasonal-Tree-Pack\_206b.dat***
+
+    ...**must then be manually deleted**. (you will likeley find them in the *PEGPROD/Seasonal Woods/* location.
+
+    This new version reduces the collective YIMBY effects of the lots in order to avoid blowing over any caps. It also replaces the previous two base and overlay textures with the new, single blended base texture used throughout the new PEG Mountain Theme. This will allow the Seasonal Woods lots to blend better with other MTP lots. Also, the reduction of the extra texture on lots used repeatedly, such as these, can have a notable reduction in game resource usage.
+
+    The textured versions of these lots will need to be re-plopped before the new texture will be visible. However, you can do this anytime you wish as the older version textures are still supported and will function and appear normally in the game. Previously plopped transparent version lots do not need to be re-plopped.
+
+    **\*\* BE SURE TO REMOVE THE OLDER VERSION FILES WHEN UPGRADING \*\***
+
+    **Installation**:
+
+    copy/extract the **PEGPROD** parent folder into your Plugins. If you extracted the ~*Documents* folder into your plugins, too, it's highly recommended to keep it, but move it out of the Plugins folder.
+
+    If any earlier version(s) of this file exist, they should be deleted.
+
+    This product contains three .DAT files; one for each style of lot and one for the tree prop and model dependnecies. After installation, you can delete either one of the LOT files if you prefer to play with only one of the styles but you must keep the **PEG\_Seasonal-Tree-Pack\_208.dat** file.
+
+    **Dependencies**:
+
+    **[PEG\-MTP MTP SUPER-PACK v1.5](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **\*\*All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested** ***[Pegasus Productions Support Site](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)***
+
+    ***This v2.08 update was made by Tyberius06 (on the behalf of Pegasus)***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4515-peg-mtp-seasonal-woods-v208/
+  images:
+    - https://www.simtropolis.com/objects/screens/0028/fe3f12ba258a7384a446b96957480326-product_image.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-seasonal-woods-v208
+
+---
+assetId: peg-mtp-seasonal-woods-v208
+version: "2.0.8"
+lastModified: "2025-01-29T09:25:24Z"
+url: https://community.simtropolis.com/files/file/4515-peg-mtp-seasonal-woods-v208/?do=download&r=205494

--- a/src/yaml/peg/4523-pine-forest.yaml
+++ b/src/yaml/peg/4523-pine-forest.yaml
@@ -32,3 +32,6 @@ assetId: peg-pine-forest
 version: "1.0"
 lastModified: "2004-10-24T01:01:12Z"
 url: https://community.simtropolis.com/files/file/4523-peg-pine-forest/?do=download&r=29233
+archiveType:
+  format: Clickteam
+  version: "20"

--- a/src/yaml/peg/4523-pine-forest.yaml
+++ b/src/yaml/peg/4523-pine-forest.yaml
@@ -1,0 +1,34 @@
+group: peg
+name: pine-forest
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Pine Forest
+  description: |-
+    Very similar to the [PEG Random Woods](https://community.simtropolis.com/files/file/4526-peg-random-woods-v206/) lots, the Pine Forest collection focuses on a look more suitable for mountain areas and higher elevations.
+
+    It also uses new BAT modeled trees for greater realism than provided by the in-game trees. Like the Random Woods lots, the Pine Forest includes multiple styles with a 1x1 & 2x2 lot for each style.
+
+    In addition to the fully textured ground and transparent ground styles, a third semi-transparent style is included. The semi transparent style is easily the best looking and most flexible to use... but is effected by the game's graphics overlay bug. It is included only for those players who are willing to deal with this issue. (see Developers Notes Below)
+
+    The Pine Forest is PEG tested & Tree-Hugger approved. Each lot has properties similar to a small green park with slightly improved air pollution qualities.
+
+    These lots are also 'Slope Conforming' so you can place them almost anywhere.
+
+    **\*\*This file currently contains an .exe installer suitable for windows users.  These files are in the process of being updated with zip files and this message will be removed once the update is complete.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Added linky to mentioned file.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4523-peg-pine-forest/
+  images:
+    - https://www.simtropolis.com/objects/screens/0020/b091d3284a831806ca24b4187b700954-product_image.jpg
+assets:
+  - assetId: peg-pine-forest
+
+---
+assetId: peg-pine-forest
+version: "1.0"
+lastModified: "2004-10-24T01:01:12Z"
+url: https://community.simtropolis.com/files/file/4523-peg-pine-forest/?do=download&r=29233

--- a/src/yaml/peg/4526-mtp-random-woods.yaml
+++ b/src/yaml/peg/4526-mtp-random-woods.yaml
@@ -1,0 +1,47 @@
+group: peg
+name: mtp-random-woods
+version: "2.0.8"
+subfolder: 660-parks
+info:
+  summary: MTP Random Woods
+  description: |-
+    This is a **MTP** compliant update to the PEG Random Woods lots which provides a fast & flexible means of adding realistic woodlands to your cities and surrounding rural areas. The Random Woods are ploppable lots, in 1x1 & 2x2 sizes, that blend together to form large, wooded forests. They are fully slope conforming and can be plopped almost anywhere. Their YIMBY effects have also been reduce substantially to avoid blowing out caps.
+
+    Two versions are included... one with transparent textures which allow the game's natural terrain to show through... and a textured version that uses the new MTP Forest Floor texture and blends well with other MTP lots. The two versions are included in separate files so after installation, you can remove either one if you do not intend to use that style.
+
+    **UPDATING LOTS FROM PREVIOUS VERSIONS**
+
+    The transparent texture lots are not affected by this update. However, the textured versions will not show any changes until they are bulldozed and re-plopped. You can do this at any time... even after the files have been updated. The old version remains fully supported and functional so you can replace them at you leisure.  
+      
+    \*\* These lot were originally designed for seamless integration with the PEG Trail Parks and the PEG Stream Kit. Obviously, they can be used by themselves, singularly or in groups, anywhere in your cities where you need a little flourish of flora.
+
+    **\*\* BE SURE TO REMOVE THE OLDER VERSION FILES WHEN UPGRADING \*\***
+
+    **Installation**:
+
+    copy/extract the **PEGPROD** parent folder into your Plugins. If you extracted the ~*Documents* folder into your plugins, too, it's highly recommended to keep it, but move it out of the Plugins folder.
+
+    If any earlier version(s) of this file exist, they should be deleted.
+
+    **Dependencies**:
+
+    **[PEG\-MTP MTP SUPER-PACK v1.5](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)**
+
+    **\*\*All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested** ***[Pegasus Productions Support Site](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)***
+
+    ***This v2.08 update was made by Tyberius06 (on the behalf of Pegasus)***
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4526-peg-mtp-random-woods-v208/
+  images:
+    - https://www.simtropolis.com/objects/screens/0006/2ac8a76943603e922d27c9553c800ffa-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2025_01/product_image_001-mtp.jpg.6826cc4f1b055626332ab4b8aa787171.jpg
+dependencies:
+  - peg:mtp-super-pack
+assets:
+  - assetId: peg-mtp-random-woods-v208
+
+---
+assetId: peg-mtp-random-woods-v208
+version: "2.0.8"
+lastModified: "2025-01-29T09:29:02Z"
+url: https://community.simtropolis.com/files/file/4526-peg-mtp-random-woods-v208/?do=download&r=205496

--- a/src/yaml/peg/4530-rtk3-watertreatment-plant.yaml
+++ b/src/yaml/peg/4530-rtk3-watertreatment-plant.yaml
@@ -1,0 +1,45 @@
+group: peg
+name: rtk3-watertreatment-plant
+version: "1.1"
+subfolder: 500-utilities
+info:
+  summary: RTK3 WaterTreatment Plant
+  description: |-
+    This is the updated BAT version of the original RTK Water Pump & Processing Plant. It has been modified for use with the new RTK3.
+
+    This lot is wider than the original, has been transit enabled, and contains numerous new BAT models. Other relevant specifications remain the same. This is a RTK3 Specific Lot. This lot must be placed on a river or coastal bank that conforms to the RTK3 specification.
+
+    Its time to upgrade your antiquated water pumps and water purification plants to these modern & efficient, all-in-one Water Reclamation plants. Powered by clean natural gas and utilizing recent breakthroughs in water processing and reclamation technologies, these facilities can suck up filthy river or sea water and process it into palatable drinking water for your thirsty Sims.
+
+    This is a hybrid lot combining the capabilities of 2 1/2 water pumps and a water purification plant into one truly functional facility. This is not a mere combination lot... but a true blending of multiple functions. The custom query will show stats and efficiencies for both water supply and water reclamation... yet you will notice there is only one, rather large underground water connector.
+
+    All properties have been adjusted to reflect realistic comparative values in the game. The comparative plop cost is slightly reduced as you get a discount for buying in bulk. The monthly budget costs are also slightly reduced to reflect the newer, more economical technology employed and the cost savings of a centralized facility.
+
+    The lot size (5x5) is also notably smaller than the 6x7 water purification plant lot... making this facility much easier to place.
+
+    Water Produced: 50,000 cu m/month  
+    Water Treated: 2,400 cu m/month
+
+    **Dependency**
+
+    [bldgprop\_vol1.dat](https://community.simtropolis.com/library/maxis/sc4/buildings/bldgprop_vol1.dat)
+
+    **Note:** DataNode reveals a prop exemplar 0x2DDB7010 which is unidentified. Following an investigation we've determined this is insignificant to the aesthetics and functionality of the lot. However if anyone has any clues what this other dep is, please contact a staff member or reply [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/?do=findComment&comment=1699079).
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Added missing dep linky and note about the missing prop exemplar.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4530-peg-rtk3-watertreatment-plant-v206/
+  images:
+    - https://www.simtropolis.com/objects/screens/0016/8d7ee368376ea459acda1759dc71847f-product_image.jpg
+dependencies:
+  - t-wrecks:maxis-prop-names-and-query-fix
+assets:
+  - assetId: peg-rtk3-watertreatment-plant-v206
+
+---
+assetId: peg-rtk3-watertreatment-plant-v206
+version: "1.1"
+lastModified: "2025-02-08T17:54:44Z"
+url: https://community.simtropolis.com/files/file/4530-peg-rtk3-watertreatment-plant-v206/?do=download&r=205680


### PR DESCRIPTION
This PR adds bunch of Peg's content, most notably from the Mountain Theme Pack.

Note: we had to exclude the https://community.simtropolis.com/files/file/15794-peg-mtp-res-replacement-mod/ because apparently it is broken. The R$ lots seem to reference the wrong building exemplars.