### PR TITLE
feat: add test script for plopping all installed lots

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "sc4pac": "node --env-file=.env scripts/sc4pac.js",
     "prune": "node --env-file=.env scripts/prune.js",
     "symlink": "node --env-file=.env scripts/symlink.js",
+    "plop": "node --env-file=.env scripts/plop-all.js",
     "list": "node scripts/list-dependencies.js",
     "fetch": "gh workflow run add-packages.yaml",
     "deploy": "gh workflow run deploy.yaml",

--- a/scripts/plop-all.js
+++ b/scripts/plop-all.js
@@ -1,0 +1,42 @@
+// # plop-all.js
+// Helper script for easily plopping all lots of a specified pattern. It allows 
+// the user to specify the default test city in an .env variable so that the 
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import standardDeps from './standard-deps.js';
+
+// command doesn't need to be remembered all the time.
+const { argv } = yargs(hideBin(process.argv));
+const bbox = process.env.TEST_PLOP_BBOX;
+let command = 'sc4 city plop --clear';
+if (bbox) {
+	command += ` --bbox ${bbox}`;
+}
+command += ` "${process.env.TEST_PLOP_CITY}"`;
+if (argv._.length > 0) {
+	for (let pattern of argv._) {
+		command += ` ${pattern}`;
+	}
+} else {
+
+	// If no patterns were specified, then we simply use all plugins that were 
+	// installed. Note that is different than using `*:*` because that one will 
+	// also plop anything that's present in a dependency!
+	const { explicit } = JSON.parse(
+		String(fs.readFileSync('./dist/plugins/sc4pac-plugins.json')),
+	);
+	const plugins = explicit.filter(plugin => {
+		return !standardDeps.includes(plugin);
+	}).join(' ');
+	command += ` ${plugins}`;
+
+}
+console.log(`> ${command}`);
+cp.execSync(command, {
+	stdio: 'inherit',
+	env: {
+		FORCE_COLOR: true,
+	},
+});

--- a/scripts/sc4pac.js
+++ b/scripts/sc4pac.js
@@ -37,6 +37,14 @@ const packages = glob
 // Always add a bunch of dependencies that come in handy when testing.
 packages.push(...standardDeps);
 
+// Find out what channels we add on top of the default ones. This is useful if 
+// you're using dependencies that are not yet available in the default channel, 
+// so you can use a locally built version of the default channel.
+const channels = (process.env.STANDARD_CHANNELS ?? '')
+	.split(',')
+	.map(channel => channel.trim())
+	.filter(Boolean);
+
 // Now generate the sc4pac-plugins.json file.
 const pluginsRoot = path.resolve(import.meta.dirname, '../dist/plugins');
 const cacheRoot = process.env.SC4PAC_CACHE_ROOT;
@@ -49,6 +57,7 @@ const json = {
 			...standardVariants,
 		},
 		channels: [
+			...channels,
 			'https://memo33.github.io/sc4pac/channel/',
 			pathToFileURL(path.resolve(import.meta.dirname, '../dist/channel'))+'/',
 		],


### PR DESCRIPTION
This PR adds a new script that helps with plopping all installed lots of the test plugins folder. Typically you had to manually type

```
sc4 city plop --clear --bbox 32,32,64,128 "Region/City - test city.sc4" group:name-*
```

all the time. This can now be automated by simply running

```
npm run plop
```

The test city and the default bounding box can be specified in your .env file:

```env
TEST_PLOP_CITY="Plopall/City - Ploptest.sc4"
TEST_PLOP_BBOX="32,32,48,128"
```

If the bbox environment is not defined, the entire city will be used.

The command will also automatically detect all packages that are installed, so no need to specify them anymore. Still, if you only want to plop a specific package, you can run

```
npm run plop -- group:name group:name-wildcard*
```

@noah-severyn This might be of interest to you.

As a recap, this means that the workflow of adding & testing packages is now:

```sh
npm run add <url>
npm run build

# If you suspect the dependencies are not correct - for example all the bsc dependencies
# have been added, then you can prune everything first. Typically not needed if the 
# package dependencies look ok straight away
npm run prune <patterns...>

# Symlinking the test plugins folder typically only needs to be done once
npm run symlink

npm run plop
```