### PR TITLE
Fix exclude rule for `s-olah:labashaz-museum-v2`

### DIFF
--- a/src/yaml/s-olah/21744-labashaz-museum-v2.yaml
+++ b/src/yaml/s-olah/21744-labashaz-museum-v2.yaml
@@ -21,7 +21,7 @@ dependencies:
   - s-olah:labashaz-museum-v2-model
 assets:
   - assetId: s-olah-labashaz-museum-v2
-    include:
+    exclude:
       - "\\.SC4Model$"
 
 ---


### PR DESCRIPTION
Address lint error `The packages 's-olah:labashaz-museum-v2' and 's-olah:labashaz-museum-v2-model' seem to install the _same_ files, unintentionally.`