### PR TITLE
AMPS Update

### DIFF
--- a/src/yaml/dk1/19296-methane-power-plant.yaml
+++ b/src/yaml/dk1/19296-methane-power-plant.yaml
@@ -1,7 +1,32 @@
 group: dk1
+name: methane-power-plant-resouces
+version: "1.0"
+subfolder: 110-resources
+info:
+  summary: Power Plant Props
+  description: |-
+    Methane Power Plant Props by DK1
+  author: dk1
+  website: https://community.simtropolis.com/files/file/19296-dk1-methane-power-plant/
+  images:
+    - https://www.simtropolis.com/objects/screens/0027/f74df7686b46907deb91b0edf32b8f14-MPP_day.JPG
+    - https://www.simtropolis.com/objects/screens/0027/f74df7686b46907deb91b0edf32b8f14-MPP_night.JPG
+assets:
+  - assetId: dk1-methane-power-plant
+    include:
+    - "/powerplant-0x5ad0e817_0x73156766_0x2850000.SC4Model"
+    - "/tank2prop-0x5ad0e817_0x73156766_0x2720000.SC4Model"
+    - "/tank2prop-0x6534284a-0x73156766-0xb49152bf.SC4Desc"
+    - "/powerplant-0x6534284a-0x73156766-0x14a350aa.SC4Desc"
+
+
+---
+group: dk1
 name: methane-power-plant
 version: "1.0"
 subfolder: 500-utilities
+dependencies:
+  - "dk1:methane-power-plant"
 info:
   summary: Methane Power Plant
   description: |-
@@ -13,6 +38,10 @@ info:
     - https://www.simtropolis.com/objects/screens/0027/f74df7686b46907deb91b0edf32b8f14-MPP_night.JPG
 assets:
   - assetId: dk1-methane-power-plant
+    include:
+    - "/Up3x2_MethanePowerPlant_f4a74c02.SC4Lot"
+    - "/Up3x3_MethanePowerPlant_f4a35355.SC4Lot"
+    - "/Up3x3_PowerPlant_Maxis tanks_f4a7512b.SC4Lot"
 
 ---
 assetId: dk1-methane-power-plant

--- a/src/yaml/dk1/19296-methane-power-plant.yaml
+++ b/src/yaml/dk1/19296-methane-power-plant.yaml
@@ -3,7 +3,7 @@ name: methane-power-plant-resouces
 version: "2.0"
 subfolder: 110-resources
 info:
-  summary: Power Plant Props
+  summary: Methane Power Plant Props
   description: |-
     Methane Power Plant Props by DK1
   author: dk1

--- a/src/yaml/dk1/19296-methane-power-plant.yaml
+++ b/src/yaml/dk1/19296-methane-power-plant.yaml
@@ -1,6 +1,6 @@
 group: dk1
 name: methane-power-plant-resouces
-version: "1.0"
+version: "2.0"
 subfolder: 110-resources
 info:
   summary: Power Plant Props
@@ -23,10 +23,10 @@ assets:
 ---
 group: dk1
 name: methane-power-plant
-version: "1.0"
+version: "2.0"
 subfolder: 500-utilities
 dependencies:
-  - "dk1:methane-power-plant"
+  - "dk1:methane-power-plant-resouces"
 info:
   summary: Methane Power Plant
   description: |-
@@ -45,6 +45,6 @@ assets:
 
 ---
 assetId: dk1-methane-power-plant
-version: "1.0"
+version: "2.0"
 lastModified: "2008-01-27T07:19:19Z"
 url: https://community.simtropolis.com/files/file/19296-dk1-methane-power-plant/?do=download&r=43909

--- a/src/yaml/dk1/22535-power-plant.yaml
+++ b/src/yaml/dk1/22535-power-plant.yaml
@@ -1,7 +1,29 @@
 group: dk1
