### PR TITLE
metadata: add even more of Peg's content

### DIFF
--- a/src/yaml/peg/10886-subterranean-mall.yaml
+++ b/src/yaml/peg/10886-subterranean-mall.yaml
@@ -1,0 +1,27 @@
+group: peg
+name: subterranean-mall
+version: "1.1"
+subfolder: 300-commercial
+info:
+  summary: Subterranean Mall
+  description: |-
+    We have built out... we have built up... now we can build down! The new PEG Subterranean Mall is the first of several new lots that will utilize your available real estate to its fullest extent by utilizing the space under your transportation network and existing development. These lots are designed to visually connect to each other both end-to-end and side-to-side... allowing you to create sprawling, inter-connected shopping complexes. They also work well when plopped alone as a small, space-saving singular shopping mall. This initial offering includes two 3x6 lots... similar in appearance but slightly different... and each containing unique store signage for added variety.
+
+    The sub-malls are now "Christmas Enabled" and will show Christmas decorations & lighting during the Holiday season. Installation of the [PEG Christmas Development Kit](https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/) is required.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10886-peg-subterranean-mall-v206/
+  images:
+    - https://www.simtropolis.com/objects/screens/0024/dcaa23db212772e0f847cc148047323d-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0024/dcaa23db212772e0f847cc148047323d-product_image2.jpg
+dependencies:
+  - peg:christmas-development-kit
+assets:
+  - assetId: peg-subterranean-mall
+
+---
+assetId: peg-subterranean-mall
+version: "1.1"
+lastModified: "2025-05-02T23:35:19Z"
+url: https://community.simtropolis.com/files/file/10886-peg-subterranean-mall-v206/?do=download&r=207353

--- a/src/yaml/peg/10893-ore-cars-prop-pack.yaml
+++ b/src/yaml/peg/10893-ore-cars-prop-pack.yaml
@@ -1,0 +1,22 @@
+group: peg
+name: ore-cars-prop-pack
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: Ore Cars Prop Pack
+  description: |-
+    The PEG Ore Car Pack contains 2 variations (classic railroad red & rusty gray) of an older style metal railroad ore car that was in common use throughout North America and many other areas. There are 2 versions of each car; loaded and empty. These are not static props. They are designed to simulate activity by randomly appearing & disappearing throughout the day, as well as changing from empty to loaded. Placing several of these on a rail siding will accurately simulate an active mining or bulk product rail activity. The cars tend to be more empty in the early hours of the day and fill up as the day progresses. Most will disappear in the late evening hours and return again the next morning. The easiest way to use these in your lot development is to use the two prop families they are assigned to. Please see the Developer Notes in the Readme file for details.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10893-peg-ore-cars-prop-pack/
+  images:
+    - https://www.simtropolis.com/objects/screens/0019/af8c60b600a5bdda7d9b529e12c6feb8-product_image.jpg
+assets:
+  - assetId: peg-ore-cars-prop-pack
+
+---
+assetId: peg-ore-cars-prop-pack
+version: "1.1"
+lastModified: "2025-05-02T23:33:03Z"
+url: https://community.simtropolis.com/files/file/10893-peg-ore-cars-prop-pack/?do=download&r=207351

--- a/src/yaml/peg/10937-big-johns-mine.yaml
+++ b/src/yaml/peg/10937-big-johns-mine.yaml
@@ -1,0 +1,33 @@
+group: peg
+name: big-johns-mine
+version: "1.1"
+subfolder: 400-industrial
+info:
+  summary: Big Johns Mine
+  description: |-
+    Big John's Mine was started by a group of mine disaster survivors and named after the man who sacrificed his life to save them. Still following the original vein discovered in 1887, Big John's Mine continues to turn a tidy profit for its owners & providing jobs for local inhabitants. Sure, mining is a dirty industry but small old mines such as Big John's often spared the landscape of the scars inflicted by large pit and hydraulic mining operations.
+
+    This lot uses the PEG Ore Car props that simulate a shuffling effect as cars generally appear early in the day, fill up, move around and often are gone after nightfall. This lot is also transit enabled for rail as well as road traffic. The UI sound effect is lengthy... an often annoying PEG trademark... but it does help set the mood.  Enjoy..
+
+    **Dependencies:**  
+    [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)  
+    [PEG Ore Cars Prop Pack](https://community.simtropolis.com/files/file/10893-peg-ore-cars-prop-pack/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+
+    **\-Cori Edit:** Made deps clickable linkys.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10937-peg-big-johns-mine-v205a/
+  images:
+    - https://www.simtropolis.com/objects/screens/0006/2aa21ad17b8a14e368eb2c5b0991771a-product_image.jpg
+dependencies:
+  - peg:mtp-super-pack
+  - peg:ore-cars-prop-pack
+assets:
+  - assetId: peg-big-johns-mine-v205a
+
+---
+assetId: peg-big-johns-mine-v205a
+version: "1.1"
+lastModified: "2025-05-02T03:05:16Z"
+url: https://community.simtropolis.com/files/file/10937-peg-big-johns-mine-v205a/?do=download&r=207283

--- a/src/yaml/peg/10938-oceanographic-institute.yaml
+++ b/src/yaml/peg/10938-oceanographic-institute.yaml
@@ -1,0 +1,32 @@
+group: peg
+name: oceanographic-institute
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Oceanographic Institute
+  description: |-
+    Pegadyne Industries is pleased to announce the opening of the their new Oceanographic Institute off the coast of your city. This long-awaited private university will take advanced education to the next level offering masters & doctorate programs in Oceanography, Marine Biology, Marine Engineering & HydroSimology. City planners anticipate a large increase in High Tech industrial demand as graduates from this elite institution hit the job market.
+
+    The Oceanographic Institute is an alternative to the game's university and has the same properties and characteristics. But unlike the university's massive size, the institute only takes up one, single land tile. The entire facility resides completely in the water.
+
+    The POI also offers up to 450 CS jobs. IT can be plopped in any water depth... however the underwater detail may only be visible in shallower water.
+
+    **Dependency:**
+
+    [BSC Textures Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/10938-peg-oceanographic-institute-v205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0014/7a9c08599556fce58350f5921710d7ec-product_image.jpg
+dependencies:
+  - bsc:textures-vol01
+assets:
+  - assetId: peg-oceanographic-institute
+
+---
+assetId: peg-oceanographic-institute
+version: "1.1"
+lastModified: "2025-05-02T23:36:36Z"
+url: https://community.simtropolis.com/files/file/10938-peg-oceanographic-institute-v205/?do=download&r=207356

--- a/src/yaml/peg/11115-seasonal-lot.yaml
+++ b/src/yaml/peg/11115-seasonal-lot.yaml
@@ -1,0 +1,47 @@
+group: peg
+name: seasonal-lot
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Seasonal Lot
+  description: |-
+    Unlike any other lot you've seen, this lot changes both in appearance and function... and is actually 3 lots in one! The new Seasonal Lot is a lot that changes through the year. It essentially is the classic empty lot suitable for urban areas, out in the burps... or way out in the stix. But this lot also serves a commercial function...
+
+    It starts the year as an ordinary empty dirt lot. In late January, the workers show up and prepare the lot for the upcoming Farmer's Market. In early February, the banners appear hyping the new market. A few weeks later, pallets and trash bins can be seen heralding the opening of the market... and in early March the tents go up and the Farmer's Market is open for business.
+
+    In early November, the tents come down to make room for the Christmas Tree lot. Over the next few weeks, the lot is cleared and new banners are put up. In early December, the lights are strung, the trees arrive and we're ready to go out and pick our tree.
+
+    After Christmas, the trees are gone... the lights come down... and a few weeks later someone gets around to taking down the banners. The workers show up to prep for the Farmers Market...and the cycle repeats...
+
+    The lot is a low wealth commercial property. It provides a handful of C$ jobs as well as generating some income from the leases to the market and tree lot. Its a ploppable 2x2 lot that also offers some park-like benefits stemming from the popularity of the Farmer's Market.
+
+    dependencies:  
+    PEG Christmas Development Kit
+
+    \* The lot is transit enabled for appearances only. The parking area can be connected to your traffic network using streets. If plopped facing existing roads, etc... it will connect automatically.
+
+    \* Depending on the time of year that the lot is plopped, the Farmer's Market and/or Christmas Tree lot may not develop until the following year. Like the Seasonal Trees, the various props used will not appear that year if plopped after their trigger dates..
+
+    **This lot requires the following dependency:**
+
+    **[PEG Christmas Development Kit](https://community.simtropolis.com/files/file/11097-peg-christmas-development-kit/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+
+    ***To all of you from all the members and staff at Pegasus Productions... Have a very, merry Holiday and a wonderful  New Year!***
+
+    [![product_image2.jpg](https://www.simtropolis.com/repository/attachments/monthly_2015_07/product_image2.thumb.jpg.9ce658e63bc0efb0bb91b52da3194ae9.jpg)](https://www.simtropolis.com/repository/attachments/monthly_2015_07/product_image2.jpg.e803b3029fc25afcb3675c46b64054c1.jpg)
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11115-peg-seasonal-lot/
+  images:
+    - https://www.simtropolis.com/objects/screens/0002/08a795af8ef8bc6fd1c1b906b418eb5a-product_image.jpg
+dependencies:
+  - peg:christmas-development-kit
+assets:
+  - assetId: peg-seasonal-lot
+
+---
+assetId: peg-seasonal-lot
+version: "1.1"
+lastModified: "2025-05-03T00:14:57Z"
+url: https://community.simtropolis.com/files/file/11115-peg-seasonal-lot/?do=download&r=207392

--- a/src/yaml/peg/11186-cop-car-mod.yaml
+++ b/src/yaml/peg/11186-cop-car-mod.yaml
@@ -1,0 +1,124 @@
+group: peg
+name: cop-car-mod
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: COP CAR MOD
+  description: |-
+    Tired of those old & clunky looking cop cars? What bad 1950s movie did they find those in? Well that's all about to change with the new PEG Police Car Replacement Modd.
+
+    This pack offers you a choice of 10 new modern police car styles that replace the game's automata as well all the props around the police stations. Its all automatic... just install the style of your choice and all the police cars in the game change to that style. There's even a new static prop in each style thrown in for the use of developers who want a cop on-lot 24/7.
+
+    The available styles include:
+
+    \* 4 styles of Black & White units with varied markings:
+
+    \- Star on doors.
+
+    \- Municipal seal on doors.
+
+    \- Sheriff's Unit.
+
+    \- SimCop's police cruiser... dedicated to Officer SimCop who is the TopCop in our books... and a major contributing factor for the success of the KrispyKremes franchise.
+
+    \* 5 styles of all White units with varied markings:
+
+    \- Standard ' POLICE ' cruiser.
+
+    \- White w/ Blue stripe.
+
+    \- White w/ Orange stripe.
+
+    \- NYPD
+
+    \- St. Lucie County Sheriff's Department in Florida. Dedicated to Deputy Dan1083 who is serving with pride through thick & thin... not to mention several hurricanes.
+
+    \* The official S.C.P.D. police cruiser... a "powerfully" blue & white unit that stands out and lets your Sims know that SimCity's finest is on the job.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11186-peg-cop-car-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0006/2c15f70f18a0bc902dee67b7aafe052e-product_image.jpg
+variants:
+  - variant: { peg:cop-car-mod:livery: black-and-white-star }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_BW-Star_205.dat"
+  - variant: { peg:cop-car-mod:livery: black-and-white-seal }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_BW-Seal_205.dat"
+  - variant: { peg:cop-car-mod:livery: black-and-white-sheriff }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_BW-Sheriff_205.dat"
+  - variant: { peg:cop-car-mod:livery: black-and-white-simcop }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_BW-Police_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-standard }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_WHT-Seal_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-blue-stripe }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_WHT-BlueStripe_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-orange-stripe }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_WHT-OrangeStripe_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-nypd }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_NYPD_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-st-lucie }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_St-Lucie-Sheriff_205.dat"
+  - variant: { peg:cop-car-mod:livery: all-white-scpd }
+    assets:
+      - assetId: peg-cop-car-mod
+        include:
+        - "/PEG_CopCar_SCPD_205.dat"
+variantInfo:
+- variantId: "peg:cop-car-mod:livery"
+  description: Customize the police vehicle livery.
+  values:
+  - value: "black-and-white-star"
+    description: Black & White unit with a star on doors.
+  - value: "black-and-white-seal"
+    description: Black & White unit with a municipal seal on doors.
+  - value: "black-and-white-sheriff"
+    description: Black & White Sheriff's unit.
+  - value: "black-and-white-simcop"
+    description: Black & White SimCop's police cruiser ... dedicated to Officer SimCop who is the TopCop in our books ... and a major contributing factor for the success of the KrispyKremes franchise.
+  - value: "all-white-standard"
+    description: All white standard police cruiser.
+  - value: "all-white-blue-stripe"
+    description: All white unit with a blue stripe.
+  - value: "all-white-orange-stripe"
+    description: All white unit with an orange stripe.
+  - value: "all-white-nypd"
+    description: All white NYPD unit.
+  - value: "all-white-st-lucie"
+    description: All white unit from St. Lucie County Sheriff's Department in Florida. Dedicated to Deputy Dan1083 who is serving with pride through thick & thin ... not to mention several hurricanes.
+  - value: "all-white-scpd"
+    description: The official S.C.P.D. police cruiser ... a "powerfully" blue & white unit that stands out and lets your Sims know that SimCity's finest is on the job.
+
+
+---
+assetId: peg-cop-car-mod
+version: "1.1"
+lastModified: "2025-05-02T23:41:01Z"
+url: https://community.simtropolis.com/files/file/11186-peg-cop-car-mod/?do=download&r=207358

