### PR TITLE
replace global variants by variants using the package namespaces

### DIFF
--- a/src/yaml/airman15/27009-concorde.yaml
+++ b/src/yaml/airman15/27009-concorde.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: concorde
-version: "2.1"
+version: "2.1-1"
 subfolder: 700-transit
 info:
   summary: Concorde
@@ -31,10 +31,10 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/0846f0a99295759063ca9451e5d5532a-concorde-2.png
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/3d7ac9874e7cfdbe246855c2eadee3c7-monthly_10_2013-3bee901eed15b4303b4a98002db8858a-concorde-1.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-concorde-hd
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-concorde-software
 

--- a/src/yaml/airman15/27423-cessna-citation-mustang.yaml
+++ b/src/yaml/airman15/27423-cessna-citation-mustang.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: cessna-citation-mustang
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Cessna Citation Mustang
@@ -19,12 +19,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_04_2015/14cb7160e09947d453e3fe00a85023b6-mustang-1.png
     - https://www.simtropolis.com/objects/screens/monthly_04_2015/f62b4d95466a2eb377ec3547297dd768-mustang-2.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-cessna-citation-mustang
       include:
       - "/.*_HD.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-cessna-citation-mustang
       include:

--- a/src/yaml/airman15/29001-hawx-space-shuttle.yaml
+++ b/src/yaml/airman15/29001-hawx-space-shuttle.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: hawx-space-shuttle
-version: "1.1"
+version: "1.1-1"
 subfolder: 710-automata
 info:
   summary: HAWX Space Shuttle
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/2684e428b9dc9ebe80327bea61872173-shuttle4.png
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/862a880f70ff4d9b10ea3b4c2ad62832-monthly_02_2014-1d3079653205267dd1735401c408fd8f-shuttlecover.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-hawx-space-shuttle
       include:
       - "/.*Hardware.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-hawx-space-shuttle
       include:

--- a/src/yaml/airman15/29266-air-france-regional-set.yaml
+++ b/src/yaml/airman15/29266-air-france-regional-set.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: air-france-regional-set
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Air France Regional Set
@@ -26,12 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/c239480bec60ce8ab8a4fc6884b47d50-af2_constellation.png
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/0afe3bfbd3ee7a2b430bf4341f76dcb5-af3_rj-85.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-air-france-regional-set
       include:
       - "/Hardware/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-air-france-regional-set
       include:

--- a/src/yaml/airman15/29267-qantas-a380.yaml
+++ b/src/yaml/airman15/29267-qantas-a380.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: qantas-a380
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Qantas A380
@@ -22,12 +22,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/15da07f40f3bdac2b49636135ea65be3-qantas2.png
     - https://www.simtropolis.com/objects/screens/monthly_02_2014/91d35d405b0436b039bb36f347c0129a-qantas3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-qantas-a380
       include:
       - "/.*HW.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-qantas-a380
       include:

--- a/src/yaml/airman15/29575-kamov-ka-50.yaml
+++ b/src/yaml/airman15/29575-kamov-ka-50.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: kamov-ka-50
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Kamov KA-50
@@ -26,12 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_05_2014/d0088beca034038420d5552e246603c7-ka50-2.png
     - https://www.simtropolis.com/objects/screens/monthly_05_2014/b46a92826e9cb99a6f397a7fd400d578-ka50-3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-kamov-ka-50
       include:
       - "/.*_HW.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-kamov-ka-50
       include:

--- a/src/yaml/airman15/29720-mi-24-hind.yaml
+++ b/src/yaml/airman15/29720-mi-24-hind.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: mi-24-hind
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: MI-24 Hind
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_07_2014/cb450e968a70160e4f90d1049c31fe61-hind-2.png
     - https://www.simtropolis.com/objects/screens/monthly_07_2014/93651b2564517bb9e1bef4377a1a16f3-hind-3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-mi-24-hind
       include:
       - "/.*_HW.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-mi-24-hind
       include:

