### PR TITLE
fix: crash on empty dependencies

### DIFF
--- a/actions/fetch/stylize-doc.js
+++ b/actions/fetch/stylize-doc.js
@@ -30,7 +30,7 @@ export default function stylize(doc) {
 
 		// If there's only 1 dependency, inline it - typically for SimFox day and nite.
 		let deps = variant.get('dependencies', true);
-		if (deps && deps.items.length < 2) {
+		if (deps && deps.items.length === 1) {
 			deps.flow = true;
 			deps.get(0, true).type = 'QUOTE_DOUBLE';
 		}


### PR DESCRIPTION
Apparently the channel crashes on the `metadata.yaml` file from [this upload](https://community.simtropolis.com/files/file/36757-dsc-elrail-glasgow-subway-tram-version/). It should be noted that the metadata.yaml is horribly, horribly wrong, but still, the channel should not crash on it and create the PR.