+name: power-plant-resouces
+version: "1.0"
+subfolder: 110-resources
+info:
+  summary: Power Plant Props
+  description: |-
+    Power Plant Props by DK1
+  author: dk1
+  website: https://community.simtropolis.com/files/file/22535-dk1-power-plant/
+  images:
+    - https://www.simtropolis.com/objects/screens/0017/98be499dd890e1475e06d2d23bc3455b-3x3PowerD.JPG
+    - https://www.simtropolis.com/objects/screens/0017/98be499dd890e1475e06d2d23bc3455b-3x3PowerN.JPG
+assets:
+  - assetId: dk1-power-plant
+    include:
+    - "/PowerPlant2-0x5ad0e817_0x73156766_0x5780000.SC4Model"
+    - "/substation2-0x5ad0e817_0x73156766_0x5750000.SC4Model"
+
+---
+group: dk1
 name: power-plant
 version: "1.0"
 subfolder: 500-utilities
+dependencies:
+  - "dk1:power-plant-resouces"
 info:
   summary: Power Plant
   description: |-
@@ -13,7 +35,11 @@ info:
     - https://www.simtropolis.com/objects/screens/0017/98be499dd890e1475e06d2d23bc3455b-3x3PowerN.JPG
 assets:
   - assetId: dk1-power-plant
-
+    include:
+    - "/Up1x1_Substation_f76f8eec.SC4Lot"
+    - "/Up3x2_PowerPlant2_7771732f.SC4Lot"
+    - "/Up3x3_PowerPlant2_7771746e.SC4Lot"
+    
 ---
 assetId: dk1-power-plant
 version: "1.0"

--- a/src/yaml/dk1/22535-power-plant.yaml
+++ b/src/yaml/dk1/22535-power-plant.yaml
@@ -1,6 +1,6 @@
 group: dk1
 name: power-plant-resouces
-version: "1.0"
+version: "2.0"
 subfolder: 110-resources
 info:
   summary: Power Plant Props
@@ -20,7 +20,7 @@ assets:
 ---
 group: dk1
 name: power-plant
-version: "1.0"
+version: "2.0"
 subfolder: 500-utilities
 dependencies:
   - "dk1:power-plant-resouces"
@@ -42,6 +42,6 @@ assets:
     
 ---
 assetId: dk1-power-plant
-version: "1.0"
+version: "2.0"
 lastModified: "2009-09-24T07:02:14Z"
 url: https://community.simtropolis.com/files/file/22535-dk1-power-plant/?do=download&r=48963

--- a/src/yaml/simmer2/32484-modular-solar-power-plant.yaml
+++ b/src/yaml/simmer2/32484-modular-solar-power-plant.yaml
@@ -1,7 +1,31 @@
 group: simmer2
+name: modular-solar-power-plant-resouces
+version: "2.0"
+subfolder: 110-resources
+info:
+  summary: Modular Solar Power Plant Resouces
+  description: |-
+   Modular Solar Power Plant Resouces by Simmer2
+  author: Simmer2
+  website: https://community.simtropolis.com/files/file/32484-sm2-modular-solar-power-plant/
+  images:
+    - https://i.imgur.com/JVg3eDn.gif
+    - https://www.simtropolis.com/objects/screens/monthly_2018_09/SP7.jpg.334e24cd07582ac5b9912a090aa16f59.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_09/SP6.jpg.96ae2d4d4c83ba4b304c07d90064fa8b.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_09/SP5.jpg.350803f188404b917a5c3ba54b3d4850.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2018_09/5b96caa29ebe2_SM2Modularsolarpowerplantcopy.jpg.fe70d39b4b23f6fa816217eec48508d4.jpg
+
+assets:
+  - assetId: simmer2-modular-solar-power-plant
+    include:
+    - "/Timed props.dat"
+    - "/SM2 Solar Power Plant_Tex.dat"
+
+---
+group: simmer2
 name: modular-solar-power-plant
-version: "1.0"
-subfolder: 500-utilities
+version: "2.0"
+subfolder: 110-resources
 info:
   summary: Modular Solar Power Plant
   description: |-
@@ -62,11 +86,15 @@ dependencies:
   - simmer2:essentials
   - simmer2:mega-prop-pack-vol1
   - simmer2:mega-prop-pack-vol2
