### PR TITLE
metadata: add TiepiNL's content

### DIFF
--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -11,7 +11,7 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include: 
-    - "/stop_maxis_growable_I-d$$.dat"
+    - "/stop_maxis_growable_I-d\\$\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop dirty industry Lots from growing"
@@ -37,7 +37,7 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include: 
-    - "/stop_maxis_growable_I-m$$.dat"
+    - "/stop_maxis_growable_I-m\\$\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop manufacturing industry Lots from growing"
@@ -63,7 +63,7 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include: 
-    - "/stop_maxis_growable_I-ht$$$.dat"
+    - "/stop_maxis_growable_I-ht\\$\\$\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop high-tech industry Lots from growing"
@@ -89,7 +89,7 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include: 
-    - "/stop_maxis_growable_I-r$.dat"
+    - "/stop_maxis_growable_I-r\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop agricultural industry Lots (farms) from growing"
@@ -115,9 +115,9 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include: 
-    - "/stop_maxis_growable_R$.dat"
-    - "/stop_maxis_growable_R$$.dat"
-    - "/stop_maxis_growable_R$$$.dat"
+    - "/stop_maxis_growable_R\\$.dat"
+    - "/stop_maxis_growable_R\\$\\$.dat"
+    - "/stop_maxis_growable_R\\$\\$\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop residential Lots (all wealth types) from growing"
@@ -143,11 +143,11 @@ subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
   include:
-    - "/stop_maxis_growable_CO$$.dat"
-    - "/stop_maxis_growable_CO$$$.dat"
-    - "/stop_maxis_growable_CS$.dat"
-    - "/stop_maxis_growable_CS$$.dat"
-    - "/stop_maxis_growable_CS$$$.dat"
+    - "/stop_maxis_growable_CO\\$\\$.dat"
+    - "/stop_maxis_growable_CO\\$\\$\\$.dat"
+    - "/stop_maxis_growable_CS\\$.dat"
+    - "/stop_maxis_growable_CS\\$\\$.dat"
+    - "/stop_maxis_growable_CS\\$\\$\\$.dat"
 info:
   author: "TiepiNL"
   summary: "Stop commercial services and commercial offices Lots (all wealth types) from growing"

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -27,7 +27,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
 
 ---
 group: "tiepinl"
@@ -53,7 +53,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
 
 ---
 group: "tiepinl"
@@ -79,7 +79,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
 
 ---
 group: "tiepinl"
@@ -105,7 +105,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
 
 ---
 group: "tiepinl"
@@ -133,7 +133,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
 
 ---
 group: "tiepinl"
@@ -163,5 +163,5 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
-  - null-45:sc4-resource-loading-hook
+  - null-45:sc4-resource-loading-hooks
   

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -1,0 +1,167 @@
+assetId: "block-maxis-rci-lots"
+version: "1"
+lastModified: "2025-09-10T08:44:22Z"
+url: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/?do=download"
+
+---
+group: "tiepinl"
+name: "block-maxis-i-d"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include: 
+    - "/stop_maxis_growable_I-d$$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop dirty industry Lots from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+
+---
+group: "tiepinl"
+name: "block-maxis-i-m"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include: 
+    - "/stop_maxis_growable_I-m$$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop manufacturing industry Lots from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+
+---
+group: "tiepinl"
+name: "block-maxis-i-ht"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include: 
+    - "/stop_maxis_growable_I-ht$$$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop high-tech industry Lots from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+
+---
+group: "tiepinl"
+name: "block-maxis-i-r"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include: 
+    - "/stop_maxis_growable_I-r$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop agricultural industry Lots (farms) from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+
+---
+group: "tiepinl"
+name: "block-maxis-residential"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include: 
+    - "/stop_maxis_growable_R$.dat"
+    - "/stop_maxis_growable_R$$.dat"
+    - "/stop_maxis_growable_R$$$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop residential Lots (all wealth types) from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+
+---
+group: "tiepinl"
+name: "block-maxis-commercial"
+version: "1"
+subfolder: "900-overrides"
+assets:
+- assetId: "block-maxis-rci-lots"
+  include:
+    - "/stop_maxis_growable_CO$$.dat"
+    - "/stop_maxis_growable_CO$$$.dat"
+    - "/stop_maxis_growable_CS$.dat"
+    - "/stop_maxis_growable_CS$$.dat"
+    - "/stop_maxis_growable_CS$$$.dat"
+info:
+  author: "TiepiNL"
+  summary: "Stop commercial services and commercial offices Lots (all wealth types) from growing"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hook
+  

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -1,12 +1,12 @@
 assetId: "block-maxis-rci-lots"
-version: "1"
+version: "1.1"
 lastModified: "2025-09-10T08:44:22Z"
 url: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/?do=download"
 
 ---
 group: "tiepinl"
 name: "block-maxis-i-d"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -32,7 +32,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-m"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -58,7 +58,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-ht"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -84,7 +84,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-r"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -110,7 +110,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-residential"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -138,7 +138,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-commercial"
-version: "1"
+version: "1.1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -165,3 +165,35 @@ info:
 dependencies:
   - null-45:sc4-resource-loading-hooks
   