--- a/src/yaml/peg/11212-hydroelectric-dam.yaml
+++ b/src/yaml/peg/11212-hydroelectric-dam.yaml
@@ -1,0 +1,38 @@
+group: peg
+name: hydroelectric-dam
+version: "1.1"
+subfolder: 500-utilities
+info:
+  summary: Hydroelectric Dam
+  description: |-
+    Yes... it produces electricity. Yes... traffic can travel across it. Yes... its designed for use with the PEG Pond Kit II. And Yes... it's pretty DAM cool!
+
+    Finally, the long lost hydro dams of yester-versions are back to provide your Sims with clean & cheap power. Now you can run a river down from your mountains using the Pond Kit II and build a series of these Hydro Dams that will provide even your largest cities with ample power & water.
+
+    Each dam produces about the same power as a Solar Power Plant. With version 2.07, each dam will increase the efficiency of connected water pumps by an extra 4,000 cu per month. The building & maintenance costs are about the same as a natural gas power plant.
+
+    \*\* This lot is not transit enabled. Its a single lot that plops on both sides of an existing road, street or rail. You can also run elevated rail across it... or trail parks... or zone it and see what develops.
+
+    This package includes the Waterfall Bottom lots (PEG\_Pond-WFB\_205.dat) that can be used to create the water turbulence on the lower side of the dam.
+
+    **Dependencies:  
+    [PEG Pond Kit II](https://community.simtropolis.com/files/file/11128-peg-pond-kit-ii/)  
+    [PEG 24/7 Mod](https://community.simtropolis.com/files/file/11220-peg-247-mod/) (used for water turbulence effect)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11212-peg-hydroelectric-dam/
+  images:
+    - https://www.simtropolis.com/objects/screens/0024/daf517292adc8702d9a5a1c9e9e99282-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0024/daf517292adc8702d9a5a1c9e9e99282-product_image2.jpg
+dependencies:
+  - peg:247-mod
+  - peg:pond-kit-ii-deluxe-edition
+assets:
+  - assetId: peg-hydroelectric-dam
+
+---
+assetId: peg-hydroelectric-dam
+version: "1.1"
+lastModified: "2025-05-02T23:20:49Z"
+url: https://community.simtropolis.com/files/file/11212-peg-hydroelectric-dam/?do=download&r=207335

--- a/src/yaml/peg/11220-247-mod.yaml
+++ b/src/yaml/peg/11220-247-mod.yaml
@@ -1,0 +1,38 @@
+group: peg
+name: 247-mod
+version: "1.0"
+subfolder: 150-mods
+info:
+  summary: 247 Mod
+  description: |-
+    **Mod Description:**  
+    \* Tired of your town rolling up the sidewalks at sunset? Wouldn't be nice to have a more active nightlife in your cities?
+
+    This mod is the foundation that will be continually added to and updated as more game props are identified for 'extended viewing'. This initial version contains only modifications to the 3 Small Fountain Effect props that shut off at sunset. With this mod, they now operate 24 hours a day.
+
+    All players and lot builders are invited to participate by identifying the game props they would like altered to be viewable 24/7 or for longer periods of time in the game. A related message topic will be started in the Lot Building forum where suggestions and ideas should be posted.
+
+    The obvious advantages to lot builders is the time saved in not having to include customized prop exemplars in your lots where the Prop Appearance or date properties need to be adjusted. This mod can also serve as a handy common 'copy & paste file(s)' source to add custom properties to these props when included in your lots... making sure to give each one a unique IID.
+
+    If the idea catches on, it could be very universally beneficial to all. If not, well, it didn't take very long to make.  :-)  
+    **UPDATE HISTORY**  
+    V1.0.5 - Original version included the 3 Small Fountain Effects, modified to be visible 24/7. They previously were visible only during daylight.
+
+    V1.0.6 - Added the 5 bridge wash effects modified to be visible 24/7. They previously were visible only during daylight.
+
+    **Installation Instructions:**  
+    After unzipping the file, copy the .dat file to your C:/My Documents/SimCity 4/Plugins folder. The effects will not be immediately apparent on exiting lots. They will have to be bulldozed and re-plopped for the new effects to be visible. However, any new development will display the new effects.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11220-peg-247-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0003/14206902b6c040e6f57273327b33aaf1-image1-247.jpg
+assets:
+  - assetId: peg-247-mod
+
+---
+assetId: peg-247-mod
+version: "1.0"
+lastModified: "2004-12-17T18:32:50Z"
+url: https://community.simtropolis.com/files/file/11220-peg-247-mod/?do=download&r=31181

--- a/src/yaml/peg/11423-lakeside-resort.yaml
+++ b/src/yaml/peg/11423-lakeside-resort.yaml
@@ -1,0 +1,59 @@
+group: peg
+name: lakeside-resort
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Lakeside Resort
+  description: |-
+    Nestled in the serene beauty of your remote wooded areas, the rustic Lakeside Resort has been heralded as the finest remote vacation getaway... bar none. Boating, fishing, swimming, horseback riding, tennis, excellent dining and a score of other activities to help your Sims relax and enjoy the breathtaking beauty of your city's wilderness area.
+
+    The Lakeside Resort is a fully functional and conditional Reward that is similar in most properties to the Resort Hotel reward. It contains over 40 new custom props with 24 new BAT models... all packed onto a modest-sized 7x5 tile lot. Many new props, such as the water taxi and the boats on the launching ramp, change and/or cycle throughout the day to simulate normal activity. The lot is also transit enabled and traffic will drive onto the lot, turn into the parking areas, turn around and exit.
+
+    The Lakeside Resort is designed for exclusive use with the [PEG Pond Kit II](https://community.simtropolis.com/files/file/11128-peg-pond-kit-ii/). It should be be plopped as part of a lake (or wide river) that you design & create using the Pond Kit.
+
+    **Conditions for Availability:**
+
+    \- City Population of  50, 000  
+    \- At least 3 connected cities  
+    \- Mayor approval over 45  
+    \- Low pollution  
+    \- or... completion of the  Speed Boat Rx Pick-up & Delivery U-Drive-It mission.
+
+    As a reward, the Lakeside Resort is free to plop and free to maintain. Its the game's way of saying, "Thanks for not screwing up!"
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/9ae951fac7de6573f690e1ebcc300eac-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0017/9ae951fac7de6573f690e1ebcc300eac-product_image2.jpg
+dependencies:
+  - peg:pond-kit-ii-deluxe-edition
+  - peg:lakeside-resort-props
+assets:
+  - assetId: peg-lakeside-resort
+    include:
+      - "/PEG_Lakeside-Resort_205.dat"
+
+---
+group: peg
+name: lakeside-resort-props
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: Props and models for `pkg=peg:lakeside-resort`
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/9ae951fac7de6573f690e1ebcc300eac-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0017/9ae951fac7de6573f690e1ebcc300eac-product_image2.jpg
+assets:
+  - assetId: peg-lakeside-resort
+    include:
+      - "/PEG_Resort-Pack_205.dat"
+
+---
+assetId: peg-lakeside-resort
+version: "1.1"
+lastModified: "2025-05-02T23:25:04Z"
+url: https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/?do=download&r=207341

--- a/src/yaml/peg/11509-krispy-kremes-and-police-station.yaml
+++ b/src/yaml/peg/11509-krispy-kremes-and-police-station.yaml
@@ -1,0 +1,41 @@
+group: peg
+name: krispy-kremes-and-police-station
+version: "1.1"
+subfolder: 610-safety
+info:
+  summary: Krispy Kremes and Police Station
+  description: |-
+    How often have we heard someone ask, "Where's a cop when you really need one?  Now we know...
+
+    In communities where there is a Krispy Kremes, there just doesn't seem to be a need for a dedicated police station. Why not just move headquarters into the local doughnut shop and save everyone a lot of time and expense.
+
+    And that's what we've done. Call it a progressive experiment in social practicality if you prefer, but we've moved the cops to where they'd rather be... closer to the action both on the streets and in the fryer.
+
+    This package contains two versions of the Krispy Kreme Doughnuts store:
+
+    1\. Police Station - Functions as a police station with properties identical to those of the small police precinct.
+
+    2\. A ploppable commercial landmark with 32 jobs. Because of it's instinctive attractive to law enforcement officials, this version also provides heightened police protection to the surrounding area. (similar to a Police Kiosk)
+
+    \* An 'as of yet' unproven growable version is included as well. There have been no reported sightings of it in any test cities which may be be due to its size, unfulfilled requirements... or it just plain doesn't work. It its there is anyone wishes to play with it. If it is sighted in your city, we'd appreciate a report about it.
+
+    \*\* Versions are contained in separate files so any one can be removed after installation if not wanted.
+
+    **\*\*\* Requires installation of the [PEG Cop Car Mod](https://community.simtropolis.com/files/file/11186-peg-cop-car-mod/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11509-peg-krispy-kremes-and-police-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/0004/1d94e7538515250993953f812429b870-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0004/1d94e7538515250993953f812429b870-product_image2.jpg
+dependencies:
+  - peg:cop-car-mod
+assets:
+  - assetId: peg-krispy-kremes-and-police-station
+
+---
+assetId: peg-krispy-kremes-and-police-station
+version: "1.1"
+lastModified: "2025-05-02T23:22:58Z"
+url: https://community.simtropolis.com/files/file/11509-peg-krispy-kremes-and-police-station/?do=download&r=207338

--- a/src/yaml/peg/11510-solar-collector-1.yaml
+++ b/src/yaml/peg/11510-solar-collector-1.yaml
@@ -1,0 +1,29 @@
+group: peg
+name: solar-collector-1
+version: "1.1"
+subfolder: 500-utilities
+info:
+  summary: Solar Collector 1
+  description: |-
+    Finally... solar power comes of age with this innovative solution for providing power at night time as well. While traditional solar power stations stop giving up the juice after sunset, this baby is (BOOM! BOOM! BOOM!) Still Going!!  
+      
+    Okay, Okay... I don't take this seriously either. But it was fun to make and actually rather fun to use. It has all the properties of a solar power plant in a small 1x2 tile lot that will fit almost anywhere. The power output is reduced correspondingly to 500MWh per month. It produces 250% more power than a windmill at double the cost... making it a realistic addition to your cities power & cost-wise.  Like an ideal girlfriend, it costs a bit less and puts out a bit more.  
+    \*\* Send all rebuffs and hate mail to deadletters@aol.com  
+      
+    The parking lot on the lot is transit enabled. You may have to manually connect it. However, like the windmills, the lot does not have to have road access.
+
+    **\*\* This lot has no dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11510-peg-solar-collector-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0016/8932d8a5f86a65338317c83e1c0cb91a-product_image.jpg
+assets:
+  - assetId: peg-solar-collector-1
+
+---
+assetId: peg-solar-collector-1
+version: "1.1"
+lastModified: "2025-05-03T00:32:15Z"
+url: https://community.simtropolis.com/files/file/11510-peg-solar-collector-1/?do=download&r=207401

--- a/src/yaml/peg/11571-solar-collector-2.yaml
+++ b/src/yaml/peg/11571-solar-collector-2.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: solar-collector-2
+version: "1.1"
+subfolder: 500-utilities
+info:
+  summary: Solar Collector 2
+  description: |-
+    The Solar Collector 2 is a modified version of the original Solar Collector. It is virtually identical to the updated original in all regards except appearance. For reality buffs, the comical AA batteries have been replaced with a more real-world look.
+
+    This lot does not replace either the original or the updated original version. Both lots can be used at the same time with separate icons appearing for both in the Utilities Power menu. Both versions have identical properties but will be listed in your budget window as separate power plant types.
+
+    The parking lot on the lot is transit enabled. You may have to manually connect it. However, like the windmills, the lot does not have to have road access.
+
+    \* Special thanks to Pegadyne Industries for their development of the new photo-electric collectors used in these plants that produce a viable amount of power from a relatively small collection surface.  
+      
+    **\*\* This lot uses props from the following files:**
+
+    **[Peg Trail Parks III](https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/)**
+
+    **[Peg Lakeside Resort](https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11571-peg-solar-collector-2/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e14f5f50e6e57c7b045a5732a04786d0-product_image.jpg
+dependencies:
+  - peg:lakeside-resort-props
+  - peg:trail-parks-iii
+assets:
+  - assetId: peg-solar-collector-2
+
+---
+assetId: peg-solar-collector-2
+version: "1.1"
+lastModified: "2025-05-03T00:33:48Z"
+url: https://community.simtropolis.com/files/file/11571-peg-solar-collector-2/?do=download&r=207403

--- a/src/yaml/peg/11572-solar-collector-3.yaml
+++ b/src/yaml/peg/11572-solar-collector-3.yaml
@@ -1,0 +1,36 @@
+group: peg
+name: solar-collector-3
+version: "1.1"
+subfolder: 500-utilities
+info:
+  summary: Solar Plant 3
+  description: |-
+    The Solar Collector 3 combines 10 solar collectors into a single facility producing 5,000 MWh/month of clean and efficient power for your cities. Unlike the game's default solar plant, which employs the Concentrated Solar Power principle of using mirrors to focus heat that is converted to electricity, these true solar collectors use  Photo-voltaic cells, which convert sunlight directly into electricity.
+
+    The plop cost, power produced, and maintenance costs for this facility are the same as building 10, single solar collector plants. This combined facility merely saves a little space with the added convenience of a single plop and budget item.
+
+    This is a conditional reward power plant. It will become available in the game after you have met the same conditions required to make the game's default solar plant available. (High Wealth Residential Population - 3000 Mayor Rating - 55)
+
+    The office/warehouse is part of a 2 structure building prop family to add a little variety. When plopped, one of the two structures will be randomly selected for the lot. The lot is transit enabled and should be connected by street to your traffic network.
+
+    \* Special thanks to Pegadyne Industries for their development of the new photo-electric collectors used in these plants that produce a viable amount of power from a relatively small collection surface.  
+      
+    **\*\* This lot requires the installation of the PEG Solar Collector 2 power plant.  
+    \*\* This lot requires [PEG Lakeside Resort](https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/) (PEG\_Resort-Pack\_205.dat)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/).**
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11572-peg-solar-plant-3/
+  images:
+    - https://www.simtropolis.com/objects/screens/0008/44dc34da7b8438eaf7e8a72ffc1a5fb7-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0008/44dc34da7b8438eaf7e8a72ffc1a5fb7-product_image2.jpg
+dependencies:
+  - peg:lakeside-resort-props
+assets:
+  - assetId: peg-solar-plant-3
+
+---
+assetId: peg-solar-plant-3
+version: "1.1"
+lastModified: "2025-05-03T00:36:23Z"
+url: https://community.simtropolis.com/files/file/11572-peg-solar-plant-3/?do=download&r=207405

--- a/src/yaml/peg/11688-tennis-park.yaml
+++ b/src/yaml/peg/11688-tennis-park.yaml
@@ -1,7 +1,7 @@
 group: peg
 name: tennis-park
 version: "1.1"
-subfolder: 600-parks
+subfolder: 660-parks
 info:
   summary: Tennis Park
   description: |-

--- a/src/yaml/peg/11688-tennis-park.yaml
+++ b/src/yaml/peg/11688-tennis-park.yaml
@@ -1,0 +1,33 @@
+group: peg
+name: tennis-park
+version: "1.1"
+subfolder: 600-parks
+info:
+  summary: Tennis Park
+  description: |-
+    I went out and bought SC4 on the very first day it was released. And from that day, the default tennis court park has bothered me and I couldn't figure out why. I even mentally played a tennis game on the default court: I serve... it goes long... and I watch the ball bounce out across the street and bean some old lady in the head. My second serve is returned and flies high and to the right... and I watch it skip across the railroad tracks and get crushed by a passing forklift.
+
+    And then it hit me... **NO FENCES!!**  I've never seen a tennis court that wasn't fenced in. Without fences, there would be 20 minute delays between serves while the players ran off to shag balls. An otherwise enjoyable game... would radically suck!
+
+    Anyway... I put a custom BAT fence around the courts, stuffed 2 on a 3x3 lot and gave it some adequate parking. Voila!! Instant Tennis Park!!
+
+    This 3x3 park has all the size, costs and benefits of the game's standard large park. The park was designed to be used with the [PEG Trail Parks](https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/) but works just as well by itself. It does not require that you have the PEG Trail Parks installed. It is fully self-contained and has no dependencies.
+
+    \* Like the PEG Krispy Kremes, this lot also uses a BAT modeled parking area instead of textures. This allows true 3D curbs, planters and sidewalks that add a depth and realism to the lot.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11688-peg-tennis-park/
+  images:
+    - https://www.simtropolis.com/objects/screens/0025/e63299972e6865ad473e39850634a4d1-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0025/e63299972e6865ad473e39850634a4d1-product_image2.jpg
+dependencies:
+  - peg:trail-parks-iii
+assets:
+  - assetId: peg-tennis-park
+
+---
+assetId: peg-tennis-park
+version: "1.1"
+lastModified: "2025-05-03T00:39:50Z"
+url: https://community.simtropolis.com/files/file/11688-peg-tennis-park/?do=download&r=207408

--- a/src/yaml/peg/11695-charas-bt-records.yaml
+++ b/src/yaml/peg/11695-charas-bt-records.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: charas-bt-records
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Charas BT Records
+  description: |-
+    The Recording Industry hits town in a big way as industry icon ***B&T Records*** decides to move their corporate headquarters to your city. B&T Records may have started as a backwater recording studio but it quickly skyrocketed to the top by signing only the best such as international recording artist and the Goddess of Country, **Chara**... who is also the company's CEO.
+
+    B&T understands the space constraints in your city so they have designed an innovative building that will maximize the wasted space under any urban freeway. The structure will be built under the freeway as well as around it... and it will even build over it with 2 connecting skywalks.
+
+    This building is big-bucks COM  providing up to 3,500 jobs. You're gonna need that freeway and plenty of access via adjacent off-ramps. You might also want to consider placing various types of mass transit stations in the area as well.
+
+    This lot has no dependencies. It utilizes a custom BAT modeled base as well as 7 other custom BAT models designed exclusively for this lot. It features a semi-symmetrical design in that there is no definitive "front-side" to the lot... which allows you greater flexibility in how you plop it.  The helicopter is functional, generally taking off and landing when ever the city is loaded.
+
+    ***B&T Records... Proving that there is always a place where dreams can come true.***
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11695-peg-presents-charas-bt-records/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/5cca9d5f62f76952a8e9a28f1d4694ec-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0011/5cca9d5f62f76952a8e9a28f1d4694ec-product_image2.jpg
+assets:
+  - assetId: peg-presents-charas-bt-records
+
+---
+assetId: peg-presents-charas-bt-records
+version: "1.1"
+lastModified: "2025-05-02T03:07:12Z"
+url: https://community.simtropolis.com/files/file/11695-peg-presents-charas-bt-records/?do=download&r=207288

--- a/src/yaml/peg/11814-rock-mod-ii-dark-basalt.yaml
+++ b/src/yaml/peg/11814-rock-mod-ii-dark-basalt.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: rock-mod-ii-dark-basalt
+version: "1.1"
+subfolder: 170-terrain
+info:
+  summary: ROCK MOD II Dark Basalt
+  description: |-
+    This is the first of a newer series of Rock Mods that use an improved development process and are more photo-realistic. As with the original Rock Mods, you now can choose a rock terrain that is more appropriate for your region. Transform the appearance of your entire region with the simple install of a single DAT file.  
+      
+    This install contains the single **Dark Basalt** rock style which can be  used as almost any type of dark colored igneous rock. This style will be installed in a separate folder in your Plugins folder by default. I suggest that you simply drag that folder to your desktop or some other location and then drag the .DAT file back into your Plugins folder while you sample it.
+
+    **REMEMBER...** Only one style can be installed at a time... including any style installed from a previous Rock Mod pack.
+
+    Each mod contains new texture files that overwrite the game's default rock textures. You can return to using the default textures at any time by simply removing the DAT file from your Plugins folder.  
+      
+    \* Some textures work better with smoother terrain while others are better for terrain with more jagged & sharper edges. Also, some look best when zoomed-in while others appear more natural when zoomed out. You will want to experiment and decide which style is best for you and the way you play your game.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11814-peg-rock-mod-ii-dark-basalt/
+  images:
+    - https://www.simtropolis.com/objects/screens/0020/b82f728342d3ccb573bd2bd782e46ed4-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0020/b82f728342d3ccb573bd2bd782e46ed4-product_image2.jpg
+assets:
+  - assetId: peg-rock-mod-ii-dark-basalt
+
+---
+assetId: peg-rock-mod-ii-dark-basalt
+version: "1.1"
+lastModified: "2025-05-02T23:45:56Z"
+url: https://community.simtropolis.com/files/file/11814-peg-rock-mod-ii-dark-basalt/?do=download&r=207362

--- a/src/yaml/peg/11815-rock-mod-ii-weathered-granite.yaml
+++ b/src/yaml/peg/11815-rock-mod-ii-weathered-granite.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: rock-mod-ii-weathered-granite
+version: "1.1"
+subfolder: 170-terrain
+info:
+  summary: ROCK MOD II Weathered Granite
+  description: |-
+    This is the one of a newer series of Rock Mods that use an improved development process and are more photo-realistic. As with the original Rock Mods, you now can choose a rock terrain that is more appropriate for your region. Transform the appearance of your entire region with the simple install of a single DAT file.  
+      
+    This install contains the single **Weathered Granite** rock style which can be  used as almost any type of gray colored igneous rock. This style works very well on steep cliffs as well as exposed rock along coastlines. This style will be installed in a separate folder in your Plugins folder by default. I suggest that you simply drag that folder to your desktop or some other location and then drag the .DAT file back into your Plugins folder while you sample it.
+
+    **REMEMBER...** Only one style can be installed at a time... including any style installed from a previous Rock Mod pack.
+
+    Each mod contains new texture files that overwrite the game's default rock textures. You can return to using the default textures at any time by simply removing the DAT file from your Plugins folder.  
+      
+    \* Some textures work better with smoother terrain while others are better for terrain with more jagged & sharper edges. Also, some look best when zoomed-in while others appear more natural when zoomed out. You will want to experiment and decide which style is best for you and the way you play your game.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11815-peg-rock-mod-ii-weathered-granite/
+  images:
+    - https://www.simtropolis.com/objects/screens/0010/591b69928ffc9f52457479f8d1a829d2-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0010/591b69928ffc9f52457479f8d1a829d2-product_image2.jpg
+assets:
+  - assetId: peg-rock-mod-ii-weathered-granite
+
+---
+assetId: peg-rock-mod-ii-weathered-granite
+version: "1.1"
+lastModified: "2025-05-02T23:49:08Z"
+url: https://community.simtropolis.com/files/file/11815-peg-rock-mod-ii-weathered-granite/?do=download&r=207374

--- a/src/yaml/peg/11822-rock-mod-ii-golden-sandstone.yaml
+++ b/src/yaml/peg/11822-rock-mod-ii-golden-sandstone.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: rock-mod-ii-golden-sandstone
+version: "1.1"
+subfolder: 170-terrain
+info:
+  summary: ROCK MOD II Golden Sandstone
+  description: |-
+    This is one of the newer series of Rock Mods that use an improved development process and are more photo-realistic. As with the original Rock Mods, you now can choose a rock terrain that is more appropriate for your region. Transform the appearance of your entire region with the simple install of a single DAT file.  
+      
+    This install contains the single **Gold Sandstone** rock style which can be  used as almost any type of golden or rust colored sedimentary rock. This style will be installed in a separate folder in your Plugins folder by default. I suggest that you simply drag that folder to your desktop or some other location and then drag the .DAT file back into your Plugins folder while you sample it.
+
+    **REMEMBER...** Only one style can be installed at a time... including any style installed from a previous Rock Mod pack.
+
+    Each mod contains new texture files that overwrite the game's default rock textures. You can return to using the default textures at any time by simply removing the DAT file from your Plugins folder.  
+      
+    \* Some textures work better with smoother terrain while others are better for terrain with more jagged & sharper edges. Also, some look best when zoomed-in while others appear more natural when zoomed out. You will want to experiment and decide which style is best for you and the way you play your game.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11822-peg-rock-mod-ii-golden-sandstone/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f5b1956a36851cf662dde8127484c1a3-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0027/f5b1956a36851cf662dde8127484c1a3-product_image2.jpg
+assets:
+  - assetId: peg-rock-mod-ii-golden-sandstone
+
+---
+assetId: peg-rock-mod-ii-golden-sandstone
+version: "1.1"
+lastModified: "2025-05-02T23:47:05Z"
+url: https://community.simtropolis.com/files/file/11822-peg-rock-mod-ii-golden-sandstone/?do=download&r=207368

--- a/src/yaml/peg/11823-rock-mod-ii-eroded-sandstone.yaml
+++ b/src/yaml/peg/11823-rock-mod-ii-eroded-sandstone.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: rock-mod-ii-eroded-sandstone
+version: "1.1"
+subfolder: 170-terrain
+info:
+  summary: ROCK MOD II Eroded Sandstone
+  description: |-
+    This is one of the newer series of Rock Mods that use an improved development process and are more photo-realistic. As with the original Rock Mods, you now can choose a rock terrain that is more appropriate for your region. Transform the appearance of your entire region with the simple install of a single DAT file.  
+      
+    This install contains the single **Eroded Sandstone** rock style which can be  used as almost any type of weathered or craggy sedimentary rock. This style will be installed in a separate folder in your Plugins folder by default. I suggest that you simply drag that folder to your desktop or some other location and then drag the .DAT file back into your Plugins folder while you sample it.
+
+    **REMEMBER...** Only one style can be installed at a time... including any style installed from a previous Rock Mod pack.
+
+    Each mod contains new texture files that overwrite the game's default rock textures. You can return to using the default textures at any time by simply removing the DAT file from your Plugins folder.  
+      
+    \* Some textures work better with smoother terrain while others are better for terrain with more jagged & sharper edges. Also, some look best when zoomed-in while others appear more natural when zoomed out. You will want to experiment and decide which style is best for you and the way you play your game.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11823-peg-rock-mod-ii-eroded-sandstone/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f429e441d10a5e639af650d9c7801d5e-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0027/f429e441d10a5e639af650d9c7801d5e-product_image2.jpg
+assets:
+  - assetId: peg-rock-mod-ii-eroded-sandstone
+
+---
+assetId: peg-rock-mod-ii-eroded-sandstone
+version: "1.1"
+lastModified: "2025-05-02T23:46:21Z"
+url: https://community.simtropolis.com/files/file/11823-peg-rock-mod-ii-eroded-sandstone/?do=download&r=207365

--- a/src/yaml/peg/11826-rock-mod-ii-mossy-granite.yaml
+++ b/src/yaml/peg/11826-rock-mod-ii-mossy-granite.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: rock-mod-ii-mossy-granite
+version: "1.1"
+subfolder: 170-terrain
+info:
+  summary: ROCK MOD II Mossy Granite
+  description: |-
+    This is one of the newer series of Rock Mods that use an improved development process and are more photo-realistic. As with the original Rock Mods, you now can choose a rock terrain that is more appropriate for your region. Transform the appearance of your entire region with the simple install of a single DAT file.  
+      
+    This install contains the single **Mossy Granite** rock style which can be  used as almost any type of gray colored igneous rock. The bits of moss would make it more suitable for moist climates. This style will be installed in a separate folder in your Plugins folder by default. I suggest that you simply drag that folder to your desktop or some other location and then drag the .DAT file back into your Plugins folder while you sample it.
+
+    **REMEMBER...** Only one style can be installed at a time... including any style installed from a previous Rock Mod pack.
+
+    Each mod contains new texture files that overwrite the game's default rock textures. You can return to using the default textures at any time by simply removing the DAT file from your Plugins folder.  
+      
+    \* Some textures work better with smoother terrain while others are better for terrain with more jagged & sharper edges. Also, some look best when zoomed-in while others appear more natural when zoomed out. You will want to experiment and decide which style is best for you and the way you play your game.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/11826-peg-rock-mod-ii-mossy-granite/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/9ae2ceb017453b1669f300fa6b7c1874-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0017/9ae2ceb017453b1669f300fa6b7c1874-product_image2.jpg
+assets:
+  - assetId: peg-rock-mod-ii-mossy-granite
+
+---
+assetId: peg-rock-mod-ii-mossy-granite
+version: "1.1"
+lastModified: "2025-05-02T23:48:35Z"
+url: https://community.simtropolis.com/files/file/11826-peg-rock-mod-ii-mossy-granite/?do=download&r=207371

--- a/src/yaml/peg/12145-rr-rural-rail-station.yaml
+++ b/src/yaml/peg/12145-rr-rural-rail-station.yaml
@@ -1,0 +1,27 @@
+group: peg
+name: rr-rural-rail-station
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: RR Rural Rail Station
+  description: |-
+    By request, the PEG Rural Rail Station is a basic passenger railroad station in an older, rural wrapper. It has the same  properties as the game's default passenger station.
+
+    Other than visually, the primary difference with the Rural Rail Station is that it is smaller at only 2x2 tiles in size. The Taxi Maker occupant group has also been removed to prevent the station from spawning and endless line of taxi cabs. Generally, taxi service in rear-world rural areas is either non-existent or a quaint novelty.
+
+    **Dependencies: None**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12145-peg-rr-rural-rail-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/0018/a3692d8ca0f54d41556ff8a39c537b75-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0018/a3692d8ca0f54d41556ff8a39c537b75-product_image2.jpg
+assets:
+  - assetId: peg-rr-rural-rail-station
+
+---
+assetId: peg-rr-rural-rail-station
+version: "1.1"
+lastModified: "2025-05-02T23:54:39Z"
+url: https://community.simtropolis.com/files/file/12145-peg-rr-rural-rail-station/?do=download&r=207380

--- a/src/yaml/peg/12150-rr-rural-freight-station.yaml
+++ b/src/yaml/peg/12150-rr-rural-freight-station.yaml
@@ -1,0 +1,29 @@
+group: peg
+name: rr-rural-freight-station
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: RR Rural Freight Station
+  description: |-
+    Our second offering in the Rural Trackside Series, the PEG Rural Freight Station is a simple freight station with a rustic look designed to match the rural passenger station.  It has the same  basic properties and costs as the game's default freight station.
+
+    Other than visually, the primary difference with the Rural Rail Station is that it is smaller at only 2x2 tiles in size. It's transit properties have also been patched to increase efficiency by allowing rail-to-truck transition as well as truck-to-rail transition.
+
+    The small parking lot/loading area is transit enabled. If connected to your road network, you will see freight trucks from nearby factories pull in, drive slowly by the docks as if unloading, and drive off again.
+
+    **Dependencies: None**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12150-peg-rr-rural-freight-station/
+  images:
+    - https://www.simtropolis.com/objects/screens/0019/abe21b0f8b647ca695254f965ff962c1-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0019/abe21b0f8b647ca695254f965ff962c1-product_image2.jpg
+assets:
+  - assetId: peg-rr-rural-freight-station
+
+---
+assetId: peg-rr-rural-freight-station
+version: "1.1"
+lastModified: "2025-05-02T23:51:11Z"
+url: https://community.simtropolis.com/files/file/12150-peg-rr-rural-freight-station/?do=download&r=207377

--- a/src/yaml/peg/12239-rr-whistle-stop.yaml
+++ b/src/yaml/peg/12239-rr-whistle-stop.yaml
@@ -1,0 +1,29 @@
+group: peg
+name: rr-whistle-stop
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: RR Whistle Stop
+  description: |-
+    The PEGPROD Trackside Series continues with this tranquil little setting that was once a common sight along rural railroad routes. **The Whistle Stop** brings back the feel and sound of the Golden Age of Steam.
+
+    These small, trackside servicing facilities were usually in very remote areas. They often also served as an informal depot for local residents. As the train approached, the engineer would sound the train's whistle (thus the name) to let the local folk know that if they had mail, freight or needed to hitch a ride, they better come runnin'.
+
+    This 2x1 lot features a small coaling tower and a classic old railroad water tower built from the blueprints of a common design that was widely used throughout America. In the game, from a transportation stand-point, the lot is merely eye-candy. However, the water tower is functional and provides a bit over half of the water produced by the game's normal water tower. Although you will need to connect pipe to it to use it as a water source, it is completely independent of your city's normal water supply and will not show up in the budget. There are also no usage or production stats for it. Like the real article, you'll know its running dry when you open the tap and nothing comes out but dust.
+
+    **Dependencies: None**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12239-peg-rr-whistle-stop/
+  images:
+    - https://www.simtropolis.com/objects/screens/0019/acf61dc884289e5c27082d91001d68d2-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0019/acf61dc884289e5c27082d91001d68d2-product_image2.jpg
+assets:
+  - assetId: peg-rr-whistle-stop
+
+---
+assetId: peg-rr-whistle-stop
+version: "1.1"
+lastModified: "2025-05-02T23:56:57Z"
+url: https://community.simtropolis.com/files/file/12239-peg-rr-whistle-stop/?do=download&r=207386

--- a/src/yaml/peg/12271-rr-service-yard.yaml
+++ b/src/yaml/peg/12271-rr-service-yard.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: rr-service-yard
+version: "1.1"
+subfolder: 700-transit
+info:
+  summary: RR Service Yard
+  description: |-
+    The **PEG\-RR** Trackside Series strikes again with this highly flexible rural-styled **Railroad Service Yard**. This 8x2 lot features a fully functional, transit-enabled double-track rail running the length of the lot... as well as a single track siding for display of the eye candy. Intended for use in rural settings, it is flexible enough to fit right into your grimiest industrial zones and even the wrong-side-of-the-tracks area of suburbia.
+
+    Don't take this the wrong way, but this lot can go both ways... either replacing your existing rail line or plopping down next to it and connected as a siding. You can even plop it on both sides of the main line, staggered or aligned,  and create larger, intricate train yards.
+
+    But wait... that's not all. We've loaded up this lot with more eye-candy than your local Hooter's Bar & Grill. Pretty much everything's in here except the kitchen sink. No wait... I think there's one in the shed.
+
+    For starters, a couple of local freights can be seen daily pulled off onto the siding for service while making room for the long haul main line trains. An ore train hauling ore from Big John's Mine stops by in the morning while a logging train from the nearby logging industry (in development) pulls off in the afternoons.
+
+    Both trains are using older steam era locos that are still earning their keep.... and both of them smoke!! (Why not? It worked for Lionel !!)  Along with that we have the facilities for tending to the steam locos and a fuel bunker for the diesels... the prerequisite tool sheds and some trucks that come and go throughout the day.
+
+    The lot is cheap to plop and free to maintain... primarily because its purely visual and serves absolutely no functional purpose. But then, that's what my wife said about me!
+
+    **Dependencies:** **[PEG\-RR Whistle Stop](https://community.simtropolis.com/files/file/12239-peg-rr-whistle-stop/)**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12271-peg-rr-service-yard/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f561b5d1576c8636d9d66f5aeba664c0-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0027/f561b5d1576c8636d9d66f5aeba664c0-product_image2.jpg
+dependencies:
+  - peg:rr-whistle-stop
+assets:
+  - assetId: peg-rr-service-yard
+
+---
+assetId: peg-rr-service-yard
+version: "1.1"
+lastModified: "2025-05-02T23:56:06Z"
+url: https://community.simtropolis.com/files/file/12271-peg-rr-service-yard/?do=download&r=207383

--- a/src/yaml/peg/12539-lighthouse-island.yaml
+++ b/src/yaml/peg/12539-lighthouse-island.yaml
@@ -1,0 +1,33 @@
+group: peg
+name: lighthouse-island
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Lighthouse Island
+  description: |-
+    The sea air... the salt spray... waves crashing on the rocks while seagulls screech overhead as they circle in search of crabs scurrying amongst the rocks. Occasionally, the mighty fog horn sounds its great and mournful blast.
+
+    Gawd, I just made myself hungry for Clam Chowder!! Okay, who's got the Oyster Crackers?
+
+    This classic New England style lighthouse sits atop a rock island that you can plop anywhere in the water. Its self-leveling so you don't need to worry about water depth or altering the terrain in any way. It is also fully self-powered via a newly developed method so it does not have to be plopped near shore in order for the rotating light beacon to function.
+
+    This version of the Lighthouse functions like the game's default lighthouse in all regards, including plop & maintenance costs. It is a Reward, but it is not conditional. You do not need  to have a seaport for it to become available. This will allow you to also use it in non-industrial cities where a seaport would be useless.
+
+    This version of the Lighthouse also does not replace the game's default lighthouse. The primary reason for this is that the default lighthouse is land-based... and this version obviously is not. A forced replacement could cause issues when upgrading. With separate versions, you can continue to enjoy the default lighthouse or any replacement for it you have installed... or reclaim the land it occupies and replace it with this water-based version at your leisure.
+
+    **\*\*This lot has No External Dependencies.\*\***
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12539-peg-lighthouse-island/
+  images:
+    - https://www.simtropolis.com/objects/screens/0005/2493d5877f043a06667f75edc70ed0d5-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0005/2493d5877f043a06667f75edc70ed0d5-product_image2.jpg
+assets:
+  - assetId: peg-lighthouse-island
+
+---
+assetId: peg-lighthouse-island
+version: "1.1"
+lastModified: "2025-05-02T23:26:07Z"
+url: https://community.simtropolis.com/files/file/12539-peg-lighthouse-island/?do=download&r=207344

--- a/src/yaml/peg/12578-caisson-style-lighthouse.yaml
+++ b/src/yaml/peg/12578-caisson-style-lighthouse.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: caisson-style-lighthouse
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Caisson Style Lighthouse
+  description: |-
+    Our second offering in the Lighthouse series features a replica of the Hooper Island Lighthouse which is still in operation in Chesapeake Bay, Maryland. A classic caisson style lighthouse, the Hooper Bay Light was first lit in 1902.
+
+    The caisson is sunk 13.5 feet into the muddy bottom of the Bay. The light stands 63 feet above the water. The inside of the metal tower is lined with white-glazed brick and there are 4 living levels, plus the watch room and lantern levels. This light was automated in 1961 and the keepers removed.  In 1976 the 4th order Fresnel lens was stolen and the Coast Guard replaced it with a solar optic.
+
+    This version of the Lighthouse functions like the game's default lighthouse in all regards, including plop & maintenance costs. It is a Reward, but it is not conditional. You do not need  to have a seaport for it to become available. This will allow you to also use it in non-industrial cities where a seaport would be useless.
+
+    Like the previous Lighthouse Island version, this lighthouse also does not replace the game's default lighthouse. The primary reason for this is that the default lighthouse is land-based... and this version obviously is not. A forced replacement could cause issues when upgrading. With separate versions, you can continue to enjoy the default lighthouse or any replacement for it you have installed... or reclaim the land it occupies and replace it with this water-based version at your leisure.
+
+    **\*\***This lot has No External Dependencies.**\*\***
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12578-peg-caisson-style-lighthouse/
+  images:
+    - https://www.simtropolis.com/objects/screens/0005/26e5618d5364977e33a44e664197ce01-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0005/26e5618d5364977e33a44e664197ce01-product_image2.jpg
+assets:
+  - assetId: peg-caisson-style-lighthouse
+
+---
+assetId: peg-caisson-style-lighthouse
+version: "1.1"
+lastModified: "2025-05-02T03:06:43Z"
+url: https://community.simtropolis.com/files/file/12578-peg-caisson-style-lighthouse/?do=download&r=207285

--- a/src/yaml/peg/12721-screw-pile-lighthouses.yaml
+++ b/src/yaml/peg/12721-screw-pile-lighthouses.yaml
@@ -1,0 +1,45 @@
+group: peg
+name: screw-pile-lighthouses
+version: "1.1"
+subfolder: 600-civics
+info:
+  summary: Screw Pile Lighthouses
+  description: |-
+    Our third offering in the Lighthouse series features one of the most famous and recognizable lighthouses in the Chesapeake Bay. The **Thomas Point Shoal Lighthouse** was first lit in 1875 and is still in operation today.
+
+    The hexagonal cottage style lighthouse sits atop seven 10-inch diameter wrought-iron screw piles that are screwed 11 feet, 6 inches into the bottom of the bay. The screw pile foundation is very sturdy but has been damaged in the past by ice floes. In 1886-87, 1600 cubic yards of loose rock, called "riprap" were poured around the piles for extra protection.
+
+    This package contains 3 versions of the lighthouse:
+
+    **Version 1:**  
+    This version of the Lighthouse functions like the game's default lighthouse in all regards, including plop & maintenance costs. It is a Reward, but it is not conditional. You do not need  to have a seaport for it to become available. This will allow you to also use it in non-industrial cities where a seaport would be useless.
+
+    Like the previous Lighthouse Island version, this lighthouse also does not replace the game's default lighthouse. The primary reason for this is that the default lighthouse is land-based... and this version obviously is not. A forced replacement could cause issues when upgrading. With separate versions, you can continue to enjoy the default lighthouse or any replacement for it you have installed... or reclaim the land it occupies and replace it with this water-based version at your leisure.
+
+    **Version 2:**  
+    Several older screw pile styled lighthouses were rescued when they were decommissioned and have been moved onshore where they now serve as museums and tourist attractions. The Drum Point Lighthouse, which is very similar in appearance to the Thomas Point Light, is one of the most famous of these Lights that have found a new home and purpose ashore.
+
+    In recognition of this effort to preserve our nautical tradition and heritage, this package contains a second version of this lighthouse that is a functioning museum and can be plopped on shore. It is a separate file that can easily be uninstalled if not needed. The land-based lighthouse/museum has the same properties and pricing of the game's default museum.
+
+    **Version 3:**  
+    This package also contains a 3rd version of the lighthouse for the CDK. Like the museum version, the CDK version is also a  retired lighthouse, preserved and relocated to serve as a tourist attraction for your Seaport Village or anywhere along your coast. This version has most of the properties and benefits of the Tourist Trap reward.
+
+    **\*\*Versions 1 & 2 have No External Dependencies.  
+    The CDK version requires that the CDK\-OWW be installed.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12721-peg-screw-pile-lighthouses/
+  images:
+    - https://www.simtropolis.com/objects/screens/0008/441f683eaf293247023f9eb3962618f8-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0008/441f683eaf293247023f9eb3962618f8-product_image2.jpg
+assets:
+  - assetId: peg-screw-pile-lighthouses
+dependencies:
+  - peg:cdk-oww-development-pack-vol1
+
+---
+assetId: peg-screw-pile-lighthouses
+version: "1.1"
+lastModified: "2025-05-03T00:13:11Z"
+url: https://community.simtropolis.com/files/file/12721-peg-screw-pile-lighthouses/?do=download&r=207389

--- a/src/yaml/peg/12727-chicken-ranch.yaml
+++ b/src/yaml/peg/12727-chicken-ranch.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: chicken-ranch
+version: "1.1"
+subfolder: 410-agriculture
+info:
+  summary: Chicken Ranch
+  description: |-
+    Pegasus Productions has finally decided to join the farming craze with this initial offering of a tranquil poultry farm for your rural and agricultural regions. The classic Victorian style ranch house graces the 3x3 lot which abounds with plenty of aggie charm in a down-home country setting.
+
+    And if you are buying any of this tripe, I've got some prime swampland to sell you... and I'll even toss in the Brooklyn Bridge. "**The**" Chicken Ranch, made world-famous by the hit movie, The Best Little Whorehouse in Texas, is a Texas institution that dates back to the early 1900s. Although illegal, a beneficial relationship between "the lady of the house" and local law enforcement allowed The Chicken Ranch to operate continuously until the 1970s. Throughout its years of operation, countless criminals were apprehended from tips provided by the staff to local law enforcement. Always a "high class joint", the Ranch's patrons and frequent visitors included many of Texas' upright & respected citizens, including judges and state Governors.
+
+    The house on the lot is modeled after the house that was used to film the movie. There are ploppable farm & growable versions included... each with a handful of Industrial Agriculture jobs... and it actually does have chickens and a chicken coop. If you keep a close eye out, you may even see Burt & Dolly come out from time to time to say Howdy!
+
+    The lots feature a custom query and custom sound effects... and are BTE Sleeze Reward enabled. Both ploppable and growable lots are also transit enabled and generate kickbacks... er, income. The lots use the PEG Seasonal Trees which requires that the PEG Seasonal Woods be installed. All other props are included in an included resource file.
+
+    Well, everyday around this time the party is just getting stated down at The Ranch. So git 'er installed, and head on over for some fun & frolicin'. Can y'all say,  **"YEE HAW"** ?  Sure ya can...
+
+    \*\* Special thanks & recognition to BarbyW who co-authored the growable version of this lot. Her expertise with growables and agricultural lots was absolutely invaluable.
+
+    **The Chicken Ranch requires the [PEG Seasonal Woods](https://community.simtropolis.com/files/file/4515-peg-seasonal-woods-v206b/)** **to  be installed.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/12727-peg-chicken-ranch/
+  images:
+    - https://www.simtropolis.com/objects/screens/0028/fe36fecd5660735d79c1ff0859173b87-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0028/fe36fecd5660735d79c1ff0859173b87-product_image2.jpg
+dependencies:
+  - peg:mtp-seasonal-woods
+assets:
+  - assetId: peg-chicken-ranch
+
+---
+assetId: peg-chicken-ranch
+version: "1.1"
+lastModified: "2025-05-02T22:54:39Z"
+url: https://community.simtropolis.com/files/file/12727-peg-chicken-ranch/?do=download&r=207327

--- a/src/yaml/peg/13096-the-great-lighthouse-of-alexandria.yaml
+++ b/src/yaml/peg/13096-the-great-lighthouse-of-alexandria.yaml
@@ -35,6 +35,9 @@ info:
   images:
     - https://www.simtropolis.com/objects/screens/0011/5cc975b429a681154f8d92b07570b03a-product_image.jpg
     - https://www.simtropolis.com/objects/screens/0011/5cc975b429a681154f8d92b07570b03a-product_image2a.jpg
+dependencies:
+  - memo:submenus-dll
+  - peg:oasis-park
 assets:
   - assetId: peg-the-great-lighthouse-of-alexandria
 

--- a/src/yaml/peg/13172-fountain-pack-1.yaml
+++ b/src/yaml/peg/13172-fountain-pack-1.yaml
@@ -1,0 +1,27 @@
+group: peg
+name: fountain-pack-1
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Fountain Pack 1
+  description: |-
+    Back by popular demand (for some reason)... these old legacy fountains have been dusted off and cleaned up just enough to make them look exactly like the originals which, of course... they are. These four fountains are pre-BAT, texture-based 1x1 Lots with the same properties and costs of a small plaza. They will appear in your Parks menu somewhere around the game's default small plaza.
+
+    The Brown Brick Fountain is designed to blend seamlessly with the popular brown brick plaza texture while the two Red Brick designs blend with the red brick "California Plaza" style texture. The Natural Rock fountain looks good in almost any setting. Of course, they can be used by themselves or mixed in with any other plaza textures.
+
+    **\*\*These lots have No External Dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/13172-peg-fountain-pack-1/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/95f75a3fdc72c039932247b43ae308b3-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0017/95f75a3fdc72c039932247b43ae308b3-product_image2.jpg
+assets:
+  - assetId: peg-fountain-pack-1
+
+---
+assetId: peg-fountain-pack-1
+version: "1.1"
+lastModified: "2025-05-02T23:03:39Z"
+url: https://community.simtropolis.com/files/file/13172-peg-fountain-pack-1/?do=download&r=207332

--- a/src/yaml/peg/13431-red-brick-mod.yaml
+++ b/src/yaml/peg/13431-red-brick-mod.yaml
@@ -1,0 +1,30 @@
+group: peg
+name: red-brick-mod
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: Red Brick Mod
+  description: |-
+    This is a simple mod that replaces the default in-game brown brick texture with the same red brick texture used in the CDK\-OWW Ferry lot. It also replaces all PEG modifications of that brown brick texture... including the brown brick fountain texture and the all the custom textures created for the Seaport Village and SV-Plaza and Food Court lots.  
+      
+    For this Facelift mod to work, it must be one of the last items read in by the game from the Plugins folder. Therefore, it must be placed in a specially named folder (the default name is ZZZ PEG Facelift Mods)... and not placed within any other folder.  
+      
+    Of course, its all a matter of personal taste. Red brick is used quite a bit in the USA... but might not be as common elsewhere. Like palm trees... you either like them or you don't.
+
+    This mod will change the appearance of game default lots as well as lots created by other developers... so you'll have to just try it and see if it appeals to you. If not, uninstalling it is as easy as deleting the file.
+
+    This package also includes a separate file created by Swamper77 that replaces the custom brown brick diagonal texture created for the Marrast Embankment set. It also includes a third file by Swamper to replace the brown brick textures used in the NAM Ped Malls. These files are included separately so they can be optionally uninstalled if not needed... or easily updated as it will be likely with the NAM.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/13431-peg-red-brick-mod/
+  images:
+    - https://www.simtropolis.com/objects/screens/0001/05ac328a23605afdf986d4c0bfe4b090-product_image.jpg
+assets:
+  - assetId: peg-red-brick-mod
+
+---
+assetId: peg-red-brick-mod
+version: "1.1"
+lastModified: "2025-05-02T23:43:07Z"
+url: https://community.simtropolis.com/files/file/13431-peg-red-brick-mod/?do=download&r=207360

--- a/src/yaml/peg/14415-snow-mod-mtp-patch.yaml
+++ b/src/yaml/peg/14415-snow-mod-mtp-patch.yaml
@@ -1,0 +1,31 @@
+group: peg
+name: snow-mod-mtp-patch
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: Snow Mod MTP Patch
+  description: |-
+    For use with the **PEG Snow Mod**, this patch replaces all of the lot base and overlay textures used by the MTP with Snow Mod compliant textures. It also updates many of the custom textures used on PEG lots released prior to the MTP.
+
+    Even if you do not use the MTP or any of the MTP lots, keep in mind that other custom lots have used the textures introduced with the MTP and other PEG Productions lots. If you are using the Snow Mod, it just might be prudent to have the patch installed... just in case.
+
+    Just like the Snow Mod, when you are ready for springtime once again, just remove the mod and everything in the game returns to normal. By default, this mod is installed to the same folder as the Snow Mod, so simply moving that one folder out of your Plugins will uninstall all related Snow mods.
+
+    **\*\* This mod has no dependencies and is designed for use**  **PEG Snow Mod.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14415-peg-snow-mod-mtp-patch/
+  images:
+    - https://www.simtropolis.com/objects/screens/0023/d4a35f5a73b8ae60dbf5b1727fbcf667-ST-PIC_SnowMod_250x400.jpg
+    - https://www.simtropolis.com/objects/screens/0023/d4a35f5a73b8ae60dbf5b1727fbcf667-product_image2.jpg
+assets:
+  - assetId: peg-snow-mod-mtp-patch
+dependencies: 
+  - peg:snow-mod-2
+
+---
+assetId: peg-snow-mod-mtp-patch
+version: "1.1"
+lastModified: "2025-05-03T00:24:35Z"
+url: https://community.simtropolis.com/files/file/14415-peg-snow-mod-mtp-patch/?do=download&r=207396

--- a/src/yaml/peg/14424-snow-mod-seasonal-tree-patch.yaml
+++ b/src/yaml/peg/14424-snow-mod-seasonal-tree-patch.yaml
@@ -1,0 +1,28 @@
+group: peg
+name: snow-mod-seasonal-tree-patch
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: Snow Mod Seasonal Tree Patch
+  description: |-
+    Now available for use with the PEG Snow Mod, this patch for the PEG Seasonal Woods will force the seasonal trees to remain in their winter state all year long. So, as long as you have the Snow Mod installed and are enjoying your Sim Winter Wonderland, your Seasonal Woods will now match the cold, snowy terrain.
+
+    Just like the Snow Mod, when you are ready for springtime once again, just remove the mod and everything in the game returns to normal. By default, this mod is installed to the same folder as the Snow Mod, so simply moving that one folder out of your Plugins will uninstall all related Snow mods.
+
+    **\*\* This lot requires installation of the PEG Seasonal Woods and is designed for use with the PEG Snow Mod.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/14424-peg-snow-mod-seasonal-tree-patch/
+  images:
+    - https://www.simtropolis.com/objects/screens/0004/1cca49adc22013281ed4a7c19e6989c3-ST-PIC_SnowMod_250x214.jpg
+assets:
+  - assetId: peg-snow-mod-seasonal-tree-patch
+dependencies: 
+  - peg:mtp-seasonal-woods
+
+---
+assetId: peg-snow-mod-seasonal-tree-patch
+version: "1.1"
+lastModified: "2025-05-03T00:29:39Z"
+url: https://community.simtropolis.com/files/file/14424-peg-snow-mod-seasonal-tree-patch/?do=download&r=207399

--- a/src/yaml/peg/18747-cdkm-marina.yaml
+++ b/src/yaml/peg/18747-cdkm-marina.yaml
@@ -1,0 +1,44 @@
+group: peg
+name: cdkm-marina
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: CDKM Marina
+  description: |-
+    At long last, the CDK delivers a functional replacement for the game-default Marina lot. In fact, we've taken it a several steps further with a fully modular, multi-lot Recreational Marina CDK.
+
+    This initial lot in the kit is the replacement for the game-default Marina and the centerpiece of your new Marina complex. It has all the same costs & rewards of the game's marina except that it is a tad easier to earn. Its nite-lited, transit-enabled and features floating docks and boats that extend well out into the water. And as a CDK lot, it plops even with the ocean surface every time so there is no more fussing with terrain height to keep the dock from plunging underwater.
+
+    The new Marina reward is one of 4 marina lots in the initial release... with many more associated lots to come. All the lots are modular and designed to easily fit together to form a single large Marina complex. On the water side, all lots have a fixed upper dock/boardwalk and lower floating docks that align with each other to form continuous docks. At the rear, each lot has custom parking lots designed to form a continuous and realistic parking area along the length of the Marina complex.
+
+    Each of the four initial Marina lots will be released separately so you can easily install only the lots you want. The other three lots will have this Marina lot as a dependency but the Marina lot itself is fully self-contained.
+
+    \* All custom models and props used in these lots have been optimized for reduced file size and game resource usage.
+
+    Other lots in this collection: (available separately)
+
+    -   2x3 Parking Lot  
+        A functional parking lot that also provides an open space between lots with extended docks. Also provides additional Marina Reward benefits  
+         
+    -   3x3 Yacht Club  
+        A ploppable landmark with CS$$$ jobs and additional Marina Reward benefits. Also provides a right-side "end" to the floating docks.  
+         
+    -   3x3 Sport Fishing Complex  
+        A ploppable landmark with CS$$ jobs and additional Marina Reward benefits. Also provides a left-side "end" to the floating docks.
+
+    **\*\* This lot has no dependencies.**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/18747-peg-cdkm-marina/
+  images:
+    - https://www.simtropolis.com/objects/screens/0002/07d445e49687a12af6d3614da2641eff-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0002/07d445e49687a12af6d3614da2641eff-product_image2.jpg
+assets:
+  - assetId: peg-cdkm-marina
+
+---
+assetId: peg-cdkm-marina
+version: "1.0"
+lastModified: "2007-10-05T12:27:10Z"
+url: https://community.simtropolis.com/files/file/18747-peg-cdkm-marina/?do=download&r=42895

--- a/src/yaml/peg/18772-cdkm-boat-ramp.yaml
+++ b/src/yaml/peg/18772-cdkm-boat-ramp.yaml
@@ -1,0 +1,41 @@
+group: peg
+name: cdkm-boat-ramp
+version: "1.0"
+subfolder: 700-transit
+info:
+  summary: CDKM Boat Ramp
+  description: |-
+    No self respecting Marina is complete without a boat ramp. So here ya go. This lot provides everything required for your Sims to launch their small, trailered boats. (ie... a ramp. Beer not included.) It is a 2x3 CS$$ ploppable lot that provides jobs and income from taxes.
+
+    The lot is a CDKM Marina modular lot that aligns with the the boardwalks and parking areas of other CDKM lots. The lot will also be compatible with the new CDK Seaport Village & CDK\-OWW collections.
+
+    The most important function of this lot is to serve as the formal left-end to the Marina complex. The lot visually closes off the boardwalk and parking areas.  
+      
+    The lot uses timed, shuffling props to simulate boat launching activity. During the day, various trailered boats and cars will appear and disappear on & around the ramp.
+
+    For help creating the perfect terrain for CDK lots, we strongly recommend reading **The Official CDK Tutorial.**
+
+     **\*\* This lot requires the following dependencies**
+
+    -   [PEG CDKM Marina](https://community.simtropolis.com/files/file/18747-peg-cdkm-marina/)
+    -   [PEG CDK3 SUPER PAK](https://community.simtropolis.com/files/file/19880-peg-cdk3-super-pak/)  (Previously: PEG\-CDK3 REC Boats Pack 1 which is now in the Super Pak)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made dep linkys clickable.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/18772-peg-cdkm-boat-ramp/
+  images:
+    - https://www.simtropolis.com/objects/screens/0003/1425aaca8a51e75128fb8898daa21d54-product_image.jpg
+    - https://www.simtropolis.com/objects/screens/0003/1425aaca8a51e75128fb8898daa21d54-product_image1.jpg
+dependencies:
+  - peg:cdkm-marina
+  - peg:cdk3-super-pak
+assets:
+  - assetId: peg-cdkm-boat-ramp
+
+---
+assetId: peg-cdkm-boat-ramp
+version: "1.0"
+lastModified: "2007-10-08T19:49:28Z"
+url: https://community.simtropolis.com/files/file/18772-peg-cdkm-boat-ramp/?do=download&r=42941

--- a/src/yaml/peg/20938-snow-mod-deflowrer-patch.yaml
+++ b/src/yaml/peg/20938-snow-mod-deflowrer-patch.yaml
@@ -1,0 +1,34 @@
+group: peg
+name: snow-mod-deflowrer-patch
+version: "1.1"
+subfolder: 150-mods
+info:
+  summary: Snow Mod Deflowrer Patch
+  description: |-
+    Please Note: This is another Snow Mod related upload.   
+      
+    Also Note: This mod can be used with any Snow Mod as it does not affect any snow textures.
+
+    For use with the **[PEG Snow Mod](https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/)**, this patch file allows you to de-flower your cities. The patch file simply removes certain flora props that normally wouldn't appear in a snow covered scene. Don't worry... your lots and cities are not affected in any way. The props are still there. They just won't show... in the snow.
+
+    Specifically, this patch hides all flower props that just look out of place in the snow.  It also conceals several of the smaller bush/brush props that would be covered up by the snow. All palm trees are replaced with pine trees... and the scrub brush that appears at higher elevations when you plant God Mode trees is also hidden.
+
+    Just like the Snow Mod, when you are ready for springtime once again, just remove the mod and everything in the game returns to normal. By default, this mod is installed to the same folder as the Snow Mod, so simply moving that one folder out of your Plugins will uninstall all related Snow mods.
+
+    **\*\* This mod has no dependencies and is designed for use with the [PEG Snow Mod](https://community.simtropolis.com/files/file/22925-peg-snow-mod-2/).**
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+
+    **\-Cori Edit:** Made referenced mod a clickable linky.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/20938-peg-snow-mod-deflowrer-patch/
+  images:
+    - https://www.simtropolis.com/objects/screens/0011/62ea991b9261d590f6e22f25072d9f31-product_image_SnowMod.jpg
+assets:
+  - assetId: peg-snow-mod-deflowrer-patch
+
+---
+assetId: peg-snow-mod-deflowrer-patch
+version: "1.1"
+lastModified: "2025-05-03T00:22:08Z"
+url: https://community.simtropolis.com/files/file/20938-peg-snow-mod-deflowrer-patch/?do=download&r=207394

--- a/src/yaml/peg/22925-snow-mod-2.yaml
+++ b/src/yaml/peg/22925-snow-mod-2.yaml
@@ -75,7 +75,7 @@ variantInfo:
   values:
   - value: "summer"
     description: Nothing from this package is installed.
-  - value: "winder"
+  - value: "winter"
     description: Override PEG textures and assets for a winter look.
 
 ---

--- a/src/yaml/peg/22925-snow-mod-2.yaml
+++ b/src/yaml/peg/22925-snow-mod-2.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: snow-mod-2
-version: "1.0"
+version: "1.0-1"
 subfolder: 900-overrides
 info:
   summary: SNOW MOD 2
@@ -65,6 +65,18 @@ variants:
   - variant: { peg:snow-mod:season: winter }
     assets:
       - assetId: peg-snow-mod-2
+    dependencies:
+      - peg:snow-mod-mtp-patch
+      - peg:snow-mod-deflowrer-patch
+      - peg:snow-mod-seasonal-tree-patch
+variantInfo:
+- variantId: "peg:snow-mod:season"
+  description: Choose which season to show in your cities
+  values:
+  - value: "summer"
+    description: Nothing from this package is installed.
+  - value: "winder"
+    description: Override PEG textures and assets for a winter look.
 
 ---
 assetId: peg-snow-mod-2

--- a/src/yaml/peg/4513-old-west-prop-pack.yaml
+++ b/src/yaml/peg/4513-old-west-prop-pack.yaml
@@ -1,0 +1,22 @@
+group: peg
+name: old-west-prop-pack
+version: "1.1"
+subfolder: 100-props-textures
+info:
+  summary: Old West Prop Pack
+  description: |-
+    The PEG Old West Prop Pack contains a variety of useful props with an Old West flavor that can be used by developers. For the player, it contains no usable or ploppable material but is required as a Dependency for many other lots, including Fort Pegasus. Lots requiring this product should list it as a dependency in their descriptions and readme files.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4513-peg-old-west-prop-pack-205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0023/ce89326ada04fd4c3224bf12df6f947d-product_image.jpg
+assets:
+  - assetId: peg-old-west-prop-pack
+
+---
+assetId: peg-old-west-prop-pack
+version: "1.1"
+lastModified: "2025-05-02T23:32:09Z"
+url: https://community.simtropolis.com/files/file/4513-peg-old-west-prop-pack-205/?do=download&r=207349

--- a/src/yaml/peg/4516-arizona-memorial.yaml
+++ b/src/yaml/peg/4516-arizona-memorial.yaml
@@ -1,0 +1,24 @@
+group: peg
+name: arizona-memorial
+version: "1.1"
+subfolder: 360-landmark
+info:
+  summary: Arizona Memorial
+  description: |-
+    On a quiet Sunday morning December 7, 1941 a Japanese surprise air attack left the Pacific Fleet in smoldering heaps of broken, twisted steel. Here, peace was interrupted and paradise lost. In hours, 2,390 futures were stolen, half of these casualties from the battleship Arizona.
+
+    Behind the shadows of destroyed airfields, aircraft, and ships, America fought fear, and a determined enemy responding with an unrivaled war effort. An epic battle for democratic ideals and world freedom would bloody the fields of Europe and the islands of the Pacific over the next four years. The USS Arizona Memorial as a national shrine symbolizes American sacrifice and resolve.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4516-peg-arizona-memorial-v205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0009/4c563fafa2c6e5992440c5d19c9cd638-product_image.jpg
+assets:
+  - assetId: peg-arizona-memorial-v205
+
+---
+assetId: peg-arizona-memorial-v205
+version: "1.1"
+lastModified: "2025-05-02T02:58:02Z"
+url: https://community.simtropolis.com/files/file/4516-peg-arizona-memorial-v205/?do=download&r=207279

--- a/src/yaml/peg/4528-attitude-park.yaml
+++ b/src/yaml/peg/4528-attitude-park.yaml
@@ -1,0 +1,24 @@
+group: peg
+name: attitude-park
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Attitude Park
+  description: |-
+    For Sims with a "Tude!!!" The City Council was hesitant at first, but the Mayor knew what he/she was doing. "Give the People what they want"... and this expressive statue was exactly that. The Sims love this statue because its exactly how they feel. Whether it stems from political misgivings, social concerns, or the jerk that cut them off in traffic... this statue says it all. Your Sims just feel better driving past it or standing before it and venting their rage. It is, after all, all about "attitude!!"
+
+    These lots, offered in both a park and plaza style, are a true blend of large park & large plaza with all the benefits associated with both. Pricing and maintenance are the same as a large plaza.
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4528-peg-attitude-park-v205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f331ef882168fd110e276828d658c5a5-product_image.jpg
+assets:
+  - assetId: peg-attitude-park-v205
+
+---
+assetId: peg-attitude-park-v205
+version: "1.1"
+lastModified: "2025-05-02T02:58:58Z"
+url: https://community.simtropolis.com/files/file/4528-peg-attitude-park-v205/?do=download&r=207281

--- a/src/yaml/peg/4563-fort-pegasus.yaml
+++ b/src/yaml/peg/4563-fort-pegasus.yaml
@@ -1,0 +1,37 @@
+group: peg
+name: fort-pegasus
+version: "1.1"
+subfolder: 360-landmark
+info:
+  summary: Fort Pegasus
+  description: |-
+    Fort Pegasus is an Historic Landmark that calls to an older era when the land was young and settlers were trekking ever westward in search of a better life.
+
+    Forts such as this, carved from the very elements of the frontier, provided sanctuary to settlers and often served as a center of commerce for the communities that sprung up around them. Due to its historic nature, exquisite preservation and daily guided tours, this landmark also serves as a museum with the appropriate scholastic EQ boost in the surrounding area.
+
+    Its a popular locale for family holidays and educational field trips.
+
+    To avoid educational capacity problems, the fort has been converted to a true museum lot... with jobs. It no longer is a landmark in the technical sense. The custom UI now shows the standard museum data and funding control.
+
+    **DEPENDENCIES:**  
+    [PEG MTP SUPER PACK](https://community.simtropolis.com/files/file/20966-peg-mtp-super-pack/)  
+    [PEG One Flag - Many Nations Mod](https://community.simtropolis.com/files/file/27711-peg-one-flag-many-nations-mod/) **(ver. 2.05)**  
+    [PEG Old West Prop Pack](https://community.simtropolis.com/files/file/4513-peg-old-west-prop-pack-205/)
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4563-peg-fort-pegasus/
+  images:
+    - https://www.simtropolis.com/objects/screens/0008/3d66396dd4fdd9b47d647a04643c6812-product_image.jpg
+dependencies:
+  - peg:mtp-super-pack
+  - peg:old-west-prop-pack
+  - peg:one-flag-many-nations
+assets:
+  - assetId: peg-fort-pegasus
+
+---
+assetId: peg-fort-pegasus
+version: "1.1"
+lastModified: "2025-05-02T22:58:41Z"
+url: https://community.simtropolis.com/files/file/4563-peg-fort-pegasus/?do=download&r=207330

--- a/src/yaml/peg/4592-oasis-park.yaml
+++ b/src/yaml/peg/4592-oasis-park.yaml
@@ -1,0 +1,22 @@
+group: peg
+name: oasis-park
+version: "1.1"
+subfolder: 660-parks
+info:
+  summary: Oasis Park
+  description: |-
+    The Oasis Park has returned with a few graphic upgrades. Two new BAT models have been added to give the oasis an improved 3D appearance and an upgraded surrounding wall. Other than being transit enabled for pedestrians, this park is identical to a large park in all aspects. It has lots of palms and other foliage and could be used as either an Oasis or Jungle themed park. A little break from the traditional for your Sims!
+
+    **All Pegasus files are now legacy content and are no longer officially supported - however support from the wider community can be requested [here](https://community.simtropolis.com/forums/topic/68471-plex-on-the-stex-community-support/)**.
+  author: Pegasus
+  website: https://community.simtropolis.com/files/file/4592-peg-oasis-park-v205/
+  images:
+    - https://www.simtropolis.com/objects/screens/0002/09333c9a2eac98e62c483c65bf81e3a3-product_image.jpg
+assets:
+  - assetId: peg-oasis-park-v205
+
+---
+assetId: peg-oasis-park-v205
+version: "1.1"
+lastModified: "2025-05-02T23:31:12Z"
+url: https://community.simtropolis.com/files/file/4592-peg-oasis-park-v205/?do=download&r=207347


### PR DESCRIPTION
Adds a second batch of assorted Pegasus's content that has been project-zipped to remove executable installers.

![S4e5VLQLZj](https://github.com/user-attachments/assets/1a958ec8-e7eb-46a6-84cf-fdc325b33fbb)