+  - simmer2:modular-solar-power-plant-resouces
 assets:
   - assetId: simmer2-modular-solar-power-plant
-
+    include:
+    - "/PLOP_1x1_SM2 Solar Power Inverter_b90b4dc3.SC4Lot"
+    - "/PLOP_2x2_SM2 Step up Transformer_a90b4e29.SC4Lot"
+    - "/SM2 Modular Solar Panels 1X1_490ff4a1.SC4Lot"
 ---
 assetId: simmer2-modular-solar-power-plant
-version: "1.0"
+version: "2.0"
 lastModified: "2018-09-10T19:58:20Z"
 url: https://community.simtropolis.com/files/file/32484-sm2-modular-solar-power-plant/?do=download

--- a/src/yaml/simmer2/32484-modular-solar-power-plant.yaml
+++ b/src/yaml/simmer2/32484-modular-solar-power-plant.yaml
@@ -25,7 +25,7 @@ assets:
 group: simmer2
 name: modular-solar-power-plant
 version: "2.0"
-subfolder: 110-resources
+subfolder: 500-utilities
 info:
   summary: Modular Solar Power Plant
   description: |-

--- a/src/yaml/simmer2/32918-geothermal-power-plant.yaml
+++ b/src/yaml/simmer2/32918-geothermal-power-plant.yaml
@@ -1,6 +1,6 @@
 group: simmer2
 name: geothermal-power-plant-resouces
-version: "2.0.0"
+version: "2.0"
 subfolder: 110-resources
 info:
   summary: Geothermal Power Plant Texture

--- a/src/yaml/simmer2/32918-geothermal-power-plant.yaml
+++ b/src/yaml/simmer2/32918-geothermal-power-plant.yaml
@@ -16,7 +16,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo9.jpg.150b80c07f78093a095dca22c92d3149.jpg
 
 assets:
-  - assetId: simmer2-sim-gideon-ng-power-plant
+  - assetId: simmer2-geothermal-power-plant
     include:
     - "/SM2_Geothermal_Plant_Tex.dat"
 

--- a/src/yaml/simmer2/32918-geothermal-power-plant.yaml
+++ b/src/yaml/simmer2/32918-geothermal-power-plant.yaml
@@ -1,6 +1,29 @@
 group: simmer2
+name: geothermal-power-plant-resouces
+version: "2.0.0"
+subfolder: 110-resources
+info:
+  summary: Geothermal Power Plant Texture
+  description: |-
+   Geothermal Power Plant Texture by Simmer2
+  author: Simmer2
+  website: https://community.simtropolis.com/files/file/32918-sm2-geothermal-power-plant/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo5.jpg.2f4ab9151176c1b97bd829e4d673b0d2.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo6.jpg.3bb625a2037c227ef8d9480c62d68dc5.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo7.jpg.751d3c80ddd796daba898e39516af31d.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo8.jpg.1194b3ca996d4d4f954eb5821f8b16be.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2019_05/geo9.jpg.150b80c07f78093a095dca22c92d3149.jpg
+
+assets:
+  - assetId: simmer2-sim-gideon-ng-power-plant
+    include:
+    - "/SM2_Geothermal_Plant_Tex.dat"
+
+---
+group: simmer2
 name: geothermal-power-plant
-version: "1.0"
+version: "2.0"
 subfolder: 500-utilities
 info:
   summary: Geothermal Power Plant
@@ -55,12 +78,15 @@ dependencies:
   - simmer2:mega-prop-pack-vol1
   - simmer2:mega-prop-pack-vol3
   - simmer2:mega-prop-pack-vol4
+  - simmer2:geothermal-power-plant-resouces
   - bsc:vip-girafe-carpack-vol01-vol02
 assets:
   - assetId: simmer2-geothermal-power-plant
-
+    include:
+    - "/PLOP_4x4_SM2 Geothermal Power Plant_3a556b6c.SC4Lot"
+    
 ---
 assetId: simmer2-geothermal-power-plant
-version: "1.0"
+version: "2.0"
 lastModified: "2019-12-02T06:17:17Z"
 url: https://community.simtropolis.com/files/file/32918-sm2-geothermal-power-plant/?do=download

