### PR TITLE
metadata: add Oidaas' content

### DIFF
--- a/permissions.yaml
+++ b/permissions.yaml
@@ -1,6 +1,21 @@
+# By default, you can only publish a package under your own account name as group.
+# This file lists alternative groups or prefixes an author is permitted to upload
+# under. These prefixes are automatically stripped when creating package names.
+# Example for permissions for specific packages.
+# authors:
+#   - name: Aaron Graham
+#     id: 226625
+#     groups:
+#       - nybt
+
 # For now, everyone is allowed to include their package on the channel, but if
 # it turns out that people are abusing this, then they might be blocked from the 
 # channel. This can be done by including them here, and then blocking them.
+# Example for blocking someone
+# authors:
+#   - id: 1234
+#     blocked: true
+
 authors:
   - name: Pegasus
     id: 2813
@@ -46,6 +61,10 @@ authors:
     prefixes:
       - ndex
       - blam
+  - name: Oidaas
+    id: 64713
+    prefixes:
+      - esa
   - name: SimFox
     id: 71768
     prefixes:
@@ -145,15 +164,3 @@ authors:
     id: 744613
     prefixes:
       - rr
-
-# Example for permissions for specific packages.
-# authors:
-#   - name: Aaron Graham
-#     id: 226625
-#     groups:
-#       - nybt
-
-# Example for blocking someone
-# authors:
-#   - id: 1234
-#     blocked: true

