### PR TITLE
fix: use sc4pac user agent

### DIFF
--- a/actions/fetch/downloader.js
+++ b/actions/fetch/downloader.js
@@ -49,7 +49,9 @@ export default class Downloader {
 		}
 
 		// If we reach this point, we perform a fresh download.
-		const headers = {};
+		const headers = {
+			'User-Agent': 'sc4pac/0.6',
+		};
 		const { SC4PAC_SIMTROPOLIS_TOKEN: token } = process.env;
 		if (token) {
 			headers.Authorization = `SC4PAC-TOKEN-ST userkey="${token}"`;


### PR DESCRIPTION
Apparently we have to set the `User-Agent` to sc4pac, otherwise the authentication token isn't properly recognized and we risk running into `429 Too Many Requests` errors.

@noah-severyn Related to #192 