--- a/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
+++ b/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
@@ -1,6 +1,6 @@
 group: dk1
 name: sim-gideon-ng-power-plant-resouces
-version: "2.0"
+version: "2.0.0"
 subfolder: 110-resources
 info:
   summary: Sim Gideon NG Power Plant Texture

--- a/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
+++ b/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
@@ -1,12 +1,12 @@
-group: dk1
+group: simmer2
 name: sim-gideon-ng-power-plant-resouces
 version: "2.0.0"
 subfolder: 110-resources
 info:
   summary: Sim Gideon NG Power Plant Texture
   description: |-
-    Methane Power Plant Props by DK1
-  author: dk1
+    Sim Gideon NG Power Plant Texture by Simmer2
+  author: Simmer2
   website: https://community.simtropolis.com/files/file/34319-sm2-sim-gideon-ng-power-plant/
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2021_03/si1.jpg.1198c3c3ba6b308fd8249fa7fe4c3eb6.jpg

--- a/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
+++ b/src/yaml/simmer2/34319-sim-gideon-ng-power-plant.yaml
@@ -1,6 +1,29 @@
+group: dk1
+name: sim-gideon-ng-power-plant-resouces
+version: "2.0"
+subfolder: 110-resources
+info:
+  summary: Sim Gideon NG Power Plant Texture
+  description: |-
+    Methane Power Plant Props by DK1
+  author: dk1
+  website: https://community.simtropolis.com/files/file/34319-sm2-sim-gideon-ng-power-plant/
+  images:
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si1.jpg.1198c3c3ba6b308fd8249fa7fe4c3eb6.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si2.jpg.69fde759234e81d85da7474633e07e1f.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si3.jpg.773db9772ce61f8d5e32068014b680b1.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si4.jpg.f04eb825eef12f489ff654cb9d4595b8.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si5.jpg.114c3475bd4e44e3a80d5db50683385c.jpg
+    - https://www.simtropolis.com/objects/screens/monthly_2021_03/si6.jpg.0094cb803242b69147e6a6e2ad0be3db.jpg
+assets:
+  - assetId: simmer2-sim-gideon-ng-power-plant
+    include:
+    - "/SM2_Sim_Gideon_Plant_Tex.dat"
+
+---
 group: simmer2
 name: sim-gideon-ng-power-plant
-version: "1.0.0"
+version: "2.0.0"
 subfolder: 500-utilities
 info:
   summary: Sim Gideon NG Power Plant
@@ -68,13 +91,16 @@ dependencies:
   - simmer2:mega-prop-pack-vol3
   - simmer2:mega-prop-pack-vol4
   - simmer2:mega-prop-pack-vol5
+  - simmer2:sim-gideon-ng-power-plant-resouces
   - bsc:vip-girafe-carpack-vol01-vol02
   - supershk:mega-parking-textures
 assets:
   - assetId: simmer2-sim-gideon-ng-power-plant
+    include:
+    - "/PLOP_9x7_SM2 Sim Gideon NG Power Plant_6dd69839.SC4Lot"
 
 ---
 assetId: simmer2-sim-gideon-ng-power-plant
-version: "1.0.0"
+version: "2.0.0"
 lastModified: "2021-08-12T18:06:05Z"
 url: https://community.simtropolis.com/files/file/34319-sm2-sim-gideon-ng-power-plant/?do=download


### PR DESCRIPTION
This PR is needed to load AMPS on SC4Pac.

This PR is needed to load AMPS on SC4pac.

Due to the particular modding performed, it is necessary to separate the props from the lots to avoid conflicts between AMPS and non-AMPS lots, since they use the same IID and problems such as the Phantom Slider Bug can occur. 

The purpose of this PR is divided into three parts

- [x] Separate the various resource packs from the lots to avoid conflicts during installation (Where possible)
- [ ] Upload missing mods to SC4Pac
- [ ] Load AMPS (NO CAM Variant) onto SC4Pac.
- [ ] Load AMPS (CAM Variant) when it becomes available. (Not important for this PR)