--- a/src/yaml/airman15/29962-delorean.yaml
+++ b/src/yaml/airman15/29962-delorean.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: delorean
-version: "2"
+version: "2-1"
 subfolder: 710-automata
 info:
   summary: DeLorean
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_10_2014/6e26461cc0e83c862d2e75163378f698-delorean3.png
     - https://www.simtropolis.com/objects/screens/monthly_10_2014/21f82c7aae8c1ab25135e2ef47a83cc8-delorean4.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-delorean
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-delorean
       include:

--- a/src/yaml/airman15/29963-american-muscle-cars.yaml
+++ b/src/yaml/airman15/29963-american-muscle-cars.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: american-muscle-cars
-version: "2"
+version: "2-1"
 subfolder: 710-automata
 info:
   summary: American Muscle Cars
@@ -23,12 +23,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_04/AMC5.png.65d3ffda8483e4cd50e841dc104930f0.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_04/AMC6.png.3c233682efff4c1ec2c1fc0a4029a260.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-american-muscle-cars
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-american-muscle-cars
       include:

--- a/src/yaml/airman15/29964-alstom-agv.yaml
+++ b/src/yaml/airman15/29964-alstom-agv.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: alstom-agv
-version: "1.1"
+version: "1.1-1"
 subfolder: 710-automata
 info:
   summary: Alstom AGV
@@ -23,12 +23,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_10_2014/189450b10be093954a99f9f8926114ae-alstom1.png
     - https://www.simtropolis.com/objects/screens/monthly_10_2014/64ec5b70dda0493ee113deae43e9b3a9-alstom2.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-alstom-agv
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-alstom-agv
       include:

--- a/src/yaml/airman15/30047-isuzu-street-sweepers.yaml
+++ b/src/yaml/airman15/30047-isuzu-street-sweepers.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: isuzu-street-sweepers
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Isuzu Street Sweepers
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_12_2014/8eb4bd19945a8f280c2262f0c7eef1c8-iss-3.png
     - https://www.simtropolis.com/objects/screens/monthly_12_2014/8381cf513672bf1d70bd8058dce729f8-iss-4.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-isuzu-street-sweepers
       include:
       - "/ISS_HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-isuzu-street-sweepers
       include:

--- a/src/yaml/airman15/30101-pagani-huayras.yaml
+++ b/src/yaml/airman15/30101-pagani-huayras.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: pagani-huayras
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Pagani Huayras
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/huayraT5.png.87a3bc4728362c35f3675c9a80c1962a.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/huayraT6.png.22bbda62791b82e5e24864e83b4433d3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-pagani-huayras
       include:
       - "/.*HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-pagani-huayras
       include:

--- a/src/yaml/airman15/30528-police-car-van-conversion-mod.yaml
+++ b/src/yaml/airman15/30528-police-car-van-conversion-mod.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: police-car-van-conversion-mod
-version: "1.1"
+version: "1.1-1"
 subfolder: 710-automata
 info:
   summary: Police Car/Van Conversion Mod
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_05_2015/491d820d74ec0201e6c496575db9c153-pm2.png
     - https://www.simtropolis.com/objects/screens/monthly_05_2015/37a6e95c1245dffd57555072295ae1aa-pm3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-police-car-van-conversion-mod
       include:
       - "/.*HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-police-car-van-conversion-mod
       include:

--- a/src/yaml/airman15/30673-chevrolet-s10s.yaml
+++ b/src/yaml/airman15/30673-chevrolet-s10s.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-s10s
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet S10's
@@ -20,12 +20,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_07/s10-0.png.61351c59ae2b7409d43f88a01f46e12b.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_07/s10-1.png.d2bc3ff21cbe135c9de37b3d285151d7.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-s10s
       include:
       - "/Chevy S10 HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-s10s
       include:

--- a/src/yaml/airman15/30768-initial-d-ae86-trueno.yaml
+++ b/src/yaml/airman15/30768-initial-d-ae86-trueno.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: initial-d-ae86-trueno
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Initial-D AE86 Trueno
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_09/trueno0.png.6786eaa64659f267192958738095f289.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_09/truenox.png.f382463573ef9d649961182c987f7861.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-initial-d-ae86-trueno
       include:
       - "/.*_HD.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-initial-d-ae86-trueno
       include:

--- a/src/yaml/airman15/30814-chevrolet-suburbans.yaml
+++ b/src/yaml/airman15/30814-chevrolet-suburbans.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-suburbans
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet Suburbans
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_10/suburban5.png.dc5c9bc167c69b58f033782ae372e3f5.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_10/suburban6.png.efdec9516dc09bf1b1880d45ccdb47d7.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-suburbans
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-suburbans
       include:

--- a/src/yaml/airman15/30829-subaru-legacy.yaml
+++ b/src/yaml/airman15/30829-subaru-legacy.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: subaru-legacy
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Subaru Legacy
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_10/legacies1.png.7370d198757078d6a0d88836cb3098fa.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_10/legacies2.png.c51460ad01b8afc2fe8940276d0aed7b.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-subaru-legacy
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-subaru-legacy
       include:

--- a/src/yaml/airman15/30860-jeep-cherokee-trailhawk.yaml
+++ b/src/yaml/airman15/30860-jeep-cherokee-trailhawk.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: jeep-cherokee-trailhawk
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Jeep Cherokee Trailhawk
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_12/trailhawk6.png.036de3ef1be7b56d17a0b0c67e3f83cf.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_12/trailhawk7.png.7699c84b99bd58c6073917e820f996fb.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-jeep-cherokee-trailhawk
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-jeep-cherokee-trailhawk
       include:

--- a/src/yaml/airman15/30861-air-france-airbus-a350.yaml
+++ b/src/yaml/airman15/30861-air-france-airbus-a350.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: air-france-airbus-a350
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Air France Airbus A350
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2015_12/a350AF-1.png.2aba310b9cb7214b3c70723e9ac00133.png
     - https://www.simtropolis.com/objects/screens/monthly_2015_12/a350AF-2.png.0582275aa5704cdda413e85db5fdae58.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-air-france-airbus-a350
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-air-france-airbus-a350
       include:

--- a/src/yaml/airman15/30898-ford-escape.yaml
+++ b/src/yaml/airman15/30898-ford-escape.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: ford-escape
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Ford Escape
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_01/escape5.png.11c2f6ab9871d5ecb19431d2408e383f.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_01/escape6.png.b8eadfb33384b632ceaac2307d395756.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-ford-escape
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-ford-escape
       include:

--- a/src/yaml/airman15/30910-ford-explorer.yaml
+++ b/src/yaml/airman15/30910-ford-explorer.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: ford-explorer
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Ford Explorer
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_01/explorer6.png.aa8fc5c0d4ccfea54f53f22c36339b57.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_01/explorer7.png.12ac3305c759046832a77c639abbccb5.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-ford-explorer
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-ford-explorer
       include:

--- a/src/yaml/airman15/30911-nissan-gtr.yaml
+++ b/src/yaml/airman15/30911-nissan-gtr.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: nissan-gtr
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Nissan GT-R
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/gtrT3.png.068837a53b2a07746ab7f25c6a5d3f1d.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/gtrT4.png.003a5119f93d4a2d829825d1455944f3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-nissan-gtr
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-nissan-gtr
       include:

--- a/src/yaml/airman15/30969-mayors-suburban.yaml
+++ b/src/yaml/airman15/30969-mayors-suburban.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: mayors-suburban
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Mayor's Suburban
@@ -19,12 +19,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/MayorSuburban1.png.cee9f3d63c04fb747b4387c73de216ad.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/MayorSuburban2.png.f9dfe36fd8da3459b2a739f405a637ce.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-mayors-suburban
       include:
       - "/.*_HD.dat"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-mayors-suburban
       include:

--- a/src/yaml/airman15/30970-buick-gnx.yaml
+++ b/src/yaml/airman15/30970-buick-gnx.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: buick-gnx
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Buick GNX
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/GNX3.png.dd4c95e6ce2d88ca32fe8dbf02091fe0.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/GNX4.png.258d9eef82b46f2d17d2bc0e7e0b6beb.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-buick-gnx
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-buick-gnx
       include:

--- a/src/yaml/airman15/30971-uh-1-iroquois-huey.yaml
+++ b/src/yaml/airman15/30971-uh-1-iroquois-huey.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: uh-1-iroquois-huey
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: UH-1 Iroquois "Huey"
@@ -23,12 +23,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/zHuey3.png.dd8b889cf42f97ccf77dac766588298f.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_02/zHuey4.png.8bc372018927e277400b29179cd36e1b.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-uh-1-iroquois-huey
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-uh-1-iroquois-huey
       include:

