### PR TITLE
metadata: misc package fixes 2025-08-03

### DIFF
--- a/src/yaml/andisart/32178-modern-hd-car-props-incl-mmp.yaml
+++ b/src/yaml/andisart/32178-modern-hd-car-props-incl-mmp.yaml
@@ -1,6 +1,6 @@
 group: andisart
 name: modern-hd-cars-mmp
-version: "1.1"
+version: "1.1-1"
 subfolder: 180-flora
 info:
   summary: Modern HD Car Props (incl. MMP)
@@ -60,7 +60,7 @@ dependencies:
 assets:
   - assetId: andisart-modern-hd-car-props-incl-mmp
     include:
-      - AndisArt_PROP_carpack_MMP.dat.dat
+      - AndisArt_PROP_carpack_MMP.dat
 
 ---
 group: andisart

--- a/src/yaml/delecto/29175-delecto-abelia-residence.yaml
+++ b/src/yaml/delecto/29175-delecto-abelia-residence.yaml
@@ -21,7 +21,7 @@ info:
 
     **Lot Size:**            3x4, 4x4, 2x4, 4x3
 
-    **Tilset:**                 Euro / Medium-density
+    **Tileset:**                 Euro / Medium-density
 
     **Growing:**            Stage 5
 
@@ -83,7 +83,7 @@ name: abelia-residence-model
 version: "1.0"
 subfolder: 100-props-textures
 info:
-  summary: "Model for `pkg:delecto:abelia-residence"
+  summary: "Model for `pkg:delecto:abelia-residence`"
   author: Delecto
   website: https://community.simtropolis.com/files/file/29175-delecto-abelia-residence/
   images:

--- a/src/yaml/mandelsoft/28636-bnl-cloverleaf-insurances.yaml
+++ b/src/yaml/mandelsoft/28636-bnl-cloverleaf-insurances.yaml
@@ -1,13 +1,13 @@
 group: mandelsoft
 name: bnl-cloverleaf-insurances
-version: "1.0"
+version: "1.1"
 subfolder: 300-commercial
 info:
   summary: BNL Cloverleaf Insurances
   description: |-
     Cloverleaf Insurances is a Dutch med-rise commercial office building. It hosts an medium sized insurance company. The Cloverleaf Insurances building is based upon the headquarters of Klaverblad Verzekeringen in Zoetermeer.  
       
-    This BAT is available as a plopable CO$$$ building in the Landmarks menu.  
+    This BAT is available as a ploppable CO$$$ building in the Landmarks menu.  
       
     **Statistics**  
       
@@ -57,12 +57,12 @@ variants:
 
 ---
 assetId: mandelsoft-bnl-cloverleaf-insurances-darknite
-version: "1.0"
-lastModified: "2013-04-10T10:54:12Z"
+version: "1.1"
+lastModified: "2025-08-03T15:34:34Z"
 url: https://community.simtropolis.com/files/file/28636-bnl-cloverleaf-insurances/?do=download&r=113933
 
 ---
 assetId: mandelsoft-bnl-cloverleaf-insurances-maxisnite
-version: "1.0"
-lastModified: "2013-04-10T10:54:12Z"
+version: "1.1"
+lastModified: "2025-08-03T15:34:34Z"
 url: https://community.simtropolis.com/files/file/28636-bnl-cloverleaf-insurances/?do=download&r=113934

--- a/src/yaml/peg/14368-csk2-3x-avenue-draw-bridge.yaml
+++ b/src/yaml/peg/14368-csk2-3x-avenue-draw-bridge.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-3x-avenue-draw-bridge
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: CSK2 3x Avenue Draw Bridge
@@ -40,3 +40,6 @@ assetId: peg-csk2-3x-avenue-draw-bridge
 version: "1.1"
 lastModified: "2025-06-07T22:48:14Z"
 url: https://community.simtropolis.com/files/file/14368-peg-csk2-3x-avenue-draw-bridge/?do=download&r=208010
+archiveType:
+  format: Clickteam
+  version: "20"


### PR DESCRIPTION
Fixes a few typos plus extraction errors with the following packages [reported by Allein](https://community.simtropolis.com/forums/topic/762677-sc4pac-lets-write-our-own-package-manager/?do=findComment&comment=1807269):
- `andisart:modern-hd-cars-mmp`: Fixed bad include rule.
- `mandelsoft:bnl-cloverleaf-insurances`: Updated STEX entry to fix issue with .rar file masquerading as a .zip file causing an issue with extraction.
- `peg:csk2-3x-avenue-draw-bridge`: Add archive extraction.