### PR TITLE
metadata: add `sg:public-pools-pack`

### DIFF
--- a/src/yaml/sg/14522-public-pools-pack.yaml
+++ b/src/yaml/sg/14522-public-pools-pack.yaml
@@ -1,0 +1,189 @@
+group: sg
+name: public-pools-pack
+version: "1.0"
+subfolder: 660-parks
+info:
+  summary: Public Pools Pack
+  description: |-
+    **Public Pools, by SimGoober**
+
+    A set of three public pools, to help develop the neighborhoods of your cities. All three have duplicate settings, and are open in day, closed at night. These also will count toward a soon to be released reward lot, so be sure to place a few in your cities now!
+
+    **Screenshots**
+
+    ![SG_Pools_Day (71K)](https://www.simtropolis.com/objects/screens/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Day.jpg)
+
+    ![SG_Pools_Nite (57K)](https://www.simtropolis.com/objects/screens/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Nite.jpg)
+
+    **Lot Details and Information**
+
+    **BTE: Parks**
+
+    Lot Size:
+
+    3 x 4,  4 x 4,  5 x 4 tiles
+
+    Lot Wealth:
+
+    Medium Wealth
+
+    Jobs:
+
+    Civic $: 12,  $$: 5
+
+    Plop Cost:
+
+    $5,000
+
+    Bulldoze Cost:
+
+    $600
+
+    Monthly Cost:
+
+    $25
+
+    Park effect:
+
+    20 over 30 tiles
+
+    Landmark effect:
+
+    10 over 40 tiles
+
+    Mayor Rating Effect:
+
+    None
+
+    Cap Relief:
+
+    R$: 500,  R$$: 500,  R$$$: 500
+
+    Max. Fire Stage:
+
+    0
+
+    Flammability:
+
+    0 of 256
+
+    Occupancy Groups:
+
+    BTE: Parks, SimGoober Creation, SG Swimming Pools, Building: Park
+
+    Power Consumption:
+
+    0 MWh/month
+
+    Water Consumption:
+
+    5 Gallons/month
+
+    Air Pollution:
+
+    \-5 over 5 tiles
+
+    Water Pollution:
+
+    \-5 over 5 tiles
+
+    Garbage Pollution:
+
+    0 over 0 tiles
+
+    **Compatibility**
+
+      
+    This download is only compatible with SimCity 4 "Rush Hour" or SimCity 4 Deluxe.
+
+    **Installation**
+
+    **Auto Installation:** Double-click the installer file to start the installation. The program will guide you through the process. You can change the default installation path, but we strongly suggest to keep the standard folder in order to make future updates and additions easier.
+
+    **MAC Users:** [File Juicer](http://echoone.com/FileJuicer/FileJuicer.html) should enable you to use this installer package.
+
+    **Un-Installing:** To un-install the files, simply bulldoze every lot from this download in your cities and delete the files from your Plugins folder afterwards.
+
+    **File Paths**
+
+    Lot and DAT Files
+
+    /Documents/SimCity 4/Plugins/SimGoober
+
+    Readme and JPGs
+
+    /Documents/SimCity 4/STEX\_Downloads/SimGoober
+
+    **Dependencies**
+
+      
+    To ensure the proper functionality, make sure the files mentioned below are installed in your Plugins folder.  
+     
+
+    **Base / Overlay Textures**
+
+    [BSC Textures Vol 01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
+
+    **Essentials**
+
+    [BSC Essentials Files](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=443)
+
+    **Individual Prop Packs**
+
+    **Found in this Mega Pack**
+
+    BSC BAT Props BLS Floral Vol 01
+
+    [BSC MEGA Props - Misc Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=426)
+
+    **Notes about Nightlighting Effects**
+
+      
+    In order to see the nightlighting, you must install the EP1-Update 1 for Rush Hour/SimCity 4 Deluxe, and then afterwards, install the SC4-Update for nightlighting (both can be found [here](https://community.simtropolis.com/sc4-maxis-files/)). If this update isn't installed, you won't see any lighting effects on custom BAT buildings.
+
+    **Disclaimer**
+
+      
+    The usage of this download is on your own risk. I try to test my lots extensively, so they should work properly, but errors may still exist. Feel free to modify the lots for yourself and show them in your City Journals, but please don't distribute them without asking first.
+
+    **Credits**
+
+      
+    Thanks to the BSC Team for their ongoing support.
+
+    **Feedback and Support**
+
+      
+    Please see my [Building Thread](https://community.simtropolis.com/forums/topic/1001-bat-projects-simgoober/) on Simtropolis for any feedback or support issues. I will attempt to answer them to the best of my knowledge, and as quickly as possible.
+
+    **History**
+
+    Initial Release
+
+    December, 2005
+
+    Updates
+
+    None
+
+    **Cori Edit:** Fixed broken description using the included ReadMe file. (All linkys above are updated and supersede those in the ReadMe.)
+  author: SimGoober
+  website: https://community.simtropolis.com/files/file/14522-public-pools-pack/
+  images:
+    - https://www.simtropolis.com/objects/screens/0018/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Day.jpg
+    - https://www.simtropolis.com/objects/screens/0018/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Nite.jpg
+dependencies:
+  - bsc:essentials
+  - bsc:mega-props-misc-vol01
+  - bsc:textures-vol01
+assets:
+  - assetId: sg-public-pools-pack
+
+---
+assetId: sg-public-pools-pack
+version: "1.0"
+lastModified: "2005-12-30T20:55:38Z"
+url: https://community.simtropolis.com/files/file/14522-public-pools-pack/?do=download&r=36323
+archiveType:
+  format: Clickteam
+  version: "40"

--- a/src/yaml/sg/14522-public-pools-pack.yaml
+++ b/src/yaml/sg/14522-public-pools-pack.yaml
@@ -5,168 +5,43 @@ subfolder: 660-parks
 info:
   summary: Public Pools Pack
   description: |-
-    **Public Pools, by SimGoober**
-
     A set of three public pools, to help develop the neighborhoods of your cities. All three have duplicate settings, and are open in day, closed at night. These also will count toward a soon to be released reward lot, so be sure to place a few in your cities now!
 
-    **Screenshots**
+    ### Lot Details and Information
+
+    |     |     |
+    | --- | --- |
+    | Lot Size: | 3 x 4,  4 x 4,  5 x 4 tiles |
+    | Lot Wealth: | Medium Wealth |
+    | Jobs: | Civic $: 12,  $$: 5 |
+    | Plop Cost: | $5,000 |
+    | Bulldoze Cost: | $600 |
+    | Monthly Cost: | $25 |
+    | Park effect: | 20 over 30 tiles |
+    | Landmark effect: | 10 over 40 tiles |
+    | Mayor Rating Effect: | None |
+    | Cap Relief: | R$: 500,  R$$: 500,  R$$$: 500 |
+    | Max. Fire Stage: | 0   |
+    | Flammability: | 0 of 256 |
+    | Occupancy Groups: | BTE: Parks, SimGoober Creation, SG Swimming Pools, Building: Park |
+    | Power Consumption: | 0 MWh/month |
+    | Water Consumption: | 5 Gallons/month |
+    | Air Pollution: | \-5 over 5 tiles |
+    | Water Pollution: | \-5 over 5 tiles |
+    | Garbage Pollution: | 0 over 0 tiles |
+
+    ### Disclaimer
 
-    ![SG_Pools_Day (71K)](https://www.simtropolis.com/objects/screens/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Day.jpg)
-
-    ![SG_Pools_Nite (57K)](https://www.simtropolis.com/objects/screens/9e4e5980159dd7186d3387f8f717d9e9-SG_Pools_Nite.jpg)
-
-    **Lot Details and Information**
-
-    **BTE: Parks**
-
-    Lot Size:
-
-    3 x 4,  4 x 4,  5 x 4 tiles
-
-    Lot Wealth:
-
-    Medium Wealth
-
-    Jobs:
-
-    Civic $: 12,  $$: 5
-
-    Plop Cost:
-
-    $5,000
-
-    Bulldoze Cost:
-
-    $600
-
-    Monthly Cost:
-
-    $25
-
-    Park effect:
-
-    20 over 30 tiles
-
-    Landmark effect:
-
-    10 over 40 tiles
-
-    Mayor Rating Effect:
-
-    None
-
-    Cap Relief:
-
-    R$: 500,  R$$: 500,  R$$$: 500
-
-    Max. Fire Stage:
-
-    0
-
-    Flammability:
-
-    0 of 256
-
-    Occupancy Groups:
-
-    BTE: Parks, SimGoober Creation, SG Swimming Pools, Building: Park
-
-    Power Consumption:
-
-    0 MWh/month
-
-    Water Consumption:
-
-    5 Gallons/month
-
-    Air Pollution:
-
-    \-5 over 5 tiles
-
-    Water Pollution:
-
-    \-5 over 5 tiles
-
-    Garbage Pollution:
-
-    0 over 0 tiles
-
-    **Compatibility**
-
-      
-    This download is only compatible with SimCity 4 "Rush Hour" or SimCity 4 Deluxe.
-
-    **Installation**
-
-    **Auto Installation:** Double-click the installer file to start the installation. The program will guide you through the process. You can change the default installation path, but we strongly suggest to keep the standard folder in order to make future updates and additions easier.
-
-    **MAC Users:** [File Juicer](http://echoone.com/FileJuicer/FileJuicer.html) should enable you to use this installer package.
-
-    **Un-Installing:** To un-install the files, simply bulldoze every lot from this download in your cities and delete the files from your Plugins folder afterwards.
-
-    **File Paths**
-
-    Lot and DAT Files
-
-    /Documents/SimCity 4/Plugins/SimGoober
-
-    Readme and JPGs
-
-    /Documents/SimCity 4/STEX\_Downloads/SimGoober
-
-    **Dependencies**
-
-      
-    To ensure the proper functionality, make sure the files mentioned below are installed in your Plugins folder.  
-     
-
-    **Base / Overlay Textures**
-
-    [BSC Textures Vol 01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=90)
-
-    **Essentials**
-
-    [BSC Essentials Files](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=443)
-
-    **Individual Prop Packs**
-
-    **Found in this Mega Pack**
-
-    BSC BAT Props BLS Floral Vol 01
-
-    [BSC MEGA Props - Misc Vol01](https://www.sc4devotion.com/csxlex/lex_filedesc.php?lotGET=426)
-
-    **Notes about Nightlighting Effects**
-
-      
-    In order to see the nightlighting, you must install the EP1-Update 1 for Rush Hour/SimCity 4 Deluxe, and then afterwards, install the SC4-Update for nightlighting (both can be found [here](https://community.simtropolis.com/sc4-maxis-files/)). If this update isn't installed, you won't see any lighting effects on custom BAT buildings.
-
-    **Disclaimer**
-
-      
     The usage of this download is on your own risk. I try to test my lots extensively, so they should work properly, but errors may still exist. Feel free to modify the lots for yourself and show them in your City Journals, but please don't distribute them without asking first.
 
-    **Credits**
+    ### Credits
 
-      
     Thanks to the BSC Team for their ongoing support.
 
-    **Feedback and Support**
+    ### Feedback and Support
 
-      
     Please see my [Building Thread](https://community.simtropolis.com/forums/topic/1001-bat-projects-simgoober/) on Simtropolis for any feedback or support issues. I will attempt to answer them to the best of my knowledge, and as quickly as possible.
 
-    **History**
-
-    Initial Release
-
-    December, 2005
-
-    Updates
-
-    None
-
-    **Cori Edit:** Fixed broken description using the included ReadMe file. (All linkys above are updated and supersede those in the ReadMe.)
   author: SimGoober
   website: https://community.simtropolis.com/files/file/14522-public-pools-pack/
   images:


### PR DESCRIPTION
This adds one SimGoober package: https://community.simtropolis.com/files/file/14522-public-pools-pack/

In general, how much should the descriptions be cleaned up? I've taken the output of `npm run add` directly, for now.

Also, an observation: The STEX entry contains a link to https://community.simtropolis.com/sc4-maxis-files/ for the nightlight patch (…the SG files are that old), which the `parse-dependencies.js` script turns into a `maxis:buildings-as-props` dependency. I understand why though – it doesn't really require fixing.