### PR TITLE
metadata: fix `glenni:mehelia-taarnet-v2`

### DIFF
--- a/src/yaml/glenni/19098-mehelia-taarnet.yaml
+++ b/src/yaml/glenni/19098-mehelia-taarnet.yaml
@@ -56,3 +56,6 @@ assetId: glenni-mehelia-taarnet-v2
 version: "1.0"
 lastModified: "2007-12-12T15:41:03Z"
 url: https://community.simtropolis.com/files/file/19098-ndex-glenni-mehelia-taarnet/?do=download&r=43539
+archiveType:
+  format: Clickteam
+  version: "40"


### PR DESCRIPTION
Missed an exe installer. Fixes #237 