### PR TITLE
fix: handle uploads without names

### DIFF
--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -48,7 +48,7 @@ export default async function handleUpload(json, opts = {}) {
 	if (
 		!json.files ||
 		json.files.length === 0 ||
-		json.files.some(file => file.name === null || file.link)
+		json.files.some(file => file.name === null || file.name === undefined)
 	) {
 		return {
 			skipped: true,

--- a/actions/fetch/handle-upload.js
+++ b/actions/fetch/handle-upload.js
@@ -48,7 +48,7 @@ export default async function handleUpload(json, opts = {}) {
 	if (
 		!json.files ||
 		json.files.length === 0 ||
-		json.files.some(file => file.name === null)
+		json.files.some(file => file.name === null || file.link)
 	) {
 		return {
 			skipped: true,


### PR DESCRIPTION
Apparently the recent publishing of the [NAM](https://community.simtropolis.com/files/file/35417-network-addon-mod-lite-nam-lite-cross-platform/) broke the channel because the upload doesn't contain a file name. We already properly handled `file.name === null`, but in this case it's simply not present.