--- a/scripts/sc4d.js
+++ b/scripts/sc4d.js
@@ -81,6 +81,7 @@ export default {
 	2687: 'girafe:cattails',
 	2711: 'girafe:bushes',
 	2740: 'girafe:norway-maples',
+	2756: 'bsc:mega-props-jmyers-common-props',
 	2758: 'girafe:parasol-pines',
 	2768: 'bsc:bat-props-mattb325-vol03',
 	2770: 'girafe:subalpine-firs',

--- a/src/yaml/krio/27588-columbia-railway-station.yaml
+++ b/src/yaml/krio/27588-columbia-railway-station.yaml
@@ -1,0 +1,60 @@
+group: krio
+name: columbia-railway-station
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Columbia Railway Station
+  description: |-
+    **Columbia Railway Station** is a fictional railway station, build in 30's Finnish funkis-style. I made this bat in December 2008, so it's quite old ![:D](https://community.simtropolis.com/assets/emoticons/LlamaGrin.gif)
+
+    Station has 2 rail connections with three platforms. Fourth rail is a pass-by only, which is very common in Finland. Due to its small size its perfect for suburban areas or to small towns. Because I made this in 2008, it was re-lotted recently by *Master Paeng* because originally this was designed on my laptop which has been dead for a year soon. Station still has some of it original lotting, platforms, electricity pylons and blue timetables are props from me.
+
+    STATS
+
+    Lot Size: 3x4
+
+    Plop cost: 200 §
+
+    Capacity: 4 000
+
+    Dependacies
+
+    Krio Station props (included)
+
+    [Porkie Props Vol 01](https://www.simtropolis.com/forum/files/file/11421-porkie-props-vol1-european-street-accessories/)
+
+    BATting by Krio, Lotting by Krio and Paeng.
+
+    Every train hit the walls in [Krioworks](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/forum/index.php?topic=6097.0)
+  author: Krio, Paeng
+  website: https://community.simtropolis.com/files/file/27588-columbia-railwaystation/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_05_2012/038da8e169a117c6b3a4c6827b3ed195-.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_05_2012/d30963dfb68fe9a7694823adbe338b56-.jpg
+dependencies:
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - krio:rail-props
+assets:
+  - assetId: krio-columbia-railwaystation
+    exclude:
+      - "/KRIO_Rail_Props.dat"
+
+---
+group: krio
+name: rail-props
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Columbia Railwaystation
+  author: Krio
+  website: https://community.simtropolis.com/files/file/27588-columbia-railwaystation/
+assets:
+  - assetId: krio-columbia-railwaystation
+    include:
+      - "/KRIO_Rail_Props.dat"
+
+---
+assetId: krio-columbia-railwaystation
+version: "1.0"
+lastModified: "2012-05-10T17:25:10Z"
+url: https://community.simtropolis.com/files/file/27588-columbia-railwaystation/?do=download&r=100674

--- a/src/yaml/krio/28021-viipuri-railway-station.yaml
+++ b/src/yaml/krio/28021-viipuri-railway-station.yaml
@@ -1,0 +1,73 @@
+group: krio
+name: viipuri-railway-station
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: Viipuri Railway Station
+  description: |-
+    **Viipuri Railway Station** is partial recreation of old Viipuri (Vyborg) railway station which was destroyed during the WW2 by retreating Soviet forces in 1941. Viipuri was Finland's second largest city before the war and Viipuri station was one of the largest railway stations in the country. It was designed by Eliel Saarinen, man who also designed Helsinki Central Railway Station.
+
+    The tracks were running "on the second floor" and it has a separate lounge for the passengers, but I didn't include it in my version and that's why I'm not sure what the facade facing the platform looked like.
+
+    During the Winter War station and railyard was hit by bombs and after the war the station with the rest of the city were ceded to Soviet Union. When fighting continued in 1941 retreating soviets decided to blow up the station buildings with the railyard so that Finnish-German forces couldn't use it. During the liberation era Finnish didn't have time to repair the building and after WW2 soviets replaced the station with a new one.
+
+    STATS:
+
+    Lot size: 6x6
+
+    Plop cost: 1 500§
+
+    Capacity: 20 000
+
+    Dependencies:
+
+    BSC Textures vol.1 and vol.2
+
+    [Porkie props vol.1](https://community.simtropolis.com/files/file/11421-porkie-props-vol1-european-street-accessories/)
+
+    [Krio railway-props from Columbia Station](https://community.simtropolis.com/files/file/27588-columbia-railwaystation/)
+
+    [Krio Small Prop pack](https://community.simtropolis.com/files/file/28016-krio-small-prop-pack/)
+
+    BAT, Lot and modding by Krio, TE'ing by *paeng*
+
+    Visit [Krioworks](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/forum/index.php?topic=6097.new#new) for new updates and feedback.
+  author: Krio
+  website: https://community.simtropolis.com/files/file/28021-viipuri-railwaystation/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/32519f9839af8cfdd88f077ee57791ef-viipuri01.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/20d0fae4dd4214ce1f194a6ea6f0646b-viipuri01c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/d047b9c5ec6cf315b5745d47b0070dd0-viipuri01b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/108b14dc145b329a3c358aeedcfde292-viipuri01d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/eb7688d233f717772c343dacdde9fddc-wiipuri212.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_09_2012/ba7e3d1a1a020c611c9a0e9be04c1aa5-wiipuri213.jpg
+dependencies:
+  - krio:rail-props
+  - krio:small-prop-pack
+  - krio:viipuri-railway-station-resources
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - bsc:textures-vol02
+assets:
+  - assetId: krio-viipuri-railwaystation
+    include:
+      - "/Viipuri Railwaystation_1d5e853b.SC4Lot"
+
+---
+group: krio
+name: viipuri-railway-station-resources
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: Viipuri Railway Station models and props
+  author: Krio
+  website: https://community.simtropolis.com/files/file/28021-viipuri-railwaystation/
+assets:
+  - assetId: krio-viipuri-railwaystation
+    exclude:
+      - "/Viipuri Railwaystation_1d5e853b.SC4Lot"
+
+---
+assetId: krio-viipuri-railwaystation
+version: "1.0"
+lastModified: "2012-09-14T17:09:42Z"
+url: https://community.simtropolis.com/files/file/28021-viipuri-railwaystation/?do=download&r=106232

--- a/src/yaml/laky99/34596-bus-pack-hd.yaml
+++ b/src/yaml/laky99/34596-bus-pack-hd.yaml
@@ -1,0 +1,35 @@
+group: laky99
+name: bus-pack-hd
+version: "1.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Bus Pack HD
+  description: |-
+    This is a bus pack HD for your modern cities. Pack includes long distance buses with different bus models. I didn't created new models. Just reskinned models with new liveries.
+
+    Textures are HD quality - 1024x1024. It is highly recommended to play the game in hardware mode.
+
+    List includes following liveries:
+
+    -   Eurolines
+    -   FlixBus
+    -   Jabbar Bus
+    -   JetBus
+    -   LeoExpress
+    -   Lufthansa Airport Express
+    -   Polski Bus
+    -   Regiojet
+
+    [![buses.jpg](https://www.simtropolis.com/objects/attachments/monthly_2021_07/buses.jpg.1e0bc5df98d82429d1cab19f08abc28b.jpg)](https://www.simtropolis.com/objects/attachments/monthly_2021_07/buses.jpg.1e0bc5df98d82429d1cab19f08abc28b.jpg)
+  author: Laky99
+  website: https://community.simtropolis.com/files/file/34596-bus-pack-hd/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_07/buses.jpg.aaba841b331a3c56872317bc7250e9a2.jpg
+assets:
+  - assetId: laky99-bus-pack-hd
+
+---
+assetId: laky99-bus-pack-hd
+version: "1.0.0"
+lastModified: "2021-07-18T12:41:41Z"
+url: https://community.simtropolis.com/files/file/34596-bus-pack-hd/?do=download&r=189342

--- a/src/yaml/mikeseith/22109-1960s-maxis-automata-replacement-modd.yaml
+++ b/src/yaml/mikeseith/22109-1960s-maxis-automata-replacement-modd.yaml
@@ -1,0 +1,64 @@
+group: mikeseith
+name: 1960s-maxis-automata-replacement-modd
+version: "1.0"
+subfolder: 710-automata
+info:
+  summary: 1960s Maxis Automata Replacement Modd
+  description: |-
+    Dig it.
+
+    Send your cities back to the 1960s with my newest automata set.  Forget the Assasinations, civil unrest and veitnam.  Just concentrate on how groovy those cars from the 60s look.  These are cars from the peak of the American automotive industry (in my humble opinion).  Believe it or not, I worked on this modd on and off for three years.  Now for the info.
+
+    Peace
+
+    This mod contains 121 UDI drivable cars for your cities and 120 commercial and residential car clusters.  All cars have custom night lighting.
+
+    Just unzip
+
+    60s family props.dat     - This is the file with the cars that are parked in front of houses and buildings in your city
+
+    and
+
+    1960s Maxis cars replacement mod.dat     -This is the file with the UDI drivable automata
+
+    **No dependencies needed**
+
+    Files that you might consider downloading also:
+
+    [Driveable Checker Taxis](https://community.simtropolis.com/files/file/3679-driveable-checker-taxis/)
+
+    [Chevy Impala 1967 Automata](https://community.simtropolis.com/files/file/12364-chevy-impala-1967-automata/) that I did a few years back
+
+    **\-Cori edit:** Fixed broken linkys.
+  author: mikeseith
+  website: https://community.simtropolis.com/files/file/22109-1960s-maxis-automata-replacement-modd/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/c148c6262a51d227b8f124decfb58adf-60s front jpg.JPG
+    - https://www.simtropolis.com/objects/screens/0021/c148c6262a51d227b8f124decfb58adf-60s back jpg.JPG
+assets:
+  - assetId: mikeseith-1960s-maxis-automata-replacement-modd
+    include:
+      - "/1960s Maxis cars replacement mod.dat"
+
+---
+group: mikeseith
+name: 1960s-automobile-props
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: 1960s automobile props by mikeseith
+  author: mikeseith
+  website: https://community.simtropolis.com/files/file/22109-1960s-maxis-automata-replacement-modd/
+  images:
+    - https://www.simtropolis.com/objects/screens/0021/c148c6262a51d227b8f124decfb58adf-60s front jpg.JPG
+    - https://www.simtropolis.com/objects/screens/0021/c148c6262a51d227b8f124decfb58adf-60s back jpg.JPG
+assets:
+  - assetId: mikeseith-1960s-maxis-automata-replacement-modd
+    include:
+      - "/60s family props.dat"
+
+---
+assetId: mikeseith-1960s-maxis-automata-replacement-modd
+version: "1.0"
+lastModified: "2009-07-25T13:20:21Z"
+url: https://community.simtropolis.com/files/file/22109-1960s-maxis-automata-replacement-modd/?do=download&r=48345

--- a/src/yaml/oidaas/33574-vastra-skolan.yaml
+++ b/src/yaml/oidaas/33574-vastra-skolan.yaml
@@ -1,0 +1,57 @@
+group: oidaas
+name: vastra-skolan
+version: "1.0.0"
+subfolder: 620-education
+info:
+  summary: Vastra Skolan
+  description: |-
+    Vastra skolan
+
+    This is a school from my hometown, nowadays used as an gymnasium, before that it was used as an elementary school.
+
+    **Dependencies**
+
+    Edit (forgot to add one more dependency)
+
+    BSC MEGA Props CP Vol01 (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    BSC - VIP girafe birches (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2620](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2620)
+
+    BSC Mega Props - JES Vol09 (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2349](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2349)
+
+    SFBT
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    Peg MTP Superpack
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33574-vastra-skolan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_04/5ea9586c925e0_vastrasida1.png.1e04f851a156344b6b306e65a9309b89.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_04/5ea958739573e_vastrasida2.png.20f0158aad509829b70293c7a9d2ef7b.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_04/5ea9587d17066_vastrasida.png.6b3a81cd90305d9e15f226181c87e65b.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_04/vastra.png.d3ec749cd5502b0787ca6aefa2d314b6.png
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-jes-vol02
+  - bsc:mega-props-jes-vol09
+  - girafe:birches
+  - peg:mtp-super-pack
+  - sfbt:essentials
+  - sfbt:sam-johnson-playground-props
+assets:
+  - assetId: oidaas-vastra-skolan
+
+---
+assetId: oidaas-vastra-skolan
+version: "1.0.0"
+lastModified: "2020-04-29T10:36:48Z"
+url: https://community.simtropolis.com/files/file/33574-vastra-skolan/?do=download&r=180856

--- a/src/yaml/oidaas/33585-towerpack.yaml
+++ b/src/yaml/oidaas/33585-towerpack.yaml
@@ -1,0 +1,91 @@
+group: oidaas
+name: towerpack
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Towerpack
+  description: |-
+    **About**
+
+    These are a couple of offices I've done a while back for variety to maxis content, hope you enjoy!
+
+    **Edit: Stats**
+
+    Dallas
+
+    Bulldoze Cost     810                                           
+    Pollution at center (13) Air (7) Water (26)Garbage (0)Radiation           
+    Pollution radii (6) Air (7)Water (0)Garbage (0)Radiation                   
+    Flammability     35                       
+    MaxFireStage     4                       
+    Power Consumed     22                       
+    Water Consumed     1141                                           
+    OccupantGroups     Building: Commercial Building: CO$$$       
+    Building Styles: Chicago/New York/Houston/Euro                                   
+    Occupant Types     CO$$     CO$$$                   
+    Building value     6014                       
+    Capacity Satisfied (769)CO-$$ (539)CO-$$$
+
+    Malmström & Wolff
+
+    Bulldoze Cost     999                       
+    Wealth     High Wealth                       
+    Pollution at center     (8) Air     (4) Water     (15) Garbage     (0) Radiation           
+    Pollution radios: (6)Air (7)Water (0)Garbage (0)Radiation  
+    Flammability     35                       
+    MaxFireStage     4                       
+    Power Consumed     13                       
+    Water Consumed     664                                            
+    OccupantGroups     Building: Commercial     Building: CO$$$       
+    Building Styles: Chicago/New York/Houston/Euro                       
+    Occupant Types     CO$$     CO$$$                   
+    Building value     3499                       
+    Capacity Satisfied (447)CO-$$ (314)CO-$$$
+
+    Midastornet
+
+    Bulldoze Cost     990                                           
+    Pollution at center     (9) Air     (4) Water     (17) Garbage     (0) Radiation               
+    Pollution radii     (6) Air     (7) Water     (0) Garbage     (0)Radiation           
+    Flammability     35                       
+    MaxFireStage     4                       
+    Power Consumed     15                       
+    Water Consumed     755                                           
+    OccupantGroups     Building: Commercial     Building: CO$$$       
+    Bulding Style: Chicago/New York/Houston/Euro                                   
+    Occupant Types     CO$$     CO$$$                   
+    Building value     3976                       
+    Capacity Satisfied (539)CO-$$ (357)CO-$$$
+
+    Torsgatan
+
+    Bulldoze Cost     999                                           
+    Pollution at center (8)Air (4) Water (15) Garbage (0)Radiation                   
+    Pollution radios (6) Air (7)Water (0)Garbage (0)Radiation                   
+    Flammability     35                       
+    MaxFireStage     4                       
+    Power Consumed     13                       
+    Water Consumed     664                                           
+    Occupant Groups     Building: Commercial Building: CO$$$  
+    Building Style: Chicago/New York/Houston/Euro                               
+    Occupant Types     CO$$     CO$$$                   
+    Building value     3498                       
+    Capacity Satisfied CO-$$ 447 CO-$$$ 314
+
+    **Dependecies**
+
+    None :-)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33585-towerpack/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_05/5ead93eb6ceb2_towerpack1.png.05b66d2ffa125a6021d64dce22f10b12.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_05/5ead93efe9184_towerpack2.png.7da0aa1785d2ab1843dfb7a83d8d6777.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_05/towerpack.png.90f4da3e99694fb63b7edf6e356652b4.png
+assets:
+  - assetId: oidaas-towerpack
+
+---
+assetId: oidaas-towerpack
+version: "1.0.0"
+lastModified: "2020-05-02T16:03:02Z"
+url: https://community.simtropolis.com/files/file/33585-towerpack/?do=download&r=180889

--- a/src/yaml/oidaas/33598-solskensvagen.yaml
+++ b/src/yaml/oidaas/33598-solskensvagen.yaml
@@ -1,0 +1,66 @@
+group: oidaas
+name: solskensvagen
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Solskensvägen
+  description: |-
+    **About**
+
+    This is an villa that i done a while back. This is based on a villa that was up for sale a while ago, i thought it looked stunning even though i tend to prefer older houses that one struck a cord with me. So i decided to make version of it. I took a few liberties, the chimneys are not in the original but i thought it would fit so i added them.
+
+    **Dependencies**
+
+    BSC MEGA props - CP Vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    BSC MEGA props - SG VOL 01[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=746](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=746)  
+    BSC - VIP girafe villa Libeskind (v1.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3071](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3071)  
+    Girafe Birches [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2620](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2620)  
+    Girafe Rowan [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3244](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3244)
+
+    LBT Mega props
+
+    [https://community.simtropolis.com/files/file/21770-lbt-mega-prop-pack-vol01/?do=embed](https://community.simtropolis.com/files/file/21770-lbt-mega-prop-pack-vol01/?do=embed)
+    PEG MTP Superpack
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+    SuperSHK MEGA Parking Textures
+
+    [https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed)
+    **Stats**
+
+    General Information  
+    Bulldoze Cost     97                       
+    Wealth     High Wealth                       
+    Pollution at center (0) Air (0) Water (1)Garbage (0) Radiation       
+    Pollution radii  (6) Air (7) Water (0) Garbage (0) Radiation           
+    Flammability     35                       
+    MaxFireStage     2                       
+    Power Consumed     2                       
+    Water Consumed     6                                       
+    OccupantGroups     Building: Residential     Building: R$$$     Style: Chicago     Style: New York Style: Houston     Style: Euro                               
+    Occupant Types     R$     R$$     R$$$               
+    Building value     547                       
+    Capacity Satisfied (36) R-$  (21) R-$$ (11) R-$$$
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33598-solskensvägen/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_05/solskensvagen.png.e2be61c60b0a06afc40f2fe9949e5fce.png
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-cp-vol02
+  - bsc:mega-props-sg-vol01
+  - bsc:textures-vol02
+  - girafe:birches
+  - girafe:hedges
+  - girafe:rowan-trees
+  - lbt:mega-prop-pack-vol01
+  - peg:mtp-super-pack
+  - supershk:mega-parking-textures
+assets:
+  - assetId: oidaas-solskensvagen
+
+---
+assetId: oidaas-solskensvagen
+version: "1.0.0"
+lastModified: "2020-05-14T15:04:21Z"
+url: https://community.simtropolis.com/files/file/33598-solskensv%C3%A4gen/?do=download&r=180958

--- a/src/yaml/oidaas/33619-proppack.yaml
+++ b/src/yaml/oidaas/33619-proppack.yaml
@@ -1,0 +1,22 @@
+group: oidaas
+name: proppack
+version: "1.0.2"
+subfolder: 100-props-textures
+info:
+  summary: ESA Proppack
+  description: |-
+    This is a prop pack containing several buildings I've made over the years for you to use as you wish.
+
+    Contains several houses, from 1700s to 1930 and outbuildings and fences.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33619-esa-proppack/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_05/5ecaa3766b15d_esaproppack.png.cc025a3137f647034b53ec4557484202.png
+assets:
+  - assetId: oidaas-proppack
+
+---
+assetId: oidaas-proppack
+version: "1.0.2"
+lastModified: "2021-05-05T03:05:15Z"
+url: https://community.simtropolis.com/files/file/33619-esa-proppack/?do=download&r=187780

--- a/src/yaml/oidaas/33637-1930-houses.yaml
+++ b/src/yaml/oidaas/33637-1930-houses.yaml
@@ -1,0 +1,49 @@
+group: oidaas
+name: 1930-houses
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: 1930 Houses
+  description: |-
+    **About**
+
+    This is a pack of buildings from 1930. They come in two versions, town and rural.
+
+    **Stats**
+
+    Bulldoze Cost     40                       
+    Wealth     Low Wealth                       
+    Pollution at center (0) Air (0)Water (0)Garbage (0)Radiation                   
+    Pollution radii  (5) Air (5) Water (0) Garbage (0) Radiation                   
+    Flammability     45                       
+    MaxFireStage     1                       
+    Power Consumed     1                       
+    Water Consumed     1                                       
+    OccupantGroups     Building: Residential     Building: R$ Style: Chicago Style: New York style: Houston Style: Euro                               
+    Occupant Types     R$                       
+    Building value     140                       
+    Capacity Satisfied (12)R-$
+
+    **Dependencies**
+
+    ESA Proppack
+
+    [https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed](https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed)
+    C.P MEGA props Vol 1
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33637-1930-houses/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_06/5ed8a60e0c84d_lotpict2.png.6e997605b0b3509bb36755a41726bf57.png
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - oidaas:proppack
+assets:
+  - assetId: oidaas-1930-houses
+
+---
+assetId: oidaas-1930-houses
+version: "1.0.0"
+lastModified: "2020-06-04T07:54:24Z"
+url: https://community.simtropolis.com/files/file/33637-1930-houses/?do=download&r=181312

--- a/src/yaml/oidaas/33677-ormen-lange.yaml
+++ b/src/yaml/oidaas/33677-ormen-lange.yaml
@@ -1,0 +1,63 @@
+group: oidaas
+name: ormen-lange
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Ormen Långe
+  description: |-
+    This is a residential building from the Swedish village of Svappavaara. It was designed by Ralph Erskine, who also designed the block "ortdrivaren" rough translating to miner cave builder (bad translation but hey). He also designed Shopping which is a shopping mall in my home town, in fact the fist indoor shopping center in the world. Ormen Långe got its name from a Viking ship found in Norway.
+
+    **Dependencies**
+
+    [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)  
+    [BSC TexturePack Cycledogg](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=101)  
+    [SFBT Essentials](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    **Stats**
+    |     |     |     |     |     |     |     |
+    | --- | --- | --- | --- | --- | --- | --- |
+    | **Item Name** | Ormen långe |     |     |     |     |     |
+    | **Item Description** | Ormen Lange by Ralph Erskine located in Svappavaara. |     |     |     |     |     |
+    | **Item Icon** | 0x00000000 |     |     |     |     |     |
+    | **Item Order** | 1   |     |     |     |     |     |
+    | **Plop Cost** | 110000 |     |     |     |     |     |
+    | **Bulldoze Cost** | 100 |     |     |     |     |     |
+    | **Wealth** | None |     |     |     |     |     |
+    | **Pollution at center** | Air | Water | Garbage | Radiation |     |     |
+    | 1   | 1   | 15  | 0   |     |     |
+    | **Pollution radii** | Air | Water | Garbage | Radiation |     |     |
+    | 1   | 2   | 0   | 0   |     |     |
+    | **Flammability** | 10  |     |     |     |     |     |
+    | **MaxFireStage** | 1   |     |     |     |     |     |
+    | **Power Consumed** | 60  |     |     |     |     |     |
+    | **Water Consumed** | 0   |     |     |     |     |     |
+    | **Mayor Rating Effect** | Magnitude | Radius |     |     |     |     |
+    | 10  | 256 |     |     |     |     |
+    | **Budget Item: Department** | Landmarks |     |     |     |     |     |
+    | **Budget Item: Line** | 0x00000000 |     |     |     |     |     |
+    | **Budget Item: Purpose** | Landmark Effect |     |     |     |     |     |
+    | **Budget Item: Cost** | 150 |     |     |     |     |     |
+    | **SFX:Query Sound** | 0x0a8c9ef0 |     |     |     |     |     |
+    | **SFX:Default Plop Sound** | 0x6a5ec589 |     |     |     |     |     |
+    | **Query exemplar GUID** | 0x2a56675c |     |     |     |     |     |
+    | **OccupantGroups** | Building: Landmark | Building: YIMBY | Building: Landmark Ogle |     |     |     |
+    | **Occupant Size** | Width | Height | Depth |     |     |     |
+    | 182 | 27.212 | 3   |
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/33677-ormen-långe/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2020_06/5ef9937a0ed4c_test-17Jun.001593405775.png.1937adde96588563a1fbfc891e475943.png
+    - https://www.simtropolis.com/objects/screens/monthly_2020_06/erskine.png.11db9794229bc1b25aa2d2a8d3d19223.png
+dependencies:
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:textures-vol03
+  - peg:mtp-super-pack
+  - sfbt:essentials
+assets:
+  - assetId: oidaas-ormen-lange
+
+---
+assetId: oidaas-ormen-lange
+version: "1.0.0"
+lastModified: "2020-06-29T07:24:38Z"
+url: https://community.simtropolis.com/files/file/33677-ormen-l%C3%A5nge/?do=download&r=181874

--- a/src/yaml/oidaas/34653-focushuset.yaml
+++ b/src/yaml/oidaas/34653-focushuset.yaml
@@ -1,0 +1,68 @@
+group: oidaas
+name: focushuset
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Focushuset
+  description: |-
+    **Focushuset**
+
+    This BAT is a recreation, not in a strict sense of the block Enitan (more commonly known as Focushuset). It was built in 1962 as a modernisation of Malmbergets city.  I've modded this as a Cs$ landmark with 2000 jobs. This is handy to soak up the endless Cs$ demand.
+
+    In regards to the scale i know this BAT is a bit underscaled. But since i cannot open the original BAT file this is TLA.
+
+    **Stats**
+
+    | Bulldoze Cost			       | 580			                  | 			        | 			         | 			          | 			         | 			 |
+    | Wealth			              | Low Wealth			           | 			        | 			         | 			          | 			         | 			 |
+    | Pollution at center			 | Air			                  | Water			         | Garbage			        | Radiation			       | 			         | 			 |
+    | 227			                 | 136			                  | 200			           | 0			              | 			          | 			         |
+    | Pollution radii			     | Air			                  | Water			         | Garbage			        | Radiation			       | 			         | 			 |
+    | 5			                   | 5			                    | 0			             | 0			              | 			          | 			         |
+    | Flammability			        | 45			                   | 			        | 			         | 			          | 			         | 			 |
+    | MaxFireStage			        | 4			                    | 			        | 			         | 			          | 			         | 			 |
+    | Power Consumed			      | 91			                   | 			        | 			         | 			          | 			         | 			 |
+    | Water Consumed			      | 848			                  | 			        | 			         | 			          | 			         | 			 |
+    | SFX:Query Sound			     | 0x2a8916ab			           | 			        | 			         | 			          | 			         | 			 |
+    | Query exemplar GUID			 | 0xca56783a			           | 			        | 			         | 			          | 			         | 			 |
+    | OccupantGroups			      | Building: Commercial			 | Building: CS$			 | Style: Chicago			 | Style: New York			 | Style: Houston			 | 			 |
+    | 			              | 			               | 			        | 			         | 			          | 			         |
+    | Style: Euro			         | 			               | 			        | 			         | 			          | 			         |
+    | Occupant Size			       | Width			                | Height			        | Depth			          | 			          | 			         | 			 |
+    | 124.872002			          | 55			                   | 39.632999			     | 			         | 			          | 			         |
+    | Occupant Types			      | CS$			                  | 			        | 			         | 			          | 			         | 			 |
+    | Building value			      | 34773			                | 			        | 			         | 			          | 			         | 			 |
+    | Capacity Satisfied			  | CS-$			                 | 			        | 			         | 			          | 			         | 			 |
+    | 4540			                |
+
+
+    **Dependencies**
+
+    [https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed](https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed)
+    BSC MEGA Props CP Vol01 (v1.0)  [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    SFBT Playground Props by Sam Johnson (v1.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2540](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2540)
+
+    [https://community.simtropolis.com/files/file/17578-blam-glenni-prop-pack/?do=embed](https://community.simtropolis.com/files/file/17578-blam-glenni-prop-pack/?do=embed)
+    SFBT Essentials (v1.0)  [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34653-esa-focushuset/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/611aff4c0bf92_test1-May.1001629152174.jpg.36ccd70462c152e25d7c9f7503ce0f8a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/611aff5675b31_test1-May.1001629152187.jpg.98dd7b01927a22431b970262554ea9e8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/611aff5eef35c_test1-May.1001629152393.jpg.8e7cad4fd16bcaa4af141261d8b2d3c1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/611aff65d6c43_test1-May.1001629152406.jpg.1a8933c4699089c6792bfd066f78923e.jpg
+dependencies:
+  - ndex:glenni-mega-props-vol01
+  - bsc:mega-props-cp-vol01
+  - mgb204:mmp-pack-vol2
+  - sfbt:essentials
+  - sfbt:sam-johnson-playground-props
+assets:
+  - assetId: oidaas-focushuset
+
+---
+assetId: oidaas-focushuset
+version: "1.0.0"
+lastModified: "2021-08-17T05:40:58Z"
+url: https://community.simtropolis.com/files/file/34653-esa-focushuset/?do=download&r=189758

--- a/src/yaml/oidaas/34662-funkis.yaml
+++ b/src/yaml/oidaas/34662-funkis.yaml
@@ -1,0 +1,47 @@
+group: oidaas
+name: funkis
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Funkis
+  description: |-
+    **ESA Funkis**
+
+    This is an fictional building modeled after a demolished building in my home town. This has been sitting on my harddrive for a while now so i thought why not release it. As with my previous release Focushuset it is a tad bit underscaled unfortunately. It comes in game as an CS$.
+
+    **Stats**
+
+    Lot size:2x2  
+    Growth stage: 4  
+    Zone type: low, med  
+    Bulldoze cost: 216  
+    capacity: cs$ 50  
+    Pollution center: Air: 6, Water: 3, Garbage: 83, Radioation:0  
+    Pollution radius: Air:5, Water:5, Garbage: 0, Radiation:0  
+    Power: 3  
+    Water:21  
+    Occupant groups: Houstion, Euro
+
+    **Now for the fun part..Dependencies**
+
+    BSCMegaProps JES Vol01 (v1.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=342](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+
+    [https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed](https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34662-esa-funkis/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/6127425b9a3f7_03-Apr.201731629960741.jpg.16e622f7e8a7be3917ca1730c7d9d83c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/6127425cd5cf8_03-Apr.201731629960755.jpg.138d39cb2ae9a79384e859b97d60a324.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/6127425e00e28_03-Apr.201731629960767.jpg.76b564be0493f8bebcdc9b10c51afa4f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/6127425f0520e_03-Apr.201731629960783.jpg.b955108fed750919fb2b6d718544d5d9.jpg
+dependencies:
+  - bsc:mega-props-jes-vol01
+  - oidaas:proppack
+assets:
+  - assetId: oidaas-funkis
+
+---
+assetId: oidaas-funkis
+version: "1.0.0"
+lastModified: "2021-08-26T08:06:47Z"
+url: https://community.simtropolis.com/files/file/34662-esa-funkis/?do=download&r=189824

--- a/src/yaml/oidaas/34665-kungsgatan.yaml
+++ b/src/yaml/oidaas/34665-kungsgatan.yaml
@@ -1,0 +1,51 @@
+group: oidaas
+name: kungsgatan
+version: "2.0.0"
+subfolder: 300-commercial
+info:
+  summary: Kungsgatan
+  description: |-
+    **ESA Kungsgatan**
+
+    This building is a mix between two separate buildings. The main building is heavily inspired by a building that was adjacent to a bus route i took when going from the university where i was studying. I took the top windows and the corner pillars from a building located next to the city hall in my home town.
+
+    For some reason i grew attached to the main building, i liked the coloring and the main structure. I was researching architectural styles of the north of Sweden at the time on a hobby basis. I grew attached to the architectural style of Finnish-russian empire style hence i decided to add the side pillars and top windows.
+
+    **Stats**
+
+    Lot size:2x2  
+    Growth stage: 3  
+    Zone type: low, med  
+    Bulldoze cost: 200  
+    Demand:CS$ 150 CS$$ 80  
+    Pollution center:Air 3 Water 2 Garbage 29 Radiation 0  
+    Pollution radius:Air 5 Water 6 Garbage 0 Radiation 0  
+    Power: 43  
+    Water: 4  
+    Occupant groups: Building Commercial, Building CS$$, Euro
+
+    **Dependencies**
+
+    BSCBATPropsMattb325\_Vol02 (v1.0)  [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2383](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2383)
+
+    Edit: my bad
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34665-esa-kungsgatan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/6128905319dad_03-Jun.91731630046717.jpg.84b35dc81c95e0f241abeda2da4ad50d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/612890626036f_03-Jun.91731630046708.jpg.bd792007f464dcf37244af27b7b74150.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/61289068a64db_03-Jun.91731630046697.jpg.5070c8e3b8ac996590b56b984ce30d58.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_08/612890890173d_03-Jun.91731630046727.jpg.a83d71474fde02159db1d110bf784f19.jpg
+dependencies:
+  - bsc:bat-props-mattb325-vol02
+  - peg:mtp-super-pack
+assets:
+  - assetId: oidaas-kungsgatan
+
+---
+assetId: oidaas-kungsgatan
+version: "2.0.0"
+lastModified: "2021-09-08T15:31:59Z"
+url: https://community.simtropolis.com/files/file/34665-esa-kungsgatan/?do=download&r=189973

--- a/src/yaml/oidaas/34677-coop.yaml
+++ b/src/yaml/oidaas/34677-coop.yaml
@@ -1,0 +1,62 @@
+group: oidaas
+name: coop
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Coop
+  description: |-
+    **Esa Coop**
+
+    This is an oldie that i made somewhere around 2008 ish. It was one of my first BATs i made when i was essentially in the basic learning of GMAX.  
+    Inspired by my remakes of old BATs i decided to update it to my current standards including mainly fixing the the texturing and some pf the splines.  
+    I liked the finished result so i decided to release it for you all to enjoy.
+
+    **Stats**
+
+    Lot size:5x5 3x5  
+    Growth stage: 4  
+    Zone type: low, med, high  
+    Bulldoze cost: 153  
+    Demand:CS$ 250, CS$$ 100  
+    Pollution center: Air 7 Water 5 Garbage 8 Radiation 0  
+    Pollution radius: Air 5 Water 6 Garbage 3 Radiation 0  
+    Power: 80  
+    Water: 138  
+    Occupant groups: Building commercial, Building CS$$, Houston
+
+    **Dependencies**
+
+    SFBT essentials  [https://www.sc4devotion.com/csxlex/lex\_filedesc.ph](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    [https://community.simtropolis.com/files/file/19096-ndex-glenni-mega-props-vol01/?do=embed](https://community.simtropolis.com/files/file/19096-ndex-glenni-mega-props-vol01/?do=embed)
+    Glenni Megaprops vol 1:
+
+    BSC - VIP girafe rowan trees (v1.0)  [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3244](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3244)
+
+    MGB Girafe flora
+
+    [https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed](https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed)
+    [https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed](https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34677-esa-coop/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_09/6131f0f62f598_coop3x51.jpg.34f7d31e2640744b881359a3c44371e4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_09/6131f0f8958d2_NewCity-Nov.51061630661522.jpg.a4d921fb15f1c8650a3ae4d27cb4100d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_09/6131f0f9c88b0_NewCity-Nov.51061630661540.jpg.b2cb2a15912348073bf8be195ca6368f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_09/6131f0fb10388_NewCity-Nov.51061630661551.jpg.b99782e2b5f4ba79e6647269a9fe5e03.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_09/6131f0fc33f32_NewCity-Nov.51061630661698.jpg.3c5ed95a8e3dbbad4e6977fe823dc4e1.jpg
+dependencies:
+  - girafe:rowan-trees
+  - mgb204:mmp-pack-vol2
+  - ndex:glenni-mega-props-vol01
+  - sfbt:essentials
+  - supershk:mega-parking-textures
+  - shk:parking-pack
+assets:
+  - assetId: oidaas-coop
+
+---
+assetId: oidaas-coop
+version: "1.0.0"
+lastModified: "2021-09-03T10:19:23Z"
+url: https://community.simtropolis.com/files/file/34677-esa-coop/?do=download&r=189915

--- a/src/yaml/oidaas/34777-rail-props-vol01.yaml
+++ b/src/yaml/oidaas/34777-rail-props-vol01.yaml
@@ -1,0 +1,28 @@
+group: oidaas
+name: rail-props-vol01
+version: "1.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Rail prop pack
+  description: |-
+    This is an prop pack i've compiled over the years.
+
+    It contains several different station, platforms, Freight stations, misc props.
+
+    Some have nightlight others have not. This is because of the fact that several of the stations are abandoned. I've also rendered the most of the props in diagonal perspective.
+
+    Anyhow enjoy!
+
+    [![Gällivare fardig perspektiv.jpg](https://www.simtropolis.com/objects/attachments/monthly_2021_12/61af313ab3327_Gllivarefardigperspektiv.jpg.f4912bc66ca0382d36f0f1ba6f40dcab.jpg)](https://www.simtropolis.com/objects/attachments/monthly_2021_12/61af313ab3327_Gllivarefardigperspektiv.jpg.f4912bc66ca0382d36f0f1ba6f40dcab.jpg)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/61af305740495_ESARailpackpic.jpg.183a6ad28f45823897938480a60ad4a0.jpg
+assets:
+  - assetId: oidaas-rail-prop-pack
+
+---
+assetId: oidaas-rail-prop-pack
+version: "1.0.0"
+lastModified: "2024-08-10T10:20:21Z"
+url: https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=download&r=202364

--- a/src/yaml/oidaas/34789-railway-stations-vol1.yaml
+++ b/src/yaml/oidaas/34789-railway-stations-vol1.yaml
@@ -1,0 +1,147 @@
+group: oidaas
+name: railway-stations-vol1
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: Railway stations vol 1
+  description: |-
+    ESA Railpack vol 1
+
+    This is a bunch of railway stations from the Swedish ore line.
+
+    stats
+
+    \----------------
+
+    Gallivare
+
+    lot size:2x4  
+    Demand:jobs $:25, jobs $$:12, jobs $$$ 8, R$:50, R$$: 24, R$$$:16  
+    Occupant Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger:2000
+
+    Boden
+
+    lotsize:4x2  
+    Demand:jobs $:25, jobs $$:12, jobs $$$ 8, R$:50, R$$: 24, R$$$:16  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger:2000
+
+    Gulltrask
+
+    lot size:2x2  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Nasberg
+
+    lotsize:3x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Koskivaara
+
+    lotsize:3x2  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Gransjo
+
+    lotsize:2x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Ljusa
+
+    lotsize:3x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Polcirkeln
+
+    lot size:2x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Nourtikon  
+    lotsize:2x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    Sandtrask
+
+    lotsize.2x1  
+    Demand:Jobs $:6, jobs $$:4, jobs $$$ 2, R$:12, R$$:8, R$$$:4  
+    Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger: 1000
+
+    \----------------------------
+
+    Dependencies  
+    ESA Railpack
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+    Historic Harbour
+
+    [https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed](https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed)
+
+    # 1960s Maxis Automata Replacement Modd
+
+    [https://community.simtropolis.com/files/file/22109-1960s-maxis-automata-replacement-modd/?do=embed](https://community.simtropolis.com/files/file/22109-1960s-maxis-automata-replacement-modd/?do=embed)
+    PEG MTP Super pack
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+    BSC MEGA Props CP Vol01 (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    SFBT essentials  [https://www.sc4devotion.com/csxlex/lex\_filedesc.ph](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    MGB Girafe flora
+
+    [https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed](https://community.simtropolis.com/files/file/31285-mgb-mmp-pack-vol2/?do=embed)
+    Glenni BLAM
+
+    [https://community.simtropolis.com/files/file/17578-blam-glenni-prop-pack/?do=embed](https://community.simtropolis.com/files/file/17578-blam-glenni-prop-pack/?do=embed)
+    I'd think thats all :-p
+
+    \---------------------------
+
+    Installation
+
+    Simply extract the folder to plugins :-)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34789-esa-railway-stations-vol-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/61bd78ff637b4_test-Jun.17001639803284.jpg.8c8121b96ea7868ff619b3628fdb1140.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/nitelite.jpg.370f06f53084a73671b90ad700ecada3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/61bd790ca2795_test-Jun.17001639803270.jpg.8c4ec30719670f0e79fe2f5ce8da602d.jpg
+dependencies:
+  - ndex:glenni-mega-props-vol01
+  - mikeseith:1960s-automobile-props
+  - bsc:mega-props-cp-vol01
+  - historic-harbor:dependencies
+  - mgb204:mmp-pack-vol2
+  - oidaas:rail-props-vol01
+  - peg:mtp-super-pack
+  - sfbt:essentials
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - bsc:mega-props-jes-vol03
+  - bsc:mega-props-newmaninc-vol02
+  - bsc:mega-props-swi21-vol01
+assets:
+  - assetId: oidaas-railway-stations-vol1
+
+---
+assetId: oidaas-railway-stations-vol1
+version: "1.0.0"
+lastModified: "2022-02-25T06:39:45Z"
+url: https://community.simtropolis.com/files/file/34789-esa-railway-stations-vol-1/?do=download&r=191472

--- a/src/yaml/oidaas/34806-railpack-the-diagonals-vol1.yaml
+++ b/src/yaml/oidaas/34806-railpack-the-diagonals-vol1.yaml
@@ -1,0 +1,49 @@
+group: oidaas
+name: railpack-the-diagonals-vol1
+version: "1.0.1"
+subfolder: 700-transit
+info:
+  summary: Railpack the diagonals vol 1
+  description: |-
+    **About**
+
+    This is the diagonal versions of the stations i release earlier. They come with diagonal platforms that are lot based so you can build the platforms how long you want.
+
+    The platforms comes in two flavours, tiles and gravel.
+
+    **Stats**
+
+    Lotsize: 1x1
+
+    Demand:jobs $:12, jobs $$:6, jobs $$$ 1  
+    Occupant Groups:Building:Transportation,Rail,Strikable,PassengerRail  
+    Passenger:1000
+
+    **Installation**
+
+    Simply drop the files in your plugin folder :-)
+
+    Edit: Forgot the dependencies :-)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1806](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1806)
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34806-esa-railpack-the-diagonals-vol-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/61c4097a5ac20_NewCity-Apr.19001640236593.jpg.af58337e8b5b77c2a92866531d313328.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_12/61c4097ff19d8_NewCity-Apr.19001640237254.jpg.aace6bbe904b66cd0a82fa3c102737b6.jpg
+dependencies:
+  - bsc:textures-vol03
+  - oidaas:rail-props-vol01
+  - sfbt:essentials
+assets:
+  - assetId: oidaas-railpack-the-diagonals-vol1
+
+---
+assetId: oidaas-railpack-the-diagonals-vol1
+version: "1.0.1"
+lastModified: "2021-12-29T11:38:56Z"
+url: https://community.simtropolis.com/files/file/34806-esa-railpack-the-diagonals-vol-1/?do=download&r=191032

--- a/src/yaml/oidaas/34921-gyljen.yaml
+++ b/src/yaml/oidaas/34921-gyljen.yaml
@@ -1,0 +1,64 @@
+group: oidaas
+name: gyljen
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Gyljen
+  description: |-
+    **ESA Gyljen**
+
+    These lots are a compilation of lots i made for myself that i thought would be nice to share with the community.
+
+    **Stats**
+
+    User Visible Name Key    0x2026960B    0x0A554AE0    0x0BA80049              
+    Bulldoze Cost    40                      
+    Wealth    Low Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation 1    1    4    0          
+    Pollution radii    Air    Water    Garbage    Radiation 3    4    0    0          
+    Flammability    40                      
+    MaxFireStage    2                      
+    Power Consumed    1                      
+    Water Consumed    2                      
+    SFX:Query Sound    0x6A63BBA2                      
+    Query exemplar GUID    0x4A5672BF                      
+    OccupantGroups    Building: Residential    Building: R$    Style: Euro              
+    Occupant Size    Width    Height    Depth    1    1    1              
+    Building value    504                      
+    Capacity Satisfied    R-$20
+
+    **Dependencies**
+
+    Girafe Birches
+
+    [https://community.simtropolis.com/files/file/29630-bsc-vip-girafe-birches/?do=embed](https://community.simtropolis.com/files/file/29630-bsc-vip-girafe-birches/?do=embed)
+    C.p. BSC TexturePack Cycledogg V 01b (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=101](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=101)
+
+    BSC MEGA Props CP Vol01 (v1.0)
+
+    [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    ESA proppack
+
+    [https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed](https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/34921-esa-gyljen/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/6221fad9788f4_test-Jun.2171646381213.jpg.972fdedd6a0f9ec1b752e056c80b5d47.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/6221fadf39fc0_test-Jun.2171646381221.jpg.e3a85fa24733429121a19ea8ba395800.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/6221fae8113bc_test-Jun.2171646381232.jpg.ac2d0d1020fc1e3ec4ba32d48a6d7a2f.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:birches
+  - oidaas:proppack
+assets:
+  - assetId: oidaas-gyljen
+
+---
+assetId: oidaas-gyljen
+version: "1.0.0"
+lastModified: "2022-03-04T11:43:28Z"
+url: https://community.simtropolis.com/files/file/34921-esa-gyljen/?do=download&r=192202

--- a/src/yaml/oidaas/35009-kalarne.yaml
+++ b/src/yaml/oidaas/35009-kalarne.yaml
@@ -1,0 +1,75 @@
+group: oidaas
+name: kalarne
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: Kalarne
+  description: |-
+    **About**
+
+    This a railway station that has seen better days.  
+    inspired by a station on the northern mainline in Sweden  
+    Transit enabled to allow freight rail. It works best with standard RRW as seen in the screenshots.
+
+    **Stats**
+
+    Lot size: 7x4  
+    plop cost: 1000  
+    monthly cost: 100  
+    flammability: 10  
+    power consumed: 19  
+    water consumed: 10  
+    capacity: 66000  
+    air pollution: 2 over 6 tiles  
+    water pollution: 4 over 2 tiles  
+    garbage: 10 over 10 tiles  
+    Transit Switch Entry Cost: 0,096
+
+    **Dependencies**
+
+    ESA railway props
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+    PEG MPT Super pack
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+    SuperSHK MEGA Parking Textures
+
+    [https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed)
+    SFBT Essentials [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+
+    Railyard and spurs MEGA pack [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2177](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2177)
+
+    BSC Textures vol 3 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1806](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1806)
+
+    C.P Megaprops vol 1[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    SG Megaprops vol 1[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=746](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=746)
+
+    JES Megaprops vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=342](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35009-esa-kalarne/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/622f9d1421789_NewCity-Feb.4011647287333.jpg.d1ee0da43f321555731d1595bdbcd383.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/622f9d1b680f7_NewCity-Feb.11011647287360.jpg.cdc7b9ae3e9b3e65bb2046860ab6f390.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/622f9d226b3ae_NewCity-Jan.27011647287286.jpg.8199ae12cbecdcd626ffd6cf4e12f201.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/622f9d29aab90_NewCity-Jan.27011647287296.jpg.29ab259bfedcbe66f5fd22c3fd51424c.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:textures-vol03
+  - ncd:rail-yard-and-spur-mega-pak-1
+  - oidaas:rail-props-vol01
+  - peg:mtp-super-pack
+  - sfbt:essentials
+  - supershk:mega-parking-textures
+ # - ncd:rail-yard-and-spur-mega-pak-1 (or RealRailway (RRW) NCD BSC Texture pack Update)
+assets:
+  - assetId: oidaas-kalarne
+
+---
+assetId: oidaas-kalarne
+version: "1.0.0"
+lastModified: "2022-03-16T17:00:01Z"
+url: https://community.simtropolis.com/files/file/35009-esa-kalarne/?do=download&r=192535

--- a/src/yaml/oidaas/35012-freight.yaml
+++ b/src/yaml/oidaas/35012-freight.yaml
@@ -1,0 +1,92 @@
+group: oidaas
+name: freight
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: Freight
+  description: |-
+    ESA Freight
+
+    About
+
+    This is a set of freight station, one small for your rural needs and a larger for  your town needs. They come as diagonal and *orthogonal.*
+
+    *Stats*
+
+    Small (orto and diagonal)
+
+    plop cost: 100  
+    monthly cost: 100  
+    flammability: 10  
+    power consumed: 10  
+    water consumed: 5  
+    capacity: 30000  
+    air pollution: 6 over 8 tiles  
+    water pollution: 0 over 0 tiles  
+    garbage: 10 over 5 tiles  
+    Transit Switch Entry Cost: 0,09
+
+    Large (orto and diagonal)
+
+    plop cost: 200  
+    monthly cost: 150  
+    flammability: 10  
+    power consumed: 10  
+    water consumed: 10  
+    capacity: 66000  
+    air pollution: 6 over 8 tiles  
+    water pollution: 0 over 0 tiles  
+    garbage: 10 over 5 tiles  
+    Transit Switch Entry Cost: 0,09
+
+    Forgive my modding btw
+
+    Dependencies
+
+    ESA Railpack
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+    Historic Harbour
+
+    [https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed](https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed)
+    BSC Megaprops - JES Vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=342](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=342)
+
+    BSC Megaprops - JES Vol 3 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=339](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=339)
+
+    BSC Megaprops - Misc vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1771](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1771)
+
+    PEG SPAM Resource
+
+    [https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed](https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed)
+    Pegasus MTP Super pack
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+    BSC texturepack vol01b  [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=101](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=101)
+
+    SFBT Essentials [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35012-esa-freight/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/62358e5c64d60_NewCity-Jul.27021647592861.jpg.babc486cbd2f24482489e50891d06f4b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/62358e6d0cd59_NewCity-Jul.27021647592884.jpg.7082a2c0b5d9ef402cb967b2f9dd7792.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/62358e74db5be_NewCity-Sep.1021647617543.jpg.3dd1ca7a3d554da2bf15558482903960.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_03/62358e8028c86_NewCity-Sep.2011647592467.jpg.1e2f601e48558c8333c504eef44adbe8.jpg
+dependencies:
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol02
+  - bsc:mega-props-jes-vol03
+  - bsc:mega-props-misc-vol02
+  - bsc:texturepack-cycledogg-vol01
+  - historic-harbor:dependencies
+  - oidaas:rail-props-vol01
+  - peg:mtp-super-pack
+  - peg:spam-super-resource-pack
+  - sfbt:essentials
+assets:
+  - assetId: oidaas-freight
+
+---
+assetId: oidaas-freight
+version: "1.0.0"
+lastModified: "2022-03-19T08:20:24Z"
+url: https://community.simtropolis.com/files/file/35012-esa-freight/?do=download&r=192550

--- a/src/yaml/oidaas/35025-rail-props-vol02.yaml
+++ b/src/yaml/oidaas/35025-rail-props-vol02.yaml
@@ -1,0 +1,23 @@
+group: oidaas
+name: rail-props-vol02
+version: "2.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Rail props 2
+  description: |-
+    **About**
+
+    This is a prop pack that is a dependency for future releases.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35025-esa-rail-props-2/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/623ffc758581f_railwayprops.jpg.6a5a7a0a17fb6463fe1ad261635070d6.jpg.08f00f447bf6987ee5078d29c224b9ce.jpg
+assets:
+  - assetId: oidaas-rail-props-2
+
+---
+#This is the asset for version 2.5, though the stex entry only says `v2.0.0`. The other asset linked on the STEX is version 2.0.
+assetId: oidaas-rail-props-2
+version: "2.0.0"
+lastModified: "2022-07-17T16:10:50Z"
+url: https://community.simtropolis.com/files/file/35025-esa-rail-props-2/?do=download&r=194735

--- a/src/yaml/oidaas/35026-rail-gantries.yaml
+++ b/src/yaml/oidaas/35026-rail-gantries.yaml
@@ -1,0 +1,43 @@
+group: oidaas
+name: rail-gantries
+version: "2.0.0"
+subfolder: 700-transit
+info:
+  summary: Gantries vol 1
+  description: |-
+    **About**
+
+    This is a series of lots that yoy can use for your railway. It is lot based thus not modded to be used when dragging a railway,  Lots are found in the power menu. And lastly, forgive my modding, i'm a batter first an foremost.
+
+    **Stats**
+
+    Size: 1x1  
+    Bulldoze cost:10  
+    Wealth: None  
+    Pollution at center:0  
+    Flammability:0  
+    Plop cost: 40  
+    Occupant groups:Utility, Power  
+    Budget cost: 5
+
+    **Dependencies**
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+    [https://community.simtropolis.com/files/file/35025-esa-rail-props-2/?do=embed](https://community.simtropolis.com/files/file/35025-esa-rail-props-2/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35026-esa-gantries-vol-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_06/666d472c61a0c_NewCity-Jan.7021718436878.jpg.ded2854d3abc18362ab6196b9a2e5cfe.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_06/666d4732ca05d_NewCity-Jan.7021718437112.jpg.1bfa46b92700092b6314d657882c5bdd.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_06/666d473f71f5c_NewCity-Jan.7021718437199.jpg.9f52bd6ded6a7c3f6d21cf2f4b2f99af.jpg
+dependencies:
+  - oidaas:rail-props-vol01
+  - oidaas:rail-props-vol02
+assets:
+  - assetId: oidaas-gantries-vol1
+
+---
+assetId: oidaas-gantries-vol1
+version: "2.0.0"
+lastModified: "2024-06-15T07:48:21Z"
+url: https://community.simtropolis.com/files/file/35026-esa-gantries-vol-1/?do=download&r=201696

--- a/src/yaml/oidaas/35043-hjarndoda-gatan.yaml
+++ b/src/yaml/oidaas/35043-hjarndoda-gatan.yaml
@@ -1,0 +1,55 @@
+group: oidaas
+name: hjarndoda-gatan
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Hjarndoda gatan
+  description: |-
+    **About**
+
+    Ah what would a town be without a modernistic fugly office.  
+    This particular office is modelled after a office that replaced a whole block of elderly structures from the 1800's to the 1930's.  
+    The name Hjarndoda gatan is translated as "braindead street", perhaps from its design or the sims who works there, the song wind up working at a gas station comes to mind :-p.  
+    talking about songs there is a song i Sweden called "Lyckliga gatan" that describes the demolition of old blocks in the favour of 60's to 70's architecture.  
+    Anyhow, enough drabble.
+
+    **Stats**
+
+    Building Value : $3500
+
+    Bulldoze Cost:  $613
+
+    Capacity Satisfied: C0-$$ 88
+
+    Flammability: 40
+
+    Max Fire Stage: 3
+
+    Pollution at center: 1 (air), 1 (water), 4 (garbage)
+
+    Pollution radious: 5, 6, 1
+
+    Power Consumed: 2
+
+    Water Consumed: 77
+
+    **Dependencies**
+
+    [https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed)
+    [https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed](https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35043-esa-hjarndoda-gatan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_04/624e968f1681d_02-Aug.10981649316450.jpg.0f795b8c191467f3da8a3e9dc119fca5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_04/624e9696c9aa2_02-Aug.10981649316466.jpg.b7cc383fe3c6dabccad7e3e063b71f90.jpg
+dependencies:
+  - shk:parking-pack
+  - supershk:mega-parking-textures
+assets:
+  - assetId: oidaas-hjarndoda-gatan
+
+---
+assetId: oidaas-hjarndoda-gatan
+version: "1.0.0"
+lastModified: "2022-04-07T08:04:24Z"
+url: https://community.simtropolis.com/files/file/35043-esa-hjarndoda-gatan/?do=download&r=192771

--- a/src/yaml/oidaas/35181-lime-kilm.yaml
+++ b/src/yaml/oidaas/35181-lime-kilm.yaml
@@ -1,0 +1,68 @@
+group: oidaas
+name: lime-kilm
+version: "1.0.0"
+subfolder: 400-industrial
+info:
+  summary: Lime kilm
+  description: |-
+    **About**
+
+    This is a chalk owen originally designed for Brtons STAMP project. I lotted it for my own use and figured why not share it.
+
+    **Stats**
+
+    Plop Cost    500                      
+    Bulldoze Cost    100                      
+    Wealth    Low Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+    134    107    63    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+    16    20    0    0          
+    Flammability    80                      
+    MaxFireStage    3                      
+    Power Consumed    0                      
+    Water Consumed    0                                          
+    OccupantGroups    Building: Landmark    Building: Landmark Ogle    Building: ID              
+    Occupant Size    Width    Height    Depth              
+    14,739    25,209    14,723              
+    Occupant Types    ID                      
+    Building value    26493                      
+    Capacity Satisfied    I-D 25
+
+    **Dependencies**
+
+    ALN Pasture flora [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1886](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1886)
+
+    Jmyers megaprops Vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2756](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2756)
+
+    SM2 Megaprops vol 3 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3787](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3787)
+
+    MMP Pack Vol2 - Girafe Trees (v1.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3401](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3401)
+
+    Historic Harbour
+
+    [https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed](https://community.simtropolis.com/files/file/29880-historic-harbor/?do=embed)
+    SPAM resource pack
+
+    [https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed](https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35181-esa-lime-kilm/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_05/627ca8a0f2c17_NewCity-Feb.29001652335546.jpg.487e661ecb43e1a00d4639392a69a987.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_05/627ca8ae473fd_NewCity-Feb.29001652335527.jpg.c16f856a1e372db770c57e23e2003df4.jpg
+dependencies:
+  #- '"[https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3401](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3401)"'
+  - bsc:mega-props-jmyers-common-props
+  - aln:rrp-pasture-flora-props
+  - historic-harbor:dependencies
+  - peg:spam-super-resource-pack
+  - simmer2:mega-prop-pack-vol3
+  - bsc:mega-props-jmyers-agriculture-vol02
+assets:
+  - assetId: oidaas-lime-kilm
+
+---
+assetId: oidaas-lime-kilm
+version: "1.0.0"
+lastModified: "2022-05-12T06:52:07Z"
+url: https://community.simtropolis.com/files/file/35181-esa-lime-kilm/?do=download&r=194212

--- a/src/yaml/oidaas/35226-boklok.yaml
+++ b/src/yaml/oidaas/35226-boklok.yaml
@@ -1,0 +1,58 @@
+group: oidaas
+name: boklok
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: BoKlok
+  description: |-
+    This is a collection of buildings on 8 different lots. The concept was developed in a consortium between Skanska and IKEA. This because housing were so expensive to produce, hence they came up with these beauties. A large number of these structures are built each year in Sweden.
+
+    ps as always read the readme :-)
+
+    Stats
+
+    Occupancy: (45/60/75/90)  
+    Building value: (511/1021/1277/1787/1532)  
+    Building worth: (96/192//72/240/288)  
+    Bulldoze cost: (766/1532/1915/2298)  
+    Max fire: 3  
+    Pollution at center: 0,0,6,0  
+    Pollution: 5,6,0,0  
+    Flammability: 40  
+    Water consumption: 7
+
+    Dependencies
+
+    BSC Mega Props DAE Vol01 v2 (v2.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=475](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=475)  
+    BSC MEGA Props D66 Vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=556](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=556)  
+    BSC MEGA Props CP Vol 02 (v1.0) [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2790](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2790)  
+    BSC TexturePack Cycledogg V 01b (v1.0)https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=101  
+    PEG SPAM Super Resource Pack
+
+    [https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed](https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/?do=embed)
+    [https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/?do=embed)
+    [https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed](https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed)
+    As always I'm a Batter first modder and lotter second.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35226-esa-boklok/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62c99625c16e0_g-Mar.5001657377875.jpg.9279c387e8f2ee3103deca04919239d3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62c99627da34e_g-Mar.5001657377896.jpg.06d7cd1584d1b3fb4d9cf87e4e00631c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62c9962a54d3e_g-Mar.5001657377909.jpg.36feec889cb1bdd034786c3c2c0fe051.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62c9962c92c34_g-Mar.5001657377920.jpg.16e9ff8fb2aa3438494b9a641f95e733.jpg
+dependencies:
+  - bsc:mega-props-cp-vol02
+  - bsc:mega-props-d66-vol02
+  - bsc:mega-props-dae-vol01
+  - bsc:texturepack-cycledogg-vol01
+  - peg:spam-super-resource-pack
+  - shk:parking-pack
+  - supershk:mega-parking-textures
+assets:
+  - assetId: oidaas-boklok
+
+---
+assetId: oidaas-boklok
+version: "1.0.0"
+lastModified: "2022-07-09T15:00:06Z"
+url: https://community.simtropolis.com/files/file/35226-esa-boklok/?do=download&r=194694

--- a/src/yaml/oidaas/35227-gammelstad-kyrka.yaml
+++ b/src/yaml/oidaas/35227-gammelstad-kyrka.yaml
@@ -1,0 +1,56 @@
+group: oidaas
+name: gammelstad-kyrka
+version: "1.0.0"
+subfolder: 650-religion
+info:
+  summary: Gammelstad Kyrka
+  description: |-
+    **About**
+
+    Around 1400 ac they decided to build a large cathedral in what was  
+    then the place of my home town. Around the church several small houses apperad forming a town, in swedish"kyrkstad" eng Churchtown.  
+    These structures were inhabitated during masses. This because people had a long way to travel. Nowadays the church and the buildings surrounding are a Unesco world herritage site.
+
+    **Stats**
+
+    Plop cost:10 000  
+    Cost:150  
+    Demand satisfied: Rs 80, Rss 50, rsss 90  
+    Landmark effekt:20  
+    Bulldoze cost: (766/1532/1915/2298)  
+    Max fire stage: 1  
+    polution at center: 1,1,15,0  
+    polution: 1,2,0,0  
+    Occupant groups: Landmark, YIMBY,Landmark Ogle, Tourist  
+    Flammability:10  
+    Water consumption:0
+
+    **Dependencies**
+
+    CP Megaprops vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2790](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2790)  
+    CP megaprops Vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    BSC Textures CP vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=101](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=101)  
+    SM2 Drystone wall [https://community.simtropolis.com/files/file/32109-sm2-dry-stone-walls/](https://community.simtropolis.com/files/file/32109-sm2-dry-stone-walls/)  
+    BSC Megaprops SimGoober vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=746](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=746)  
+    NDEX Textures Vol 1 [https://community.simtropolis.com/files/file/11617-ndex\-texture-set-volume-1/](https://community.simtropolis.com/files/file/11617-ndex-texture-set-volume-1/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35227-gammelstad-kyrka/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62cafaa9a3c14_NewCity-Jan.20001657466682.jpg.4fe11d6720d5cb9800c255bfa67a50d6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_07/62cafaac85f54_NewCity-Jan.20001657466689.jpg.e74a5fd1e96531862a81303ae58a9e77.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-cp-vol02
+  - bsc:mega-props-sg-vol01
+  - bsc:texturepack-cycledogg-vol01
+  - ndex:textures-vol1
+  - simmer2:dry-stone-walls
+  - bsc:sg-models-im2
+assets:
+  - assetId: oidaas-gammelstad-kyrka
+
+---
+assetId: oidaas-gammelstad-kyrka
+version: "1.0.0"
+lastModified: "2022-07-10T16:15:24Z"
+url: https://community.simtropolis.com/files/file/35227-gammelstad-kyrka/?do=download&r=194699

--- a/src/yaml/oidaas/35285-egnahem.yaml
+++ b/src/yaml/oidaas/35285-egnahem.yaml
@@ -1,0 +1,53 @@
+group: oidaas
+name: egnahem
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Egnahem
+  description: |-
+    About
+
+    Egnahem is a type of housing built in the 30's by decree of the one home movement.
+
+    Stats
+
+    Bulldoze cost: 127  
+    Occupant size: 11,3 width 9,7 height depth 8,5  
+    Filing degree: 0,8  
+    Wealth: Low wealth  
+    Purpose: Residence  
+    Capacity satisfied: 13  
+    Pollution at center: 1,1,4,0  
+    Power consumed: 1  
+    Flammability: 45  
+    Max firestage: 2  
+    Pollution radius: 5,5,0,0  
+    Worth: 127  
+    Water consumed: 1  
+    Building value:176
+
+    Dependencies
+
+    Simgoober Megapack vol 1  
+    ESA Proppack vol 1  
+    BSC TexturePack Cycledogg V 01b
+
+    [about.txt](//community.simtropolis.com/applications/core/interface/file/attachment.php?id=89121)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35285-esa-egnahem/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_08/630e0fc0ec23c_NewCity-Nov.26121661865290.jpg.6172e69f736c40ba5c6534eb19946b4d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_08/630e0fc877410_NewCity-Nov.26121661865298.jpg.3e7a28fb07e3e0331178e633e01c819e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_08/630e0fd156259_NewCity-Nov.26121661865327.jpg.b77d2ad7da189af4122fd5bdd5bcb85e.jpg
+dependencies:
+  - oidaas:proppack
+  - bsc:mega-props-sg-vol01
+  - bsc:texturepack-cycledogg-vol01
+assets:
+  - assetId: oidaas-egnahem
+
+---
+assetId: oidaas-egnahem
+version: "1.0.0"
+lastModified: "2022-08-30T13:28:47Z"
+url: https://community.simtropolis.com/files/file/35285-esa-egnahem/?do=download&r=195206

--- a/src/yaml/oidaas/35314-nationalromantik.yaml
+++ b/src/yaml/oidaas/35314-nationalromantik.yaml
@@ -1,0 +1,46 @@
+group: oidaas
+name: nationalromantik
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Nationalromantik
+  description: |-
+    **About**
+
+    This is a BAT i made a while ago that i decided to upload for all to enjoy. The architecture is Swedish Nationalromantik. It's a style that was common in the start of the 20th century. I realize now upon seeing the pictures that the nightlightning doesn't show, but trust me :-).
+
+    **Dependencies**
+
+    BSC MEGA props CP vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    BSC MEGA props D66 vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=396](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=396)  
+    BSC MEGA props D66 vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=556](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=556)  
+    BSC MEGA props Swi21 vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=403](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=403)
+
+    BSC MEGA props Misc 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=426](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=426)
+
+    BSC Textures vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=90](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)  
+    BSC Textures vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=638](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=638)  
+    BSC Texturepack CP vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=101](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=101)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35314-esa-nationalromantik/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_10/634c71a23346c_NewCity-May.17021665953929.jpg.312bc30d86c18599d56972e04755c671.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_10/634c71aad0045_NewCity-May.17021665953937.jpg.bc18209d4ddd0611bc827c2591675dfc.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_10/634c71b36c9aa_NewCity-May.17021665953948.jpg.c318729382e497eb91501f5204415e1a.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-d66-vol01
+  - bsc:mega-props-d66-vol02
+  - bsc:mega-props-misc-vol01
+  - bsc:mega-props-swi21-vol01
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+assets:
+  - assetId: oidaas-nationalromantik
+
+---
+assetId: oidaas-nationalromantik
+version: "1.0.0"
+lastModified: "2022-10-16T21:30:09Z"
+url: https://community.simtropolis.com/files/file/35314-esa-nationalromantik/?do=download&r=195493

--- a/src/yaml/oidaas/35339-boden.yaml
+++ b/src/yaml/oidaas/35339-boden.yaml
@@ -1,0 +1,87 @@
+group: oidaas
+name: boden
+version: "2.0.0"
+subfolder: 700-transit
+info:
+  summary: Boden
+  description: |-
+    **About:**
+
+    This is a replica of Boden central, located in the town of Boden. It's built as a hub between the Haparanda line, Main line and the Ore line.
+
+    **Stats**  
+                  
+    Item Name:ESA Boden          
+    Item Description:LA replica of Boden central, connecting the ore line with the main line.      
+    Item Order    3                      
+    Plop Cost    100                      
+    Bulldoze Cost    100                      
+    Wealth    None                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+                2    0    1    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+            1    2    0    0          
+    Flammability    10                      
+    MaxFireStage    3                      
+    Power Consumed    61                      
+    Water Consumed    5                      
+    Demand Created    Jobs $    Jobs $$    Jobs $$$    R-$    R-$$     R-$$$                      
+            95    5    0    95    5    0    0                      
+    Budget Item: Department    Mass Transit                      
+    Budget Item: Line    0x00000001                      
+    Budget Item: Purpose    Mass Transit Switch                      
+    Budget Item: Cost    10                                          
+    OccupantGroups    Building: Transportation    Building: Rail    Building: Strikeable Transit    Building: Taxi\_Maker    Building: PassengerRail      
+    Occupant Size    Width    Height    Depth              
+            1    1    1                                  
+    Transit Switch Entry Cost    0,071                      
+    Transit Switch Traffic Capacity    100000
+
+    Transit enabled for freight and rail and pedestrian,  
+    this means that you need to put a bus or subway entrance beside.
+
+    **Dependencies**
+
+    BSC Textures vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=90](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+
+    BSC Textures Vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=638](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=638)
+
+    BSC Textures CP Vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)
+
+    BSC MEGA props vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1771](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1771)
+
+    Railyard textures MEGA pack [https://community.simtropolis.com/files/file/22325-rail-yard-and-spur-mega-pak-1-version-2/](https://community.simtropolis.com/files/file/22325-rail-yard-and-spur-mega-pak-1-version-2/)
+
+    ESA Railpack vol 1 [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/)
+
+    NDEX Glenni MEGA Props Vol01 [https://community.simtropolis.com/files/file/19096-ndex\-glenni-mega-props-vol01/](https://community.simtropolis.com/files/file/19096-ndex-glenni-mega-props-vol01/)
+
+    Murimk props vol03 - industrials [https://community.simtropolis.com/files/file/27698-murimk-props-vol03-industrials/](https://community.simtropolis.com/files/file/27698-murimk-props-vol03-industrials/)
+
+    SFBT Birke [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=752](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=752)
+
+    SFBT Essentials [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35339-esa-boden/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2022_11/63809743d7e00_NewCity-Mar.30031669369746.jpg.0721363eb4ce13abda799894411007a1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2022_11/6380974ff0f8f_NewCity-Jun.24041669371056.jpg.775b388745fbb64a4e9e32919e724056.jpg
+dependencies:
+  #- '"[https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=752](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=752)"'
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-misc-vol02
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - murimk:props-vol03-industrials
+  - ncd:rail-yard-and-spur-mega-pak-1
+  - ndex:glenni-mega-props-vol01
+  - oidaas:rail-props-vol01
+  - sfbt:essentials
+assets:
+  - assetId: oidaas-boden
+
+---
+assetId: oidaas-boden
+version: "2.0.0"
+lastModified: "2022-11-25T15:29:55Z"
+url: https://community.simtropolis.com/files/file/35339-esa-boden/?do=download&r=195706

--- a/src/yaml/oidaas/35438-stores.yaml
+++ b/src/yaml/oidaas/35438-stores.yaml
@@ -1,0 +1,81 @@
+group: oidaas
+name: stores
+version: "2.0.0"
+subfolder: 300-commercial
+info:
+  summary: Stores
+  description: |-
+    **About**
+
+    This is two stores with the brand Konsum and ICA.
+
+    **Dependencies**
+
+    CP MEGA props vol 1 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    CP MEGA props vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2790](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2790)  
+    PEG MTP Resource
+
+    [https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/?do=embed)
+    Stats
+
+    **Konsum Stats**
+
+    User Visible Name Key    ESA konsumstorre  
+    Bulldoze Cost    157                      
+    Wealth    Low Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+    1    1    4    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+    5    5    0    0          
+    Flammability    45                      
+    MaxFireStage    2                      
+    Power Consumed    1                      
+    Water Consumed    9                      
+    SFX:Query Sound    0x2a8916ab                      
+    Query exemplar GUID    0xca56783a                      
+    OccupantGroups    Building: Commercial    Building: CS$ Style: Houston      
+    Occupant Size    Width    Height    Depth    16.9117    12.7382    18.1              
+    Occupant Types    CS$                      
+    Building value    283                      
+    Capacity Satisfied    CS-$ 37
+
+    **ICA Stats**
+
+    Bulldoze Cost    161                      
+    Wealth    Low Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+    4    2    59    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+    5    5    0    0          
+    Flammability    45                      
+    MaxFireStage    3                      
+    Power Consumed    2                      
+    Water Consumed    15                      
+    SFX:Query Sound    0x2a8916ab                      
+    Query exemplar GUID    0xca56783a                      
+    OccupantGroups    Building: Commercial    Building: CS$    Style: Houston              
+    Occupant Size    Width    Height    Depth              
+    20.69300079    13.13000011    17.06699944              
+    Occupant Types    CS$                      
+    Building value    614                      
+    Capacity Satisfied    CS-$                      
+    20
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35438-esa-stores/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_01/63d1087d20a6e_NewCity-Feb.20001674493442.jpg.d2eb2317644c1b3c1efefe87873438c2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_01/63d1088161583_NewCity-Feb.20001674493450.jpg.68f840e48ed07e851f42fb15e1b7e07d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_01/63d10883b6fc3_NewCity-Feb.20001674493459.jpg.398366ee6e32d80fc13395bc6f72bc8a.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-cp-vol02
+  - peg:mtp-super-pack
+  - supershk:mega-parking-textures
+assets:
+  - assetId: oidaas-stores
+
+---
+assetId: oidaas-stores
+version: "2.0.0"
+lastModified: "2023-01-25T14:26:26Z"
+url: https://community.simtropolis.com/files/file/35438-esa-stores/?do=download&r=196360

--- a/src/yaml/oidaas/35440-krakan.yaml
+++ b/src/yaml/oidaas/35440-krakan.yaml
@@ -1,0 +1,57 @@
+group: oidaas
+name: krakan
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Krakan
+  description: |-
+    **About**
+
+    These houses are inspired by homes built in th 1800's in cities. I made these as low wealth.
+
+    **Stats**
+
+    Bulldoze Cost    109                      
+    Wealth    Low Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+    1    0    1    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+    5    5    0    0          
+    Flammability    45                      
+    MaxFireStage    2                      
+    Power Consumed    1                      
+    Water Consumed    1                      
+    SFX:Query Sound    0x6A63BBA2                      
+    Query exemplar GUID    0x4A5672BF                      
+    OccupantGroups    Building: Residential    Building: R$    Style: Euro              
+    Occupant Size    Width    Height    Depth              
+    7.96000004    7.90199995    17.79899979              
+    Occupant Types    R$                      
+    Building value    244                      
+    Capacity Satisfied    R-$                      
+    10
+
+    **Dependencies**
+
+    ESA Props vol 1
+
+    [https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed](https://community.simtropolis.com/files/file/34777-esa-rail-prop-pack/?do=embed)
+    BSC MEGA props vol [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    SFBT Essentials [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=750](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=750)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35440-esa-krakan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_01/63d13aed66090_02-Aug.23431674589908.jpg.4560caffddb41be78712ae79e52b848c.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - oidaas:rail-props-vol01
+  - oidaas:proppack
+  - sfbt:essentials
+assets:
+  - assetId: oidaas-krakan
+
+---
+assetId: oidaas-krakan
+version: "1.0.0"
+lastModified: "2023-01-25T14:24:07Z"
+url: https://community.simtropolis.com/files/file/35440-esa-krakan/?do=download&r=196358

--- a/src/yaml/oidaas/35539-1950s-villas.yaml
+++ b/src/yaml/oidaas/35539-1950s-villas.yaml
@@ -1,0 +1,68 @@
+group: oidaas
+name: 1950s-villas
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: 1950's Villas
+  description: |-
+    **About**
+
+    These are a couple of homes i made i while ago. I cleaned up the lotting and the dependencies.
+
+    **Stats**
+
+    Bulldoze Cost     103                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+                0     0     2     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+                5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     3                       
+    SFX:Query Sound     0x6A63BBA2                       
+    Query exemplar GUID     0x4A5672BF                       
+    OccupantGroups     Building: Residential     Building: R$$     Style: Houston               
+    Occupant Size     Width     Height     Depth               
+    14.70499992     7.07000017     18.93199921               
+    Occupant Types     R$     R$$                   
+    Building value     424                       
+    Capacity Satisfied     R-$     R-$$                   
+                29     18  
+    **Dependencies**
+
+    BSC MEGA props SG vol 1[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=746](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=746)  
+    BSC MEGA props Jestarr vol 2 [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=338](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=338)  
+    BSC MEGA props D66 vol 1[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=396](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=396)  
+    BSC MEGA props CP vol 1[https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=1180](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=1180)  
+    Mikeseith euro car mod
+
+    [https://community.simtropolis.com/files/file/14400-european-cars-automata-and-family-props-new-instances/?do=embed](https://community.simtropolis.com/files/file/14400-european-cars-automata-and-family-props-new-instances/?do=embed)
+    Girafe birches [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2620](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2620)  
+    Girafe Maples [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2809](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2809)  
+    Girafe Elms [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=3347](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=3347)  
+    Girafe Ashes [https://www.sc4devotion.com/csxlex/lex\_filedesc.php?lotGET=2809](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=2809)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35539-esa-1950s-villas/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/6479f8e9e1b60_NewCity-Jan.16001685714681.jpg.e3dde34bbb3243d7a3f5a45941190c35.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/6479f8eb296e4_NewCity-Jan.16001685714690.jpg.25596cc0528f5fdd9f3e0813b15240f4.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/6479f8ec7d959_NewCity-Jan.16001685714701.jpg.3c1d0acea9c41b58a7ea29828b8c604f.jpg
+dependencies:
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-d66-vol01
+  - bsc:mega-props-jes-vol02
+  - bsc:mega-props-sg-vol01
+  - girafe:birches
+  - girafe:elms
+  - girafe:maples-v2
+  - mikeseith:european-cars-automata-and-family-props-new-instances
+assets:
+  - assetId: oidaas-1950s-villas
+
+---
+assetId: oidaas-1950s-villas
+version: "1.0.0"
+lastModified: "2023-06-02T14:23:51Z"
+url: https://community.simtropolis.com/files/file/35539-esa-1950s-villas/?do=download&r=197157

--- a/src/yaml/oidaas/35541-industrial-props.yaml
+++ b/src/yaml/oidaas/35541-industrial-props.yaml
@@ -1,0 +1,29 @@
+group: oidaas
+name: industrial-props
+version: "1.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Industrial props
+  description: |-
+    **About**
+
+    These props were made with the intentions of being included in Twrecks genius IRM. However since he is not active and because i still wanted to share i decided to upload for all.
+
+    **Dependencies**
+
+    These are dependencies ![:)](https://community.simtropolis.com/assets/emoticons/LlamaSmile.gif ":)")
+
+    Have some fun.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35541-esa-industrial-props/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/647eb628f04b8_NewCity-Jan.8001686025149.jpg.9c274ed8d46353d524af89a5b742ade9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_06/647eb634c8119_NewCity-Jan.8001686025117.jpg.2ec17b8ae040546975dbd244fe59f977.jpg
+assets:
+  - assetId: oidaas-industrial-props
+
+---
+assetId: oidaas-industrial-props
+version: "1.0.0"
+lastModified: "2023-06-06T04:33:05Z"
+url: https://community.simtropolis.com/files/file/35541-esa-industrial-props/?do=download&r=197166

--- a/src/yaml/oidaas/35570-sunken-railstation.yaml
+++ b/src/yaml/oidaas/35570-sunken-railstation.yaml
@@ -1,0 +1,59 @@
+group: oidaas
+name: sunken-railstation
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: Sunken railstation
+  description: |-
+    **About**
+
+    This station was originally made with purpose as being a HRW station. However i made it a sunken RRW station.  
+    It can however be modded as a HRW station since the LOD allows it.
+
+    **Stats**
+
+    Pollution at center: air 3, Water 2, garbage 5, radiation,0  
+    Power consumed: 1  
+    Flammability: 37  
+    Max fire stage: 1  
+    Plop cost: 600  
+    Pollution radius: air 1, water 2, garbage 0, radiation 0,  
+    Transit cost:0,071  
+    Capacity: 53000
+
+    **Dependencies**
+
+    NDEX Glenni MEGA Props Vol01  
+       
+    [https://community.simtropolis.com/files/file/19096-ndex\-glenni-mega-props-vol01/¨](https://community.simtropolis.com/files/file/19096-ndex-glenni-mega-props-vol01/%C2%A8)
+
+    Girafe Maples
+
+    [https://www.sc4devotion.com/?lotGET=2809](https://www.sc4devotion.com/?lotGET=2809)
+
+    SFBT Essentials
+
+    [https://www.sc4devotion.com/](https://www.sc4devotion.com/)
+
+    BSC MEGA Props Jes Vol 01
+
+    [https://www.sc4devotion.com/](https://www.sc4devotion.com/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35570-esa-sunken-railstation/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2023_07/64b66cdd8e53b_NewCity-Jan.20071689522038.jpg.264649f3fbf13dd81a4e7c44aaac31e9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2023_07/64b66ce31f366_NewCity-Jan.20071689522038.png.954cf1f0c4a36469390b25b9f640c327.png
+    - https://www.simtropolis.com/objects/screens/monthly_2023_07/64b66ce544908_NewCity-Mar.19001689610914.jpg.cf1a9f7c1da45322c61bbf4a899b1dea.jpg
+dependencies:
+  - ndex:glenni-mega-props-vol01
+  - girafe:maples-v2
+  - sfbt:essentials
+  - bsc:mega-props-jes-vol01
+assets:
+  - assetId: oidaas-sunken-railstation
+
+---
+assetId: oidaas-sunken-railstation
+version: "1.0.0"
+lastModified: "2023-07-18T10:45:27Z"
+url: https://community.simtropolis.com/files/file/35570-esa-sunken-railstation/?do=download&r=197349

--- a/src/yaml/oidaas/35928-bolagsvagen.yaml
+++ b/src/yaml/oidaas/35928-bolagsvagen.yaml
@@ -1,0 +1,81 @@
+group: oidaas
+name: bolagsvagen
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Bolagsvagen
+  description: |-
+    **About**
+
+    These are worker housing from the town of Malmberget.
+
+    **Stats**
+
+    Bolagsvagen 1x
+
+    Bulldoze Cost     350                       
+    Wealth     Low Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     5     0     0           
+    Flammability     45                       
+    MaxFireStage     3                       
+    Power Consumed     1                       
+    Water Consumed     1                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Style: Houston     Building: R$               
+    Occupant Size     Width     Height     Depth               
+    1     1     1               
+    Occupant Types     R$                       
+    Building value     951                       
+    Capacity Satisfied     R-$                       
+    70
+
+    Bolagsvagen 2x
+
+    Bulldoze Cost     190                       
+    Wealth     Low Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     5     0     0           
+    Flammability     45                       
+    MaxFireStage     3                       
+    Power Consumed     2                       
+    Water Consumed     3                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Building: R$     Style: Chicago     Style: New York Style: Houston     Style: Euro                       
+    Occupant Size     Width     Height     Depth               
+    1     1     1               
+    Occupant Types     R$                       
+    Building value     3329                       
+    Capacity Satisfied     R-$                       
+    245
+
+    **Dependencies**
+
+    Malmberget proppack vol 1 [https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/](https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/)  
+    Malmberget proppack vol 2 [https://community.simtropolis.com/files/file/35927-malmberget-proppack-vol-2/](https://community.simtropolis.com/files/file/35927-malmberget-proppack-vol-2/)  
+    Girafe [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe -flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX-legacy-bsc-vip-girafe%20-flora)  
+    PEG MTP Essentials [https://community.simtropolis.com/files/file/20966-peg-mtp\-super-pack/](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35928-esa-bolagsvagen/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659b6b983f34a_NewCity-Dec.30291704643953.jpg.9eb28394e3b2ea06572f551339805aa9.jpg
+dependencies:
+  - oidaas:malmberget-props-vol01
+  - oidaas:malmberget-props-vol02
+  - peg:mtp-super-pack
+  - girafe:rowan-trees
+  - girafe:common-spruces
+assets:
+  - assetId: oidaas-bolagsvagen
+
+---
+assetId: oidaas-bolagsvagen
+version: "1.0.0"
+lastModified: "2024-01-08T03:28:29Z"
+url: https://community.simtropolis.com/files/file/35928-esa-bolagsvagen/?do=download&r=199101

--- a/src/yaml/oidaas/35929-jugend.yaml
+++ b/src/yaml/oidaas/35929-jugend.yaml
@@ -1,0 +1,58 @@
+group: oidaas
+name: jugend
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Jugend
+  description: |-
+    **About**
+
+    This mansion is inspired by a mansion i saw when googling jugend mansions.
+
+    **Stats**
+
+    Bulldoze Cost    158                      
+    Wealth    High Wealth                      
+    Pollution at center    Air    Water    Garbage    Radiation          
+    1    1    4    0          
+    Pollution radii    Air    Water    Garbage    Radiation          
+    6    7    0    0          
+    Flammability    35                      
+    MaxFireStage    2                      
+    Power Consumed    1                      
+    Water Consumed    5                      
+    SFX:Query Sound    0x6a63bba2                      
+    Query exemplar GUID    0x4a5672bf                      
+    OccupantGroups    Building: Residential    Building: R$$$    Style: Chicago    Style: New York    Style: Houston      
+    Style: Euro                      
+    Occupant Size    Width    Height    Depth              
+    18.812    12    14.306              
+    Occupant Types    R$    R$$    R$$$              
+    Building value    458                      
+    Capacity Satisfied    R-$    R-$$    R-$$$              
+    30    18    9
+
+    **Dependencies**
+
+    SC4D LEX Legacy - BSC Common Dependencies Pack [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    ESA props vol 1 [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35929-esa-jugend/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659b6ff118edf_NewCity-Jan.10001704685329.jpg.8eeef7af2c5da66b40c293e6fa6a473c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659b6ff6560ec_NewCity-Jan.10001704685311.jpg.b4c1477601ccf976ba54cd5d46689ac7.jpg
+dependencies:
+  - oidaas:proppack
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:chestnuts
+  - girafe:hedges
+  - bsc:vip-girafe-carpack-vol03
+  - peg:mtp-super-pack
+assets:
+  - assetId: oidaas-jugend
+
+---
+assetId: oidaas-jugend
+version: "1.0.0"
+lastModified: "2024-01-08T03:47:06Z"
+url: https://community.simtropolis.com/files/file/35929-esa-jugend/?do=download&r=199103

--- a/src/yaml/oidaas/35930-ingenjorsvillan.yaml
+++ b/src/yaml/oidaas/35930-ingenjorsvillan.yaml
@@ -1,0 +1,66 @@
+group: oidaas
+name: ingenjorsvillan
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Ingenjorsvillan
+  description: |-
+    **About**
+
+    This is a villa that served as a engineers villa in the town of Malmberget.
+
+    **Stats**
+
+    Bulldoze Cost     136                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     4                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Style: Euro     Building: R$$$               
+    Occupant Size     Width     Height     Depth               
+    15.5     10     14.3028               
+    Occupant Types     R$     R$$     R$$$               
+    Building value     274                       
+    Capacity Satisfied     R-$     R-$$     R-$$$               
+    18     11     7
+
+    **Dependencies**
+
+    Malmberget proppack vol 1 [https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/](https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/)  
+    ESA props vol 1 [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)  
+    Girafe props [https://community.simtropolis.com/files/file/29630-bsc-vip-girafe-birches/](https://community.simtropolis.com/files/file/29630-bsc-vip-girafe-birches/)  
+    Girafe flora [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)  
+    SG Proppack [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    BSC textures [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    CP texture pack vol 1 [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35930-esa-ingenjorsvillan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659b7abd10596_NewCity-Apr.6001704687535.png.7689bb98fac1227654f2f6573af06c7f.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659b7ac3b8b95_NewCity-Apr.6001704687522.png.336fc687d108b383f4b67a815513b471.png
+dependencies:
+  - oidaas:proppack
+  - oidaas:malmberget-props-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - bsc:mega-props-cp-vol01
+  - girafe:birches
+  - girafe:chestnuts
+  - girafe:rowan-trees
+  - bsc:texturepack-cycledogg-vol01
+assets:
+  - assetId: oidaas-ingenjorsvillan
+
+---
+assetId: oidaas-ingenjorsvillan
+version: "1.0.0"
+lastModified: "2024-01-08T04:33:05Z"
+url: https://community.simtropolis.com/files/file/35930-esa-ingenjorsvillan/?do=download&r=199106

--- a/src/yaml/oidaas/35933-74-an.yaml
+++ b/src/yaml/oidaas/35933-74-an.yaml
@@ -1,0 +1,59 @@
+group: oidaas
+name: 74-an
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: 74:an
+  description: |-
+    **About**
+
+    This is an apartment for rich people based on an now disassembled house in Malmberget.
+
+    **Stats**
+
+    Bulldoze Cost     136                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     4                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Style: Euro     Building: R$$$               
+    Occupant Size     Width     Height     Depth               
+    15.5     10     14.3028               
+    Occupant Types     R$     R$$     R$$$               
+    Building value     274                       
+    Capacity Satisfied     R-$     R-$$     R-$$$               
+    18     11     7
+
+    **Dependencies**
+
+    Girafe flora pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)  
+    SHK Parking Pack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/](https://community.simtropolis.com/files/file/27563-shk-parking-pack/)  
+    BSC Textures [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35933-esa-74an/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659ba078723f9_06-Sep.21801704697326.png.8faf8c187a530021230e705303a2f310.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659ba09a1dce2_06-Sep.21801704697311.png.5327316f870629249f735cf10ad4ca67.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659ba0a0b73e1_06-Sep.21801704697318.png.ce1ee25c948e3218fd8d05f85d51b330.png
+dependencies:
+  - bsc:textures-vol01
+  - shk:parking-pack
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:maples-v2
+  - girafe:rowan-trees
+  - girafe:conifers
+assets:
+  - assetId: oidaas-74-an
+
+---
+assetId: oidaas-74-an
+version: "1.0.0"
+lastModified: "2024-01-08T07:14:37Z"
+url: https://community.simtropolis.com/files/file/35933-esa-74an/?do=download&r=199115

--- a/src/yaml/oidaas/35940-medlerstein.yaml
+++ b/src/yaml/oidaas/35940-medlerstein.yaml
@@ -1,0 +1,67 @@
+group: oidaas
+name: medlerstein
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Medlerstein
+  description: |-
+    **About**
+
+    This is a mansion modelled after a mansion not far from where i live.  
+    The name comes from a man who worked at the Malmberget mine.
+
+    **Stats**
+
+    Bulldoze Cost     228                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     3                       
+    Power Consumed     2                       
+    Water Consumed     5                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Building: R$$$     Style: Chicago     Style: New York     Style: Houston       
+                          
+    Style: Euro                       
+    Occupant Size     Width     Height     Depth               
+    22.8536     18.6476     15.3006               
+    Occupant Types     R$     R$$     R$$$               
+    Building value     748                       
+    Capacity Satisfied     R-$     R-$$     R-$$$               
+    49     28     14
+
+    **Dependencies**
+
+    Girafe flora pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)  
+    BSC textures [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    SHK parkingpack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/#google\_vignette](https://community.simtropolis.com/files/file/27563-shk-parking-pack/#google_vignette)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35940-esa-medlerstein/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659cf60e877b7_06-Sep.181801704784586.jpg.b9c030c6dfa6ba4ccb70c5ddb6a3fb3a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659cf6152f1cd_06-Sep.181801704784576.jpg.94ec3ed6fd9c5db527f3e023719e15ea.jpg
+dependencies:
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - shk:parking-pack
+  - bsc:texturepack-cycledogg-vol01
+  - ndex:textures-vol1
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-cp-vol01
+  - bsc:mega-props-cp-vol02
+  - girafe:maples-v2
+  - girafe:poplars
+  - girafe:conifers
+  - girafe:beeches
+assets:
+  - assetId: oidaas-medlerstein
+
+---
+assetId: oidaas-medlerstein
+version: "1.0.0"
+lastModified: "2024-01-09T07:31:33Z"
+url: https://community.simtropolis.com/files/file/35940-esa-medlerstein/?do=download&r=199149

--- a/src/yaml/oidaas/35945-ica-supermarket.yaml
+++ b/src/yaml/oidaas/35945-ica-supermarket.yaml
@@ -1,0 +1,95 @@
+group: oidaas
+name: ica-supermarket
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: ICA Supermarket
+  description: |-
+    I declare war!..custom content war!..Jokes aside
+
+    About
+
+    ICA is one of the largest retailers in Sweden. This comes in two sizes, one RL and one growable smaller size.
+
+    Stats
+
+    Growable
+
+    Bulldoze Cost     212                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    29     19     272     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     4                       
+    Power Consumed     32                       
+    Water Consumed     538                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Building: CS$$     Style: Chicago     Style: New York     Style: Houston       
+                          
+    Style: Euro                       
+    Occupant Size     Width     Height     Depth               
+    96     17.621     54.932999               
+    Occupant Types     CS$     CS$$                   
+    Building value     13314                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    1552     390
+
+    LM
+
+    Item Name     ICA supermark  
+    Item Description     ICA Supermarket RL size  
+    Item Order     1                       
+    Plop Cost     4096                       
+    Bulldoze Cost     100                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     15     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    1     2     0     0           
+    Flammability     40                       
+    MaxFireStage     4                       
+    Power Consumed     97                       
+    Water Consumed     1670                       
+    Budget Item: Department     Landmarks                       
+    Budget Item: Line     0x00000000                       
+    Budget Item: Purpose     Landmark Effect                       
+    Budget Item: Cost     150                       
+    SFX:Query Sound     0x2A8916AB                       
+    SFX:Default Plop Sound     0x6A5EC589                       
+    Query exemplar GUID     0xCA56783A                       
+    OccupantGroups     Building: Landmark     Building: CS$$                   
+    Occupant Size     Width     Height     Depth               
+    114,13     25     101,212               
+    Occupant Types     CS$     CS$$                   
+    Building value     41321                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    500     250
+
+    dependencies
+
+    SHK Parking pack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/](https://community.simtropolis.com/files/file/27563-shk-parking-pack/)  
+    SuperSHK MEGA Parking Textures [https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/](https://community.simtropolis.com/files/file/31006-supershk-mega-parking-textures/)  
+    BSC Common dependencies [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35945-ica-supermarket/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659e38817dc57_06-Jul.221801704867639.jpg.582650947ec5289697b1dbc3a3ce319c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659e38884cfa0_06-Jul.221801704867624.jpg.012575aa71e63bf4588d29e00d09c06f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659e388c79809_06-Jul.221801704867632.jpg.ccec156c944e0952d94d1adbd087e295.jpg
+dependencies:
+  - shk:parking-pack
+  - supershk:mega-parking-textures
+  - bsc:mega-props-jes-vol01
+  - bsc:mega-props-jes-vol09
+  - peg:mtp-super-pack
+assets:
+  - assetId: oidaas-ica-supermarket
+
+---
+assetId: oidaas-ica-supermarket
+version: "1.0.0"
+lastModified: "2024-01-10T06:28:56Z"
+url: https://community.simtropolis.com/files/file/35945-ica-supermarket/?do=download&r=199163

--- a/src/yaml/oidaas/35962-cornershops.yaml
+++ b/src/yaml/oidaas/35962-cornershops.yaml
@@ -1,0 +1,89 @@
+group: oidaas
+name: cornershops
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Cornershops
+  description: |-
+    The war continues ![:)](https://community.simtropolis.com/assets/emoticons/LlamaSmile.gif ":)")
+
+    **About**
+
+    These houses are fictional based on houses that dominated Swedish towns before the demolition craze in the 60s-70s.
+
+    **Stats**
+
+    Nygatan
+
+    Bulldoze Cost     200                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    2     2     22     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     3                       
+    Power Consumed     3                       
+    Water Consumed     44                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    19.535999     16.5     22.990999               
+    Occupant Types     CS$     CS$$                   
+    Building value     1085                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    127     34
+
+    Grosshandlare Wallencreuz
+
+    Bulldoze Cost     200                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    2     2     22     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     3                       
+    Power Consumed     3                       
+    Water Consumed     44                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    19.535999     16.5     22.990999               
+    Occupant Types     CS$     CS$$                   
+    Building value     1085                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    127     34
+
+    **Dependencies**
+
+    Girafe flora pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX-legacy-bsc-vip-girafe-flora)  
+    BSC common pack [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    SHK parking pack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/](https://community.simtropolis.com/files/file/27563-shk-parking-pack/)  
+    ESA props vol 1 [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35962-esa-cornershops/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659eccd278eec_06-Aug.21801704869432.jpg.fa91433453ad5af579506df24ed8eabd.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659eccd41a6a5_06-Aug.21801704869443.jpg.6c345d4129ff99c77212abf6aac29900.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659eccd5371e8_06-Aug.21801704869452.jpg.eb1c72f720d1284231ae4bf360049f24.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659eccd69fa5d_06-Aug.21801704869799.jpg.042c235c49d33f9fe3d6d9df2c5701e8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659eccd847a77_06-Aug.21801704869791.jpg.841d53ce99e2a637cb8d2c4a994c514d.jpg
+dependencies:
+  - oidaas:proppack
+  - shk:parking-pack
+  - peg:mtp-super-pack
+  - girafe:maples-v2
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:mega-props-cp-vol01
+  - girafe:ashes
+assets:
+  - assetId: oidaas-cornershops
+
+---
+assetId: oidaas-cornershops
+version: "1.0.0"
+lastModified: "2024-01-10T17:00:43Z"
+url: https://community.simtropolis.com/files/file/35962-esa-cornershops/?do=download&r=199202

--- a/src/yaml/oidaas/35973-storgatan.yaml
+++ b/src/yaml/oidaas/35973-storgatan.yaml
@@ -1,0 +1,130 @@
+group: oidaas
+name: storgatan
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Storgatan
+  description: |-
+    The war continues
+
+    **About**
+
+    These houses are based on a house in my hometown that is long since demolished.
+
+    **Storgatan 7 high wealth**
+
+    Bulldoze Cost     239                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     3                       
+    Power Consumed     3                       
+    Water Consumed     25                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$$               
+    Occupant Size     Width     Height     Depth               
+    24.797     19.6732     17.4127               
+    Occupant Types     CS$     CS$$     CS$$$               
+    Building value     767                       
+    Capacity Satisfied     CS-$     CS-$$     CS-$$$               
+    79     22     11
+
+    **Storgatan 7 medium wealth**
+
+    Bulldoze Cost     194                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     14                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    20.0856     15.9353     14.1043               
+    Occupant Types     CS$     CS$$                   
+    Building value     360                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    42     13
+
+    Storgatan 8 High wealth
+
+    Bulldoze Cost     40                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     1                       
+    Power Consumed     1                       
+    Water Consumed     7                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$$               
+    Occupant Size     Width     Height     Depth               
+    8     1     8               
+    Occupant Types     CS$     CS$$     CS$$$               
+    Building value     38                       
+    Capacity Satisfied     CS-$     CS-$$     CS-$$$               
+    79    22     11
+
+    **Storgatan 8 medium wealth**
+
+    Bulldoze Cost     234                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     3                       
+    Power Consumed     2                       
+    Water Consumed     23                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Euro     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    24.8626     19.746     17.4588               
+    Occupant Types     CS$     CS$$                   
+    Building value     686                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    80     22
+
+    **Dependencies**
+
+    ESA props vol 1 [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)  
+    Girafe flora pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX-legacy-bsc-vip-girafe-flora)  
+    BSC common dependencies [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    SHK parking pack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/](https://community.simtropolis.com/files/file/27563-shk-parking-pack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/35973-esa-storgatan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659f993a1f664_06-Jul.221801704957951.jpg.cbacf7b063545731d8b4a942f84f0b66.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659f993bac59a_06-Jul.221801704957936.jpg.541c74b930221f97da7afdfa7173ceac.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659f993dbb497_06-Jul.221801704957932.jpg.b4f766c74cc70d9057f0738833e5e597.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659f993f68d07_06-Jul.221801704957922.jpg.85fafb5dfd2ea38f7ed4d97061093d82.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/659f994138b22_06-Jul.221801704957915.jpg.04aa8c1b6d5e60d1478c58f303cb8cad.jpg
+dependencies:
+  - oidaas:proppack
+  - shk:parking-pack
+  - bsc:mega-props-cp-vol01
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:maples-v2
+  - girafe:rowan-trees
+assets:
+  - assetId: oidaas-storgatan
+
+---
+assetId: oidaas-storgatan
+version: "1.0.0"
+lastModified: "2024-01-11T07:32:58Z"
+url: https://community.simtropolis.com/files/file/35973-esa-storgatan/?do=download&r=199228

--- a/src/yaml/oidaas/36047-kiosk-funkis.yaml
+++ b/src/yaml/oidaas/36047-kiosk-funkis.yaml
@@ -1,0 +1,57 @@
+group: oidaas
+name: kiosk-funkis
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Kiosk funkis
+  description: |-
+    **About**
+
+    This is a kiosk that is modeled after a kiosk in a neighboring county.
+
+    **Stats**
+
+    Bulldoze Cost     103                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     7                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Houston     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    18.3327     7.082     11.3198               
+    Occupant Types     CS$     CS$$                   
+    Building value     137                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    16     6
+
+    **Dependcies**
+
+    BSC Creation pack [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    SC4D LEX LEGACY - BSC VIP Girafe Flora Pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    SHK Parking pack [https://community.simtropolis.com/files/file/27563-shk-parking-pack/](https://community.simtropolis.com/files/file/27563-shk-parking-pack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36047-esa-kiosk-funkis/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/65aab3e95ef1b_NewCity-May.7001705685234.jpg.5e3f22fd3f66fc91a2f1d93fc9195c1a.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_01/65aab3ea7b21a_NewCity-May.7001705685242.jpg.86a1540e68d30e5c5abea08934282719.jpg
+dependencies:
+  - shk:parking-pack
+  - girafe:maples-v2
+  - girafe:birches
+  - bsc:texturepack-cycledogg-vol01
+assets:
+  - assetId: oidaas-kiosk-funkis
+
+---
+assetId: oidaas-kiosk-funkis
+version: "1.0.0"
+lastModified: "2024-01-19T17:40:53Z"
+url: https://community.simtropolis.com/files/file/36047-esa-kiosk-funkis/?do=download&r=199435

--- a/src/yaml/oidaas/36054-kallarvagen.yaml
+++ b/src/yaml/oidaas/36054-kallarvagen.yaml
@@ -1,0 +1,58 @@
+# TODO - requires nob:texture-pack-vol01
+
+# group: oidaas
+# name: kallarvagen
+# version: "1.0.0"
+# subfolder: 300-commercial
+# info:
+#   summary: Källarvägen
+#   description: |-
+#     **About**  
+#     This is a house that is a somewhat copy of a house in Stockholm.  
+#     It had been sitting on my computers harddrive for a while so i decided to fi it up and release it.
+
+#     **Stats**
+
+#     Bulldoze Cost     250                       
+#     Wealth     High Wealth                       
+#     Pollution at center     Air     Water     Garbage     Radiation           
+#     1     1     4     0           
+#     Pollution radii     Air     Water     Garbage     Radiation           
+#     6     7     0     0           
+#     Flammability     35                       
+#     MaxFireStage     3                       
+#     Power Consumed     2                       
+#     Water Consumed     31                       
+#     SFX:Query Sound     0xEA55BDEB                       
+#     Query exemplar GUID     0xCA56783A                       
+#     OccupantGroups     Building: Commercial     Style: Euro     Building: CO$$$               
+#     Occupant Size     Width     Height     Depth               
+#     23.78630066     20.65810013     25.6739006               
+#     Occupant Types     CO$$     CO$$$                   
+#     Building value     437                       
+#     Capacity Satisfied     CO-$$     CO-$$$                   
+#     56     40
+
+#     **Dependencies**
+
+#     [SC4D LEX Legacy - BSC Common Dependencies Pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack)
+#     [SC4D LEX LEGACY - BSC VIP Girafe Flora Pack](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+#   author: Oidaas
+#   website: https://community.simtropolis.com/files/file/36054-esa-källarvägen/
+#   images:
+#     - https://www.simtropolis.com/objects/screens/monthly_2024_01/65af95ec9ab58_b-Apr.14231706004713.jpg.d67c2e3cada57d814288b891a88fe0b2.jpg
+#     - https://www.simtropolis.com/objects/screens/monthly_2024_01/65af95f223b08_b-Apr.14231706004672.jpg.9dfd30228fe6f4232a2bc72aa79ee8dc.jpg
+# dependencies:
+#   - nob:texture-pack-vol01
+#   - bsc:mega-props-cp-vol01
+#   - girafe:maples-v2
+#   - girafe:lindens
+#   - girafe:elms
+# assets:
+#   - assetId: oidaas-kallarvagen
+
+# ---
+# assetId: oidaas-kallarvagen
+# version: "1.0.0"
+# lastModified: "2024-01-23T10:34:30Z"
+# url: https://community.simtropolis.com/files/file/36054-esa-k%C3%A4llarv%C3%A4gen/?do=download&r=199490

--- a/src/yaml/oidaas/36123-elvestads-university-hospital.yaml
+++ b/src/yaml/oidaas/36123-elvestads-university-hospital.yaml
@@ -1,0 +1,100 @@
+group: oidaas
+name: elvestads-university-hospital
+version: "2.0.0"
+subfolder: 630-health
+info:
+  summary: Elvestads university hospital
+  description: |-
+    **About**
+
+    This is an old BAT that i spruced up with a helipad for instance.
+
+    **Dependencies**
+
+    ##### SC4D LEX Legacy - BSC Common Dependencies Pack [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+
+    ##### SC4D LEX LEGACY - BSC VIP Girafe Flora Pack [https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    [https://community.simtropolis.com/files/file/34596-bus-pack-hd/?do=embed](https://community.simtropolis.com/files/file/34596-bus-pack-hd/?do=embed)
+    [https://community.simtropolis.com/files/file/21968-bus-prop-pack/?do=embed](https://community.simtropolis.com/files/file/21968-bus-prop-pack/?do=embed)
+
+    Lot size:
+
+    20 x 15 tiles
+
+    Menu position:
+
+    Building: Civic,Building: Health,Building: Strikable Health,Building: Hospital,Building: LargeHealth
+
+    Jobs:
+
+    Jobs $ : 381,Jobs $$ : 1132,Jobs $$$ : 376,R-$ : 381,R-$$ : 1132,R-$$$ : 376
+
+    Plop cost:
+
+    § 26500
+
+    Bulldoze cost:
+
+    § 1150
+
+    Monthly cost:
+
+    § 14200,2400
+
+    Patient Capacity
+
+    56500
+
+     
+
+     
+
+    Max. Fire Stage:
+
+    36
+
+    Power consumption:
+
+    41 MWh/month
+
+    Water consumption:
+
+    161 Gallons/month
+
+    Air pollution:
+
+    24 over 3 tiles
+
+    Water pollution:
+
+    16 over 4 tiles
+
+    Garbage pollution:
+
+    12 over 0 tiles
+
+    staff edit 09.03.2024 - fixing description format by Tyberius06
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36123-esa-elvestads-university-hospital/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65ce763d36cc0_NewCity-Dec.12141708027840.png.4b025f630f0525300edd7134b5648829.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65ce764386fe7_NewCity-Jan.14151708027851.png.7b0e8eac1aeef41a26b870444234b68f.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65ce765062956_NewCity-Jan.14151708027870.png.7f5173d13331452e4250f8ae89fe932f.png
+dependencies:
+  - laky99:bus-pack-hd
+  - glenni:bus-prop-pack
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-dae-vol01
+  - bsc:mega-props-cp-vol02
+  - bsc:textures-vol02
+  - girafe:poplars
+assets:
+  - assetId: oidaas-elvestads-university-hospital
+
+---
+assetId: oidaas-elvestads-university-hospital
+version: "2.0.0"
+lastModified: "2024-03-10T09:15:10Z"
+url: https://community.simtropolis.com/files/file/36123-esa-elvestads-university-hospital/?do=download&r=200655

--- a/src/yaml/oidaas/36134-elvestad-addon.yaml
+++ b/src/yaml/oidaas/36134-elvestad-addon.yaml
@@ -1,0 +1,164 @@
+group: oidaas
+name: elvestad-addon
+version: "1.0.0"
+subfolder: 630-health
+info:
+  summary: Elvestad Addon
+  description: |-
+    About
+
+    This is an expansion of Elvestads hospital
+
+    Dependencies
+
+    BSC Common dependencies [https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+
+    Girafe Common [SC4D LEX LEGACY - BSC VIP Girafe Flora Pack](https://sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    Elvestad hospital
+
+    [https://community.simtropolis.com/files/file/36123-esa-elvestads-university-hospital/?do=embed](https://community.simtropolis.com/files/file/36123-esa-elvestads-university-hospital/?do=embed)
+    Stats
+
+    infection
+
+    Item Name     H flygeln\_recover 1  
+    Item Description     This building was made by a Typing Monkey  
+    Item Icon       
+    Item Order     2                       
+    Plop Cost     4200                       
+    Bulldoze Cost     200                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    6     4     3     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    3     4     0     0           
+    Flammability     36                       
+    MaxFireStage     4                       
+    Power Consumed     11                       
+    Water Consumed     41                       
+    Demand Created     Jobs $     Jobs $$     Jobs $$$     R-$     R-$$       
+    53     148     48     53     148       
+    R-$$$                       
+    48                       
+    Budget Item: Department     Health Staff     Health Coverage                   
+    Budget Item: Line     0x00000000     0x00000001                   
+    Budget Item: Purpose     Hospital Staff     Hospital Coverage                   
+    Budget Item: Cost     2300     400                   
+    SFX:Query Sound     0xaa55ba71                       
+    SFX:Default Plop Sound     0x4a5ec571                       
+    Query exemplar GUID     0xaa554aea                       
+    OccupantGroups     Building: Civic     Building: Health     Building: Strikable Health     Building: Hospital     Building: LargeHealth       
+    Occupant Size     Width     Height     Depth               
+    111.5     34.8088     48.9001               
+    Jail  
+    Catalog Capacity     7300                       
+    Hospital  
+    Hospital Coverage Radius     1128                       
+    Hospital Population vs. Distance     0     100     100     100           
+    Hospital Effectiveness vs. Average Age     0     8     100     8           
+    Hospital Patient Capacity     7300                       
+    Hospital HQ boost     11.52000046                       
+    Catalog Capacity     7300                       
+    Catalog Monthly Cost     2700
+
+    Pathology
+
+    User Visible Name Key     Open Paved Area  
+    Item Description Key     0x2026960B     0x07BDDF1C     0x335A551D               
+    Item Icon       
+    Item Order     5                       
+    Plop Cost     3250                       
+    Bulldoze Cost     90                       
+    Wealth     None                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Flammability     0                       
+    MaxFireStage     0                       
+    Power Consumed     0                       
+    Water Consumed     0                       
+    Landmark Effect     Magnitude     Radius                   
+    200     10                   
+    Demand Satisfied     R-$     R-$$     R-$$$               
+    80000     80000     80000               
+    Budget Item: Department     Park and Rec                       
+    Budget Item: Line     0x00000000                       
+    Budget Item: Purpose     Park Effect                       
+    Budget Item: Cost     400                       
+    SFX:Query Sound     0xCA9B8233                       
+    SFX:Default Plop Sound     0xEA5EC59F                       
+    Query exemplar GUID     0x0A562A05                       
+    OccupantGroups     Building: Civic     Building: Health     Building: Strikable Health     Building: Hospital     Building: LargeHealth       
+    Occupant Size     Width     Height     Depth
+
+    Psychiatry
+
+    Item Name     Custom Ploppable  
+    Item Description     Insert ploppable description here.  
+    Item Icon       
+    Item Order     1                       
+    Plop Cost     100                       
+    Bulldoze Cost     100                       
+    Wealth     None                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Flammability     10                       
+    MaxFireStage     1                       
+    Power Consumed     16                       
+    Water Consumed     0                       
+    Demand Satisfied     R-$     R-$$     R-$$$               
+    20     20     20               
+    Demand Created     Jobs $     Jobs $$     Jobs $$$     R-$     R-$$       
+    1     6     1     1     6       
+    R-$$$                       
+    1                       
+    Budget Item: Department     Health Staff     Health Coverage                   
+    Budget Item: Line     0x00000000     0x00000001                   
+    Budget Item: Purpose     Hospital Staff     Hospital Coverage                   
+    Budget Item: Cost     300     100                   
+    SFX:Query Sound     0xAA55BA71                       
+    SFX:Default Plop Sound     0x4A5EC571                       
+    Query exemplar GUID     0xAA554AEA                       
+    OccupantGroups     Building: Civic     Building: Health     Building: Strikable Health     Building: Hospital     Building: AmbulanceMaker       
+    Occupant Size     Width     Height     Depth               
+    101     31     66,16599               
+    Hospital  
+    Hospital Coverage Radius     400                       
+    Hospital Population vs. Distance     0     100     100     100           
+    Hospital Effectiveness vs. Average Age     0     8     100     8           
+    Hospital Patient Capacity     3000                       
+    Hospital HQ boost     11,52                   
+    1     0     1
+
+    staff edit 09.03.2024: deleted the large empty spaces around the text. - Tyberius06
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36134-esa-elvestad-addon/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65d58eac3a1c3_NewCity-Jan.11001708457905.jpg.e0b9796f55278935471f359961adc4b3.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65d58eadb0346_NewCity-Jan.11001708457910.jpg.2d55c8d050a92094d4266bb07a5eb1de.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65d58eb09173f_NewCity-Jan.11001708457922.png.b703eb34e41d80507c313d1cf35a59b3.png
+    - https://www.simtropolis.com/objects/screens/monthly_2024_02/65d58eeb1270a_NewCity-Jan.11001708457916.png.39bb2af91feafbb66bdf3cdee6dab327.png
+dependencies:
+  - oidaas:elvestads-university-hospital
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:mega-props-sg-vol01
+  - bsc:mega-props-cp-vol02
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - girafe:maples-v2
+  - girafe:birches
+  - girafe:elms
+  - girafe:lindens
+  - squidi:ps-textures
+assets:
+  - assetId: oidaas-elvestad-addon
+
+---
+assetId: oidaas-elvestad-addon
+version: "1.0.0"
+lastModified: "2024-02-21T06:00:03Z"
+url: https://community.simtropolis.com/files/file/36134-esa-elvestad-addon/?do=download&r=200325

--- a/src/yaml/oidaas/36167-rail-props-vol3.yaml
+++ b/src/yaml/oidaas/36167-rail-props-vol3.yaml
@@ -1,0 +1,22 @@
+group: oidaas
+name: rail-props-vol3
+version: "2.0.0"
+subfolder: 100-props-textures
+info:
+  summary: Rail props vol 3
+  description: |-
+    About
+
+    This is a dependency pack for your use to enjoy.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36167-esa-rail-props-vol-3/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_03/65edb6099ecbc_Railpropsvol3.png.0b2b3ae67a8cdd8f0bbdd7a213fb3b2a.png
+assets:
+  - assetId: oidaas-rail-props-vol3
+
+---
+assetId: oidaas-rail-props-vol3
+version: "2.0.0"
+lastModified: "2024-03-10T15:01:39Z"
+url: https://community.simtropolis.com/files/file/36167-esa-rail-props-vol-3/?do=download&r=200661

--- a/src/yaml/oidaas/36390-paittasjarvi.yaml
+++ b/src/yaml/oidaas/36390-paittasjarvi.yaml
@@ -1,0 +1,87 @@
+# TODO - requires bnl:essentials
+
+group: oidaas
+name: paittasjarvi
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Paittasjarvi
+  description: |-
+    **About**
+
+    This is a collection of R$ and r$$ homes from the ghost village of the ghost village of Paittasjarvi in the style Finnish Russian architecture.
+
+    **Stats**
+
+    **R$**
+
+    Bulldoze Cost     122                       
+    Wealth     Low Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    0     0     2     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     3                                           
+    OccupantGroups     Building: Residential     Building: R$     Style: Euro               
+    Occupant Size     Width     Height     Depth               
+    1     1     1               
+    Occupant Types     R$                       
+    Building value     358                       
+    Capacity Satisfied       
+    R-$ 15
+
+    **r$$**
+
+    Bulldoze Cost     122                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    0     0     2     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     3                                           
+    OccupantGroups     Building: Residential     Building: R$$     Style: Euro               
+    Occupant Size     Width     Height     Depth               
+    1     1     1               
+    Occupant Types     R$     R$$                   
+    Building value     358                       
+    Capacity Satisfied     R-$     R-$$                   
+    5     15
+
+    **Dependencies**  
+    BSC Common dependency [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    BSC VIP Girafe Flora Pack [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)  
+    ESA Props vol 1  [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)  
+    PEG SPAM Super Resource Pack [https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/](https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/)  
+    SFBT Essentials [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/13-sfbt\-essentials](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/13-sfbt-essentials)  
+    Historic Harbour [https://community.simtropolis.com/files/file/29880-historic-harbor/](https://community.simtropolis.com/files/file/29880-historic-harbor/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36390-esa-paittasjarvi/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66b95ecc7d004_NewCity-May.16341723310142.jpg.f5007b09c649d88f0664377363c5c02e.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66b95ed994cc0_NewCity-Mar.2181723393867.jpg.f7b13f363c5ef9c40caa937f9343dbcf.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66b9617613d2d_NewCity-Dec.11401723425010.jpg.b1c686cfafed82e87034815adbca020f.jpg
+dependencies:
+  - oidaas:proppack
+  #- bnl:essentials
+  - historic-harbor:dependencies
+  - peg:spam-super-resource-pack
+  - sfbt:essentials
+  - girafe:ashes
+  - girafe:birches
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:mega-props-sg-vol01
+  - t-wrecks:maxis-prop-names-and-query-fix
+assets:
+  - assetId: oidaas-paittasjarvi
+
+---
+assetId: oidaas-paittasjarvi
+version: "1.0.0"
+lastModified: "2024-08-12T01:12:32Z"
+url: https://community.simtropolis.com/files/file/36390-esa-paittasjarvi/?do=download&r=202421

--- a/src/yaml/oidaas/36391-kallax.yaml
+++ b/src/yaml/oidaas/36391-kallax.yaml
@@ -1,0 +1,58 @@
+group: oidaas
+name: kallax
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Kallax
+  description: |-
+    **About**
+
+    This is a modern take on Paittasjarvi named after a village near my hometown. It's modded as a r$$ and grows in New york tileset.
+
+    **Stats**
+
+    Bulldoze Cost     126                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     2                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Style: New York     Building: R$$               
+    Occupant Size     Width     Height     Depth               
+    15.288     9.36     11.44               
+    Occupant Types     R$     R$$                   
+    Building value     202                       
+    Capacity Satisfied     R-$     R-$$                   
+    14     9
+
+    **Dependencies**
+
+    BSC Common Dependencies Pack [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+
+    Girafe Flora pack [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    ESA Proppack vol [https://community.simtropolis.com/files/file/33619-esa-proppack/](https://community.simtropolis.com/files/file/33619-esa-proppack/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36391-esa-kallax/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66ba2bf2dd9cb_NewCity-Apr.1031723440496.jpg.0658be22a58a76a7af6749f9dbfcd617.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66ba2c1462484_NewCity-Feb.2711723441039.jpg.da2d124a36951f6d862d352c1d3a58da.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_08/66ba2c1bb0b48_NewCity-Feb.2711723441054.jpg.44344702901c43f3c06bcec63be4b223.jpg
+dependencies:
+  - oidaas:proppack
+  - bsc:textures-vol02
+  - girafe:maples-v2
+assets:
+  - assetId: oidaas-kallax
+
+---
+assetId: oidaas-kallax
+version: "1.0.0"
+lastModified: "2024-08-12T15:39:10Z"
+url: https://community.simtropolis.com/files/file/36391-esa-kallax/?do=download&r=202425

--- a/src/yaml/oidaas/36514-malmberget-funkis.yaml
+++ b/src/yaml/oidaas/36514-malmberget-funkis.yaml
@@ -1,0 +1,60 @@
+group: oidaas
+name: malmberget-funkis
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Malmberget Funkis
+  description: |-
+    **About**
+
+    This is a villa made in Funkis style after a villa built in the Swedish Town of Malmberget.
+
+    **Stats**
+
+    Bulldoze Cost     130                       
+    Wealth     Low Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     5     0     0           
+    Flammability     45                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     1                       
+    SFX:Query Sound     0x6A63BBA2                       
+    Query exemplar GUID     0x4A5672BF                       
+    OccupantGroups     Building: Residential     Building: R$     Style: Houston               
+    Occupant Size     Width     Height     Depth               
+    12.80000019     10     19.3526001               
+    Occupant Types     R$                       
+    Building value     271                       
+    Capacity Satisfied     R-$ 20
+
+    **Dependencies**
+
+    SC4D LEX LEGACY - BSC VIP Girafe Flora Pack  
+    [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    SC4D LEX Legacy - BSC Common Dependencies Pack  
+    [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy) bsc-common-dependencies-pack
+
+    Glenni Megaprops vol 2  
+    [https://community.simtropolis.com/files/file/20564-ndex\-glenni-mega-props-vol02/](https://community.simtropolis.com/files/file/20564-ndex-glenni-mega-props-vol02/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36514-esa-malmberget-funkis/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67142f9011bd9_(Byske)-Apr.6471729372261.jpg.00f34d8f703e99c8eca7f48cdbb97e58.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67142f90a1326_(Byske)-Apr.6471729372273.jpg.6ad173f41bedde28670eab20e0e9dc24.jpg
+dependencies:
+  - ndex:glenni-mega-props-vol02
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:maples-v2
+  - girafe:birches
+assets:
+  - assetId: oidaas-malmberget-funkis
+
+---
+assetId: oidaas-malmberget-funkis
+version: "1.0.0"
+lastModified: "2024-10-19T22:19:10Z"
+url: https://community.simtropolis.com/files/file/36514-esa-malmberget-funkis/?do=download&r=203991

--- a/src/yaml/oidaas/36515-fritz-olsson.yaml
+++ b/src/yaml/oidaas/36515-fritz-olsson.yaml
@@ -1,0 +1,58 @@
+group: oidaas
+name: fritz-olsson
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Fritz Olsson
+  description: |-
+    **About**
+
+    This is a replica of a pair of now demolished houses in my hometown.
+
+    **Stats**
+
+    Bulldoze Cost     233                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    4     3     6     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     3                       
+    Power Consumed     10                       
+    Water Consumed     123                       
+    SFX:Query Sound     0x2A8916AB                       
+    Query exemplar GUID     0xCA56783A                       
+    OccupantGroups     Building: Commercial     Building: CS$$     Style: Euro     BTE : Comm. W2W     BTE : Comm. Retailers       
+    Occupant Size     Width     Height     Depth               
+    43.61109924     19.65049934     38.22579956               
+    Occupant Types     CS$     CS$$                   
+    Building value     4272                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    498     127
+
+    **Dependencies**
+
+    C4D LEX LEGACY - BSC VIP Girafe Flora Pack  
+    [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    SC4D LEX Legacy - BSC Common Dependencies Pack  
+    [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36515-esa-fritz-olsson/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67143d04731f2_(Byske)-Dec.28461729378797.jpg.3730f4abeddf50f0d8563be3bbc84de7.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67143d054e4e8_(Byske)-Dec.28461729378732.jpg.05ad5004ca5e8b258c9ede177e3115ea.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67143d0653716_(Byske)-Dec.28461729378740.jpg.fa8dd1cefd6c9b373b69df9c769c200d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/67143d49c2647_(Byske)-Dec.28461729378807.jpg.b7259d82f819bd2d7a45e1a6b17a76c9.jpg
+dependencies:
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - girafe:maples-v2
+assets:
+  - assetId: oidaas-fritz-olsson
+
+---
+assetId: oidaas-fritz-olsson
+version: "1.0.0"
+lastModified: "2024-10-19T23:16:02Z"
+url: https://community.simtropolis.com/files/file/36515-esa-fritz-olsson/?do=download&r=203994

--- a/src/yaml/oidaas/36529-brutalist.yaml
+++ b/src/yaml/oidaas/36529-brutalist.yaml
@@ -1,0 +1,49 @@
+group: oidaas
+name: brutalist
+version: "1.0.0"
+subfolder: 300-commercial
+info:
+  summary: Brutalist
+  description: |-
+    **About**
+
+    This is an old bat that i decided to share,
+
+    **Stats**
+
+    Bulldoze Cost     275                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     3                       
+    Power Consumed     3                       
+    Water Consumed     30                       
+    SFX:Query Sound     0x2a8916ab                       
+    Query exemplar GUID     0xca56783a                       
+    OccupantGroups     Building: Commercial     Style: Chicago     Building: CS$$               
+    Occupant Size     Width     Height     Depth               
+    31.5     23.767     15.5               
+    Occupant Types     CS$     CS$$                   
+    Building value     952                       
+    Capacity Satisfied     CS-$     CS-$$                   
+    111     30
+
+    **Dependencies**
+
+    For once non.
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36529-esa-brutalist/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/671f69681a1f6_NewCity-Nov.17731730109929.jpg.eb1f13b48fee32800afefcb44ea1f930.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_10/671f696f3d0aa_NewCity-Dec.20731730109946.jpg.5ea5b0f2fde87b1fa84c67908d890de7.jpg
+assets:
+  - assetId: oidaas-brutalist
+
+---
+assetId: oidaas-brutalist
+version: "1.0.0"
+lastModified: "2024-10-28T10:38:59Z"
+url: https://community.simtropolis.com/files/file/36529-esa-brutalist/?do=download&r=204145

--- a/src/yaml/oidaas/36538-farm-pack-vol1.yaml
+++ b/src/yaml/oidaas/36538-farm-pack-vol1.yaml
@@ -1,0 +1,60 @@
+# TODO - requires bnl:essentials, ac:mega-textures-vol01
+
+group: oidaas
+name: farm-pack-vol1
+version: "1.0.0"
+subfolder: 410-agriculture
+info:
+  summary: Farm pack vol 1
+  description: |-
+    **About**
+
+    This is a pack of farms that I've gathered over time that i decided to share.
+
+    **Dependencies**
+
+    BSC Common dependencies [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    ESA Props vol 1 [https://community.simtropolis.com](https://community.simtropolis.com)  
+    ESA Malmberget vol 1 [https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/](https://community.simtropolis.com/files/file/33552-malmberget-proppack-vol1/)  
+    ESA Farmprops [https://community.simtropolis.com/files/file/36236-esa-farmprops-vol-1/](https://community.simtropolis.com/files/file/36236-esa-farmprops-vol-1/)  
+    PEG SPAM Super resource pack [https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/](https://community.simtropolis.com/files/file/26079-peg-spam-super-resource-pack/)  
+    PEG MTP SUPER PACK [https://community.simtropolis.com/files/file/20966-peg-mtp\-super-pack/](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)
+
+    Girafe florapack [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    [https://community.simtropolis.com/files/file/26806-vip-rural-pack-v2/?do=embed](https://community.simtropolis.com/files/file/26806-vip-rural-pack-v2/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36538-esa-farm-pack-vol-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/6729337585338_Norra-Dec.28131730743049.jpg.df0080eec42168933d8da5636f89a4c6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/672933765f304_Norra-Sep.10131730742943.jpg.38298682e9c90cfbcde7b3c07608a497.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/672933946e273_East-Mar.19081730752501.jpg.5385f0366be8799308849f1a12f252d9.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/6729339559276_East-Mar.19081730752566.jpg.6d5c2d275e1f175adad8a8ac4d29ef0d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/67293396255b6_East-Sep.13081730752904.jpg.70419754af7da7027d61bad530ae7367.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/67293396c0d63_East-Sep.13081730752999.jpg.f104e1d70bdbd9039241da90d5661e1f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/6729339780008_East-Sep.13081730753026.jpg.20b136e88ee9f7b0a4ae4d20457fec14.jpg
+dependencies:
+  - oidaas:proppack
+  - oidaas:malmberget-props-vol01
+  - esa:farm-props-vol01
+  - peg:mtp-super-pack
+  - peg:spam-super-resource-pack
+  - vip:rural-pack
+  - bsc:bat-props-mattb325-vol02
+  - bsc:texturepack-cycledogg-vol01
+  - bsc:mega-props-jmyers-agriculture-vol02
+  - bsc:mega-props-sg-vol01
+  - girafe:rowan-trees
+  - girafe:birches
+  #- bnl:essentials
+  - t-wrecks:maxis-prop-names-and-query-fix
+  - bsc:sg-models-agriculture
+  #- ac:mega-textures-vol01
+assets:
+  - assetId: oidaas-farm-pack-vol1
+
+---
+assetId: oidaas-farm-pack-vol1
+version: "1.0.0"
+lastModified: "2024-11-04T20:51:38Z"
+url: https://community.simtropolis.com/files/file/36538-esa-farm-pack-vol-1/?do=download&r=204237

--- a/src/yaml/oidaas/36545-hallgatan.yaml
+++ b/src/yaml/oidaas/36545-hallgatan.yaml
@@ -1,0 +1,65 @@
+group: oidaas
+name: hallgatan
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: Hallgatan
+  description: |-
+    **About**
+
+    This is a house that was situated in the Swedish Town of Malmberget. In game it's modded as a R$$$
+
+    **Stats**
+
+    Bulldoze Cost     186                       
+    Wealth     High Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    6     7     0     0           
+    Flammability     35                       
+    MaxFireStage     2                       
+    Power Consumed     2                       
+    Water Consumed     5                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Style: Houston     Building: R$$$               
+    Occupant Size     Width     Height     Depth               
+    24.895     14.7     13.0117               
+    Occupant Types     R$     R$$     R$$$               
+    Building value     549                       
+    Capacity Satisfied     R-$     R-$$     R-$$$               
+    36     21     11
+
+    **Dependencies**
+
+    Malmberget proppack vol 2
+
+    [https://community.simtropolis.com/files/file/35927-malmberget-proppack-vol-2/](https://community.simtropolis.com/files/file/35927-malmberget-proppack-vol-2/)
+
+    SC4D LEX Legacy - BSC Common Dependencies Pack
+
+    [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+
+    SC4D LEX LEGACY - BSC VIP Girafe Flora Pack
+
+    [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36545-esa-hallgatan/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673123a45acb2_Aircity-Oct.21131731272568.jpg.01f17852f66b58e271357e3ec5362500.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673123b102486_Aircity-Nov.3131731272603.jpg.38cc571e9818038a2bd0d30af2cfb476.jpg
+dependencies:
+  - oidaas:malmberget-props-vol02
+  - bsc:texturepack-cycledogg-vol01
+  - girafe:oaks
+  - girafe:maples-v2
+  - bsc:mega-props-sg-vol01
+assets:
+  - assetId: oidaas-hallgatan
+
+---
+assetId: oidaas-hallgatan
+version: "1.0.0"
+lastModified: "2024-11-10T21:22:12Z"
+url: https://community.simtropolis.com/files/file/36545-esa-hallgatan/?do=download&r=204307

--- a/src/yaml/oidaas/36564-1920-homes.yaml
+++ b/src/yaml/oidaas/36564-1920-homes.yaml
@@ -1,0 +1,74 @@
+group: oidaas
+name: 1920-homes
+version: "1.0.0"
+subfolder: 200-residential
+info:
+  summary: 1920 Style Homes
+  description: |-
+    About
+
+    This is 1920 style homes.
+
+    Stats
+
+    Bulldoze Cost     40                       
+    Wealth     Medium Wealth                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    1     1     4     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    5     6     0     0           
+    Flammability     40                       
+    MaxFireStage     1                       
+    Power Consumed     1                       
+    Water Consumed     2                       
+    SFX:Query Sound     0x6a63bba2                       
+    Query exemplar GUID     0x4a5672bf                       
+    OccupantGroups     Building: Residential     Building: R$$     Style: Houston       
+                          
+    Occupant Size     Width     Height     Depth               
+    8     1     8               
+    Occupant Types     R$     R$$                   
+    Building value     43                       
+    Capacity Satisfied     R-$     R-$$                   
+    3     3
+
+    Dependencies
+
+    ##### SC4D LEX Legacy - BSC Common Dependencies Pack [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)
+
+    Garge props (included)
+
+    ESA proppack vol 1
+
+    [https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed](https://community.simtropolis.com/files/file/33619-esa-proppack/?do=embed)
+    Girafe Common [https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/25-flora-fauna-and-mayor-mode-ploppables/27-sc4d-lex-legacy-bsc-vip-girafe-flora)
+
+    Shk parking pack
+
+    [https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed](https://community.simtropolis.com/files/file/27563-shk-parking-pack/?do=embed)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36564-esa-1920/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673b9276ed22e_NewCity-Sep.4161731956348.jpg.80ab7d954d7c0434396c837649079be1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673b928b3973a_NewCity-Sep.4161731956330.jpg.7eff95480f134917163f7e5e0485b236.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673b92a41d3bc_NewCity-Sep.4161731956374.jpg.d7ac58f4bf3d5235df94d92e0056d12c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/evidense.jpg.5b6efc3c37fd670313e0f3d2932b5e19.jpg
+dependencies:
+  - oidaas:proppack
+  - shk:parking-pack
+  - girafe:norway-maples
+assets:
+  - assetId: oidaas-1920-homes
+  - assetId: oidaas-1920-garage-props
+
+---
+assetId: oidaas-1920-homes
+version: "1.0.0"
+lastModified: "2024-11-18T19:32:10Z"
+url: https://community.simtropolis.com/files/file/36564-esa-1920/?do=download&r=204443
+
+---
+assetId: oidaas-1920-garage-props
+version: "1.0.0"
+lastModified: "2024-11-18T19:32:10Z"
+url: https://community.simtropolis.com/files/file/36564-esa-1920/?do=download&r=204444

--- a/src/yaml/oidaas/36566-viipuri-relot.yaml
+++ b/src/yaml/oidaas/36566-viipuri-relot.yaml
@@ -1,0 +1,66 @@
+group: oidaas
+name: viipuri-relot
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: SC4 Viipuri relot
+  description: |-
+    **About**
+
+    this a relot of Krio's fantastica Viipuri station-    
+    Stats
+
+    Item Order     1                       
+    Plop Cost     1500                       
+    Bulldoze Cost     100                       
+    Wealth     None                       
+    Pollution at center     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Pollution radii     Air     Water     Garbage     Radiation           
+    0     0     0     0           
+    Flammability     10                       
+    MaxFireStage     1                       
+    Power Consumed     61                       
+    Water Consumed     0                       
+    Demand Created     Jobs $     Jobs $$     Jobs $$$     R-$     R-$$       
+    95     5     0     95     5       
+    R-$$$                       
+    0                       
+    Budget Item: Department     Mass Transit                       
+    Budget Item: Line     0x00000001                       
+    Budget Item: Purpose     Mass Transit Switch                       
+    Budget Item: Cost     100                       
+    SFX:Query Sound     0x2A55BD56                       
+    SFX:Default Plop Sound     0x4A5EC571                       
+    Query exemplar GUID     0x4A565D13                       
+    OccupantGroups     Building: Transportation     Building: Rail     Building: Strikable Transit     Building: Taxi\_Maker     Building: PassengerRail
+
+    **Dependencies**
+
+    BSC common [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    Girafe common [https://www.sc4evermore.com/index.php/downloads/download/27-sc4d-LEX\-legacy-bsc-vip-girafe-flora](https://www.sc4evermore.com/index.php/downloads/download/27-sc4d-lex-legacy-bsc-vip-girafe-flora)  
+    Krio Viipuri [https://community.simtropolis.com/files/file/28021-viipuri-railwaystation/](https://community.simtropolis.com/files/file/28021-viipuri-railwaystation/)  
+    Mumrik bike [https://community.simtropolis.com/files/file/25681-murimk-props-vol01-bicycle-props-with-bikers-mmp/](https://community.simtropolis.com/files/file/25681-murimk-props-vol01-bicycle-props-with-bikers-mmp/)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36566-sc4-viipuri-relot/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673d6b1a65556_NewCity-Apr.1001732076985.jpg.a81f7075afd90c7c47b139fc7f064d29.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/673d6b1aec03e_NewCity-Apr.1001732077011.jpg.c41b09c3386fb36c6538ee69ddd1f662.jpg
+dependencies:
+  - krio:viipuri-railway-station-resources
+  - murimk:props-vol01-bicycles
+  - bsc:textures-vol01
+  - bsc:textures-vol02
+  - porkissimo:jenx-porkie-expanded-porkie-props
+  - girafe:beeches
+  - girafe:maples-v2
+  - bsc:mega-props-jes-vol01
+  - krio:small-prop-pack
+assets:
+  - assetId: oidaas-sc4-viipuri-relot
+
+---
+assetId: oidaas-sc4-viipuri-relot
+version: "1.0.0"
+lastModified: "2024-11-20T04:54:30Z"
+url: https://community.simtropolis.com/files/file/36566-sc4-viipuri-relot/?do=download&r=204457

--- a/src/yaml/oidaas/36573-skelleftea-station.yaml
+++ b/src/yaml/oidaas/36573-skelleftea-station.yaml
@@ -1,0 +1,63 @@
+group: oidaas
+name: skelleftea-station
+version: "1.0.0"
+subfolder: 700-transit
+info:
+  summary: Skelleftea station
+  description: |-
+    About
+
+    This is based on a Railway in a neighbouring Town.
+
+    Stats
+
+    Item Name     Skelleftea station  
+    Item Order     1                       
+    Plop Cost     500                       
+    Bulldoze Cost     30                                           
+    Flammability     37                       
+    MaxFireStage     2                       
+    Power Consumed     1                       
+    Water Consumed     2                                       
+    Budget Item: Department     Mass Transit                       
+    Budget Item: Line     0x00000001                       
+    Budget Item: Purpose     Mass Transit Switch                       
+    Budget Item: Cost     15                                           
+    OccupantGroups     Building: Transportation     Building: Rail     Building: Strikable Transit     Building: Taxi\_Maker     Building: PassengerRail       
+    Occupant Size     Width     Height     Depth               
+    30,717     11,838     12,638                                   
+    Catalog Capacity     3600                       
+    Transit Switch Point     Outside to Inside     North,West,South,East     Rail     Rail           
+    Inside to Outside     North,West,South,East     Rail     Rail           
+    Outside to Inside     North,West,South,East     Freight Train     Freight Train           
+    Inside to Outside     North,West,South,East     Freight Train     Freight Train           
+    Transit Switch Entry Cost     0,0071                       
+    Transit Switch Traffic Capacity     13599
+
+    Dependencies
+
+    NDEX Glenni MEGA Props Vol01: [https://community.simtropolis.com/files/file/19096-ndex\-glenni-mega-props-vol01/](https://community.simtropolis.com/files/file/19096-ndex-glenni-mega-props-vol01/)  
+    BSC common: [https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-LEX\-legacy-bsc-common-dependencies-pack](https://www.sc4evermore.com/index.php/downloads/download/22-dependencies/3-sc4d-lex-legacy-bsc-common-dependencies-pack)  
+    Girafe common: [https://www.sc4evermore.com/index.php](https://www.sc4evermore.com/index.php)
+  author: Oidaas
+  website: https://community.simtropolis.com/files/file/36573-esa-skelleftea-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/674777277ef7c_Norra-Jul.11191732725155.jpg.11955c0a9124a940eec938596ae3e5af.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/674777284293c_Norra-May.3181732709055.jpg.abfbc5db88a4c7cc26171a442e795422.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/67477728e1b5c_Norra-May.14181732709088.jpg.d568c42a430800a19e5c37957f520b61.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2024_11/674777299085c_Norra-May.14181732709117.jpg.a7858897b47490194203d25d7cfd19e1.jpg
+dependencies:
+  - ndex:glenni-mega-props-vol01
+  - bsc:mega-props-misc-vol02
+  - bsc:mega-props-sg-vol01
+  - girafe:rowan-trees
+  - girafe:maples-v2
+  - bsc:texturepack-cycledogg-vol01
+assets:
+  - assetId: oidaas-skelleftea-station
+
+---
+assetId: oidaas-skelleftea-station
+version: "1.0.0"
+lastModified: "2024-11-27T19:48:09Z"
+url: https://community.simtropolis.com/files/file/36573-esa-skelleftea-station/?do=download&r=204518

--- a/src/yaml/squidi/19571-ps-textures.yaml
+++ b/src/yaml/squidi/19571-ps-textures.yaml
@@ -1,0 +1,20 @@
+group: squidi
+name: ps-textures
+version: "1.0"
+subfolder: 100-props-textures
+info:
+  summary: ps textures
+  description: |-
+    there are about 130 textures i created.and maybe you like to use them in your lots.
+  author: squidi
+  website: https://community.simtropolis.com/files/file/19571-ps-textures/
+  images:
+    - https://www.simtropolis.com/objects/screens/0024/d65e6bf6e7c4bef91e3d3e36cdc4837a-textures.jpg
+assets:
+  - assetId: squidi-ps-textures
+
+---
+assetId: squidi-ps-textures
+version: "1.0"
+lastModified: "2008-03-25T07:52:17Z"
+url: https://community.simtropolis.com/files/file/19571-ps-textures/?do=download&r=44365


### PR DESCRIPTION
The dependencies here are a mess. There's numerous dependencies missing I couldn't identify as they were missing from the Prop Texture Catalog. Also some model files were reported as missing. I'll revisit after updates to the Catalog to see if that helps.

Also all of the STEX file descriptions should be updated with the generated dependencies. Especially with the content on page 1, most of the dependencies linked on the STEX point to just the Common Dependencies pack instead of the individual prop packs.