### PR TITLE
eliminate equal variants

### DIFF
--- a/src/yaml/jasoncw/28714-hammer-data-security.yaml
+++ b/src/yaml/jasoncw/28714-hammer-data-security.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: hammer-data-security
-version: "1.0"
+version: "1.0-1"
 subfolder: 400-industrial
 info:
   summary: Hammer Data Security
@@ -42,13 +42,6 @@ variants:
     dependencies: [ "simfox:day-and-nite-mod" ]
     assets:
       - assetId: jasoncw-hammer-data-security-darknite
-  - variant: { nightmode: standard, CAM: "yes", jasoncw:hammer-data-security:capacity: standard }
-    assets:
-      - assetId: jasoncw-hammer-data-security-cam-maxisnite
-  - variant: { nightmode: dark, CAM: "yes", jasoncw:hammer-data-security:capacity: standard }
-    dependencies: [ "simfox:day-and-nite-mod" ]
-    assets:
-      - assetId: jasoncw-hammer-data-security-cam-darknite
   - variant: { nightmode: standard, CAM: "no", jasoncw:hammer-data-security:capacity: doubled }
     assets:
       - assetId: jasoncw-hammer-data-security-2x-maxisnite
@@ -56,10 +49,10 @@ variants:
     dependencies: [ "simfox:day-and-nite-mod" ]
     assets:
       - assetId: jasoncw-hammer-data-security-2x-darknite
-  - variant: { nightmode: standard, CAM: "yes", jasoncw:hammer-data-security:capacity: doubled }
+  - variant: { nightmode: standard, CAM: "yes" }
     assets:
       - assetId: jasoncw-hammer-data-security-cam-maxisnite
-  - variant: { nightmode: dark, CAM: "yes", jasoncw:hammer-data-security:capacity: doubled }
+  - variant: { nightmode: dark, CAM: "yes" }
     dependencies: [ "simfox:day-and-nite-mod" ]
     assets:
       - assetId: jasoncw-hammer-data-security-cam-darknite

--- a/src/yaml/simfox/20502-p44towers-take2.yaml
+++ b/src/yaml/simfox/20502-p44towers-take2.yaml
@@ -1,6 +1,6 @@
 group: simfox
 name: p44towers-take2
-version: "2"
+version: "2-1"
 subfolder: 200-residential
 info:
   summary: P44towers take2
@@ -95,17 +95,10 @@ dependencies:
   - bsc:textures-vol01
   - bsc:textures-vol02
   - simfox:p44towers-models
-variants:
-- variant: { CAM: "no" }
-  assets:
-  - assetId: simfox-p44towers-take2-non-cam
-    exclude:
-    - "SimFox_P44TM_towers.dat"
-- variant: { CAM: "yes" }
-  assets:
-  - assetId: simfox-p44towers-take2-non-cam #TODO - There was a CAM version uploaded to the LEX that is not available for now
-    exclude:
-    - "SimFox_P44TM_towers.dat"
+assets:
+- assetId: simfox-p44towers-take2-non-cam #TODO - There was a CAM version uploaded to the LEX that is not available for now
+  exclude:
+  - "SimFox_P44TM_towers.dat"
 
 ---
 group: simfox


### PR DESCRIPTION
This is a minor tweaking of some definitions of variants, to avoid having variants that install identical files.

This is in preparation for a new lint rule: https://github.com/memo33/sc4pac-actions/issues/6