+---
+group: "tiepinl"
+name: "block-maxis-CAM"
+version: "1.1"
+subfolder: "900-overrides"
+variants:
+- variant: { CAM: "yes" }
+  assets:
+  - assetId: "block-maxis-rci-lots"
+    include:
+    - "/CAM_Buildings_custom_rci_blocker.dat"
+- variant: { CAM: "no" }
+  assets:
+  - assetId: "block-maxis-rci-lots"
+    include: []
+info:
+  author: "TiepiNL"
+  summary: "Stop CAM commercial lots based on Maxis Landmarks"
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
+
+    For exemplar patches the loading order doesn't matter.
+  website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+dependencies:
+  - null-45:sc4-resource-loading-hooks
+

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -1,6 +1,6 @@
 assetId: "block-maxis-rci-lots"
 version: "1.1"
-lastModified: "2025-09-10T08:44:22Z"
+lastModified: "2025-09-13T06:59:22Z"
 url: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/?do=download"
 
 ---

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -6,7 +6,7 @@ url: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/?d
 ---
 group: "tiepinl"
 name: "block-maxis-i-d"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -18,8 +18,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -28,11 +26,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
 ---
 group: "tiepinl"
 name: "block-maxis-i-m"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -44,8 +43,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -54,11 +51,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
 ---
 group: "tiepinl"
 name: "block-maxis-i-ht"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -70,8 +68,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -80,11 +76,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
 ---
 group: "tiepinl"
 name: "block-maxis-i-r"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -96,8 +93,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -106,11 +101,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
 ---
 group: "tiepinl"
 name: "block-maxis-residential"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -124,8 +120,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -134,11 +128,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
 ---
 group: "tiepinl"
 name: "block-maxis-commercial"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -154,8 +149,6 @@ info:
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -164,11 +157,12 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
   
 ---
 group: "tiepinl"
 name: "block-maxis-cam"
-version: "1.1"
+version: "1.1.0"
 subfolder: "900-overrides"
 variants:
 - variant: { CAM: "yes" }
@@ -177,17 +171,12 @@ variants:
     include:
     - "/CAM_Buildings_custom_rci_blocker.dat"
 - variant: { CAM: "no" }
-  assets:
-  - assetId: "block-maxis-rci-lots"
-    include: []
 info:
   author: "TiepiNL"
   summary: "Stop CAM commercial lots based on Maxis Landmarks"
   description: |-
     Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
     The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.
-
-    For exemplar patches the loading order doesn't matter.
   website: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/"
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
@@ -196,4 +185,31 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
 dependencies:
   - null-45:sc4-resource-loading-hooks
+  - config:sc4-edition-windows-digital
 
+---
+group: tiepinl
+name:  block-maxis-building-collection    
+version: "1.1.0"
+subfolder: 900-overrides
+info:
+  summary: Stop Maxis Building from growing
+  description: |-
+    Modern and lightweight version of existing Maxis blockers, based on Exemplar Patching.
+    The blockers prevent Maxis RCI lots from growing, by setting the minimum slope angle to an impossible value.       
+  author: TiepiNL
+  websites: 
+    - https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/Nano_Banana.png.50509be1bb7fd255dec84136efdf1064.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8e53ff2_Screenshot2025-09-10071839.png.d2ff21d5f307b9c58de1c77843d20717.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11b8f91bbc_Screenshot2025-09-10071942.png.3c7cc859941052eb3837f48fb649579a.png
+    - https://www.simtropolis.com/objects/screens/monthly_2025_09/68c11fbc75e8f_Screenshot2025-09-10084843.png.bb156ac3c7127638bd475282ddbf5387.png
+
+dependencies:
+  - tiepinl:block-maxis-i-d
+  - tiepinl:block-maxis-i-m
+  - tiepinl:block-maxis-i-ht
+  - tiepinl:block-maxis-residential
+  - tiepinl:block-maxis-commercial
+  - tiepinl:block-maxis-cam

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -167,7 +167,7 @@ dependencies:
   
 ---
 group: "tiepinl"
-name: "block-maxis-CAM"
+name: "block-maxis-cam"
 version: "1.1"
 subfolder: "900-overrides"
 variants:


### PR DESCRIPTION
This PR adds metadata for TiepiNL's Block Maxis RCI Lots mod to sc4pac.

## What's included:
- **tiepinl:block-maxis-i-d** - Block Maxis Industrial Dirty lots
- **tiepinl:block-maxis-i-m** - Block Maxis Industrial Manufacturing lots  
- **tiepinl:block-maxis-i-ht** - Block Maxis Industrial High-Tech lots
- **tiepinl:block-maxis-i-r** - Block Maxis Industrial Resource lots
- **tiepinl:block-maxis-residential** - Block Maxis Residential lots
- **tiepinl:block-maxis-commercial** - Block Maxis Commercial lots
- **tiepinl:block-maxis-CAM** - Block CAM commercial lots based on Maxis Landmarks

## Package Details:
- **STEX URL:** https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/
- **Version:** 1.1
- **Modern exemplar patching approach** - no loading order dependencies
- **CAM variant support** - can be enabled/disabled based on CAM usage

All packages include proper dependencies and are organized in the 900-overrides subfolder.