--- a/src/yaml/airman15/31000-fiat-500c.yaml
+++ b/src/yaml/airman15/31000-fiat-500c.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: fiat-500c
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Fiat 500C
@@ -26,12 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_03/fiat6.png.afe990a566769491a14d701f159d101c.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_03/fiat7.png.c8e364600d43add20c14e0a9b7db6800.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-fiat-500c
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-fiat-500c
       include:

--- a/src/yaml/airman15/31049-nissan-skyline-gtr.yaml
+++ b/src/yaml/airman15/31049-nissan-skyline-gtr.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: nissan-skyline-gtr
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Nissan Skyline GT-R
@@ -29,12 +29,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/r34skyline9.png.da2559ac92a1274df24fe074087fe176.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/r34skyline10.png.e45b42cd731df2d816d5ee65555e7973.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-nissan-skyline-gt-r
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-nissan-skyline-gt-r
       include:

--- a/src/yaml/airman15/31101-wrightbus-new-routemaster.yaml
+++ b/src/yaml/airman15/31101-wrightbus-new-routemaster.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: wrightbus-new-routemaster
-version: "1.1"
+version: "1.1-1"
 subfolder: 710-automata
 info:
   summary: Wrightbus New Routemaster
@@ -22,22 +22,22 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/newroutemaster2.png.f9b0f6572fa1e02c11803b47f160c36b.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/newroutemaster3.png.8c40e12b04cd7180ef5f2f1bd4086358.png
 variants:
-  - variant: { driveside: right, "prop-resolution": "hd" }
+  - variant: { driveside: right, "airman15:prop-resolution": "hd" }
     assets:
       - assetId: airman15-wrightbus-new-routemaster-rhd
         include:
         - "/HD/"
-  - variant: { driveside: left, "prop-resolution": "hd" }
+  - variant: { driveside: left, "airman15:prop-resolution": "hd" }
     assets:
       - assetId: airman15-wrightbus-new-routemaster-lhd
         include:
         - "/HD/"
-  - variant: { driveside: right, "prop-resolution": "sd" }
+  - variant: { driveside: right, "airman15:prop-resolution": "sd" }
     assets:
       - assetId: airman15-wrightbus-new-routemaster-rhd
         include:
         - "/SD/"
-  - variant: { driveside: left, "prop-resolution": "sd" }
+  - variant: { driveside: left, "airman15:prop-resolution": "sd" }
     assets:
       - assetId: airman15-wrightbus-new-routemaster-lhd
         include:

--- a/src/yaml/airman15/31102-volvo-v90.yaml
+++ b/src/yaml/airman15/31102-volvo-v90.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: volvo-v90
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Volvo V90
@@ -29,12 +29,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/volvov90_7.png.18ed907ea8ed13f934a012f67a336cf3.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_05/volvov90_8.png.629a6cf9895fa9c7d1a1910eaf770d30.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-volvo-v90
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-volvo-v90
       include:

--- a/src/yaml/airman15/31214-mercedes-sprinter-2500.yaml
+++ b/src/yaml/airman15/31214-mercedes-sprinter-2500.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: mercedes-sprinter-2500
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Mercedes Sprinter 2500
@@ -22,12 +22,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_07/sprinter2.png.f1a58c58e9a95eb657baab16596a8df7.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_07/sprinter3.png.eb12c44952219ba3529aa92de5958dab.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-mercedes-sprinter-2500
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-mercedes-sprinter-2500
       include:

--- a/src/yaml/airman15/31291-plymouth-superbirds.yaml
+++ b/src/yaml/airman15/31291-plymouth-superbirds.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: plymouth-superbirds
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Plymouth Superbirds
@@ -27,12 +27,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2016_09/superbird7.png.fd5b661e3e1563ee0d26524d27a3ea8b.png
     - https://www.simtropolis.com/objects/screens/monthly_2016_09/superbird8.png.04f8bba184a67ffc8eac4b961b54a851.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-plymouth-superbirds
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-plymouth-superbirds
       include:

--- a/src/yaml/airman15/31430-ford-fusions.yaml
+++ b/src/yaml/airman15/31430-ford-fusions.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: ford-fusions
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Ford Fusions
@@ -26,12 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_01/Fusions6.png.656dacf39db779aadcb5c6e09dc9af62.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_01/Fusions7.png.24948c726def7e9bbc2acd9b73825ea3.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-ford-fusions
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-ford-fusions
       include:

--- a/src/yaml/airman15/31587-aston-martin-vanquish.yaml
+++ b/src/yaml/airman15/31587-aston-martin-vanquish.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: aston-martin-vanquish
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Aston Martin Vanquish
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_04/AMVanquish6.png.45c1c11b2e0b11addac8d4d847c9c14f.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_04/AMVanquish7.png.7a77f0ccd93445a8a334d8a9469b51f6.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-aston-martin-vanquish
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-aston-martin-vanquish
       include:

--- a/src/yaml/airman15/31931-chevrolet-impala.yaml
+++ b/src/yaml/airman15/31931-chevrolet-impala.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-impala
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet Impala
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_09/Imapala07.png.84ed990b3529f4f8c6d33a8c58bcb802.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_09/Imapala08.png.201c19cfedc2a21bd34d97874c817965.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-impala
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-impala
       include:

--- a/src/yaml/airman15/31966-vector-w8-twin-turbo.yaml
+++ b/src/yaml/airman15/31966-vector-w8-twin-turbo.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: vector-w8-twin-turbo
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Vector W8 Twin Turbo
@@ -22,12 +22,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_10/Vector4.png.590abaa4b42c22c1e5b3c3033a343539.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_10/Vector5.png.97e42ff84b5a331917c9652f493c878f.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-vector-w8-twin-turbo
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-vector-w8-twin-turbo
       include:

--- a/src/yaml/airman15/32037-chevrolet-impala-police-edition.yaml
+++ b/src/yaml/airman15/32037-chevrolet-impala-police-edition.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-impala-police-edition
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet Impala- Police Edition
@@ -18,12 +18,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_12/ImpalaPolice0.png.bbb641fcdbe96ecbf5cc7bc79c2d67e6.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_12/ImpalaPolice1.png.c29dfabe84d16d2fc19d4b0d1d53e3bc.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-impala-police-edition
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-impala-police-edition
       include:

--- a/src/yaml/airman15/32038-chevrolet-impala-taxi-edition.yaml
+++ b/src/yaml/airman15/32038-chevrolet-impala-taxi-edition.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-impala-taxi-edition
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet Impala- Taxi Edition
@@ -20,12 +20,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_12/ImpalaTaxi2.png.7a4589aa3fef7ebdfb08c54d1539045d.png
     - https://www.simtropolis.com/objects/screens/monthly_2017_12/ImpalaTaxi3.png.4a3542b57178cb6da0a24ac2ddd47dec.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-impala-taxi-edition
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-impala-taxi-edition
       include:

--- a/src/yaml/airman15/32206-chevrolet-c7-corvettes.yaml
+++ b/src/yaml/airman15/32206-chevrolet-c7-corvettes.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: chevrolet-c7-corvettes
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Chevrolet C7 Corvettes
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2018_04/C7Corvette_7.png.d363a0e0f2a7dab17b489be116f9c09b.png
     - https://www.simtropolis.com/objects/screens/monthly_2018_04/C7Corvette_8.png.b638d70ad72198d936a18f627150c98b.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-chevrolet-c7-corvettes
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-chevrolet-c7-corvettes
       include:

--- a/src/yaml/airman15/32340-1957-chevrolet-bel-air.yaml
+++ b/src/yaml/airman15/32340-1957-chevrolet-bel-air.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: 1957-chevrolet-bel-air
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: 1957 Chevrolet Bel Air
@@ -26,12 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2018_06/BelAir_8.png.e05e3dd269692a927b5789e455887c6a.png
     - https://www.simtropolis.com/objects/screens/monthly_2018_06/BelAir_9.png.0c26558066710ef94c9f963c39c99e34.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-1957-chevrolet-bel-air
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-1957-chevrolet-bel-air
       include:

--- a/src/yaml/airman15/32424-cadillac-escalade.yaml
+++ b/src/yaml/airman15/32424-cadillac-escalade.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: cadillac-escalade
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Cadillac Escalade
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2018_08/Escalade4.png.9b41b01f2994bcf3a8de223749f89f54.png
     - https://www.simtropolis.com/objects/screens/monthly_2018_08/Escalade5.png.fdc4921d7dac251e4ddb2c362d701ea1.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-cadillac-escalade
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-cadillac-escalade
       include:

--- a/src/yaml/airman15/32425-mayors-cadillac-escalade.yaml
+++ b/src/yaml/airman15/32425-mayors-cadillac-escalade.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: mayors-cadillac-escalade
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Mayor's Cadillac Escalade
@@ -21,12 +21,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2018_08/MEscalade1.png.410bc71add0922aaa16afaba6046e26e.png
     - https://www.simtropolis.com/objects/screens/monthly_2018_08/MEscalade2.png.7f869b39090ac4d228d172559f7ddb63.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-mayors-cadillac-escalade
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-mayors-cadillac-escalade
       include:

--- a/src/yaml/airman15/32596-infiniti-q50.yaml
+++ b/src/yaml/airman15/32596-infiniti-q50.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: infiniti-q50
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Infiniti Q50
@@ -25,12 +25,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2018_11/Q50Infiniti_5.png.4897b619a002c8ea20684df64d678ee4.png
     - https://www.simtropolis.com/objects/screens/monthly_2018_11/Q50Infiniti_6.png.4f6b13d2912b33998702a42fdba02d4d.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-infiniti-q50
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-infiniti-q50
       include:

--- a/src/yaml/airman15/33021-honda-crvs.yaml
+++ b/src/yaml/airman15/33021-honda-crvs.yaml
@@ -1,6 +1,6 @@
 group: airman15
 name: honda-crvs
-version: "1.0"
+version: "1.0-1"
 subfolder: 710-automata
 info:
   summary: Honda CR-Vs
@@ -24,12 +24,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2019_07/HondaCRV6.png.05039e6bfd4575e8ccaba4907e29d415.png
     - https://www.simtropolis.com/objects/screens/monthly_2019_07/HondaCRV7.png.dfdc3c29a29dbb8ed791491564e9060c.png
 variants:
-  - variant: { "prop-resolution": "hd" }
+  - variant: { "airman15:prop-resolution": "hd" }
     assets:
     - assetId: airman15-honda-crvs
       include:
       - "/HD/"
-  - variant: { "prop-resolution": "sd" }
+  - variant: { "airman15:prop-resolution": "sd" }
     assets:
     - assetId: airman15-honda-crvs
       include:

--- a/src/yaml/deadwoods/14766-road-top-bus-stop-set.yaml
+++ b/src/yaml/deadwoods/14766-road-top-bus-stop-set.yaml
@@ -43,7 +43,7 @@ assets:
 ---
 group: deadwoods
 name: road-top-bus-stop-textures
-version: "103"
+version: "103-1"
 subfolder: 100-props-textures
 info:
   summary: Textures for `pkg=deadwoods:road-top-bus-stop-set`
@@ -53,12 +53,12 @@ info:
     - https://www.simtropolis.com/objects/screens/0021/baa3b76bb61f4f837a376d8ead070fe3-DEDWD_RTBusStops-stexpic1.jpg
     - https://www.simtropolis.com/objects/screens/0021/baa3b76bb61f4f837a376d8ead070fe3-DEDWD_RTBusStops-stexpic2.jpg
 variants:
-- variant: { texture-style: "Maxis" }
+- variant: { roadstyle: "US" }
   assets:
   - assetId: "deadwoods-road-top-bus-stop-set"
     include:
     - "/DEDWD_RTBusStop_Maxis_textures.dat"
-- variant: { texture-style: "Euro" }
+- variant: { roadstyle: "EU" }
   assets:
   - assetId: "deadwoods-road-top-bus-stop-set"
     include:

--- a/src/yaml/vlasky/28271-525-west-48th-street.yaml
+++ b/src/yaml/vlasky/28271-525-west-48th-street.yaml
@@ -1,6 +1,6 @@
 group: vlasky
 name: 525-west-48th-street
-version: "1.0"
+version: "1.0-1"
 subfolder: 400-industrial
 info:
   summary: NYBT 525 West 48th Street
@@ -39,53 +39,53 @@ dependencies:
   - nybt:essentials
 
 variants:
-- variant: { nightmode: standard, IRM: "no", toroca:industry-quadrupler:capacity: "standard" }
+- variant: { nightmode: standard, vlasky:525-west-48th-street:irm: "no", toroca:industry-quadrupler:capacity: "standard" }
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-maxisnite
       include:
         - "/MaxisNite/"
         - "/Regular_Zoning/Regular lot/"
-- variant: { nightmode: standard, IRM: "no", toroca:industry-quadrupler:capacity: "quadrupled" }
+- variant: { nightmode: standard, vlasky:525-west-48th-street:irm: "no", toroca:industry-quadrupler:capacity: "quadrupled" }
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-maxisnite
       include:
         - "/MaxisNite/"
         - "/Regular_Zoning/Qua?druple lot/"
-- variant: { nightmode: dark, IRM: "no", toroca:industry-quadrupler:capacity: "standard" }
+- variant: { nightmode: dark, vlasky:525-west-48th-street:irm: "no", toroca:industry-quadrupler:capacity: "standard" }
   dependencies: [ "simfox:day-and-nite-mod" ]
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-darknite
       include:
         - "/DarkNite/"
         - "/Regular_Zoning/Regular lot/"
-- variant: { nightmode: dark, IRM: "no", toroca:industry-quadrupler:capacity: "quadrupled" }
+- variant: { nightmode: dark, vlasky:525-west-48th-street:irm: "no", toroca:industry-quadrupler:capacity: "quadrupled" }
   dependencies: [ "simfox:day-and-nite-mod" ]
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-darknite
       include:
         - "/DarkNite/"
         - "/Regular_Zoning/Qua?druple lot/"
-# IRM = yes
-- variant: { nightmode: standard, IRM: "yes", toroca:industry-quadrupler:capacity: "standard" }
+# vlasky:525-west-48th-street:irm = yes
+- variant: { nightmode: standard, vlasky:525-west-48th-street:irm: "yes", toroca:industry-quadrupler:capacity: "standard" }
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-maxisnite
       include:
         - "/MaxisNite/"
         - "/Industrial Revolution Mod_Zoning/Regular lot/"
-- variant: { nightmode: standard, IRM: "yes", toroca:industry-quadrupler:capacity: "quadrupled" }
+- variant: { nightmode: standard, vlasky:525-west-48th-street:irm: "yes", toroca:industry-quadrupler:capacity: "quadrupled" }
   assets:
   - assetId: vlasky-nybt-525-west-48th-street-maxisnite
     include:
       - "/MaxisNite/"
       - "/Industrial Revolution Mod_Zoning/Qua?druple lot/"
-- variant: { nightmode: dark, IRM: "yes", toroca:industry-quadrupler:capacity: "standard" }
+- variant: { nightmode: dark, vlasky:525-west-48th-street:irm: "yes", toroca:industry-quadrupler:capacity: "standard" }
   dependencies: [ "simfox:day-and-nite-mod" ]
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-darknite
       include:
         - "/DarkNite/"
         - "/Industrial Revolution Mod_Zoning/Regular lot/"
-- variant: { nightmode: dark, IRM: "yes", toroca:industry-quadrupler:capacity: "quadrupled" }
+- variant: { nightmode: dark, vlasky:525-west-48th-street:irm: "yes", toroca:industry-quadrupler:capacity: "quadrupled" }
   dependencies: [ "simfox:day-and-nite-mod" ]
   assets:
     - assetId: vlasky-nybt-525-west-48th-street-darknite


### PR DESCRIPTION
In preparation for a change to the linter (https://github.com/memo33/sc4pac-actions/commit/eb5e921b448b328cd51ad3377c61c80c124b3898) as previously discussed, this PR replaces some global variants by ones using the package (or group) namespace. Adding new global variants should generally be avoided.