### PR TITLE
Remove `mikeseith:park-n-pay`

### DIFF
--- a/src/yaml/mikeseith/2519-park-n-pay.yaml
+++ b/src/yaml/mikeseith/2519-park-n-pay.yaml
@@ -1,23 +1,24 @@
-group: mikeseith
-name: park-n-pay
-version: "1.0"
-subfolder: 700-transit
-info:
-  summary: Park n Pay parking garage
-  description: |-
-    this lot gives your city an infusion of cash each month from parking fees. for more of the car props you see on the lot visit my site: props.freeservers.com
+# removed 13 Jan 2026 due to missing model. See STEX banner.
+# group: mikeseith
+# name: park-n-pay
+# version: "1.0"
+# subfolder: 700-transit
+# info:
+#   summary: Park n Pay parking garage
+#   description: |-
+#     this lot gives your city an infusion of cash each month from parking fees. for more of the car props you see on the lot visit my site: props.freeservers.com
 
-    this lot contains a modd from someone who i forget their name, but deserves the modding credit.
-  author: mikeseith
-  website: https://community.simtropolis.com/files/file/2519-park-n-pay-by-mikeseith/
-  images:
-    - https://www.simtropolis.com/objects/screens/0009/49d6b9ef9211c432b8262f0089fbcf93-garage day.JPG
-    - https://www.simtropolis.com/objects/screens/0009/49d6b9ef9211c432b8262f0089fbcf93-garage night.JPG
-assets:
-  - assetId: mikeseith-park-n-pay-by-mikeseith
+#     this lot contains a modd from someone who i forget their name, but deserves the modding credit.
+#   author: mikeseith
+#   website: https://community.simtropolis.com/files/file/2519-park-n-pay-by-mikeseith/
+#   images:
+#     - https://www.simtropolis.com/objects/screens/0009/49d6b9ef9211c432b8262f0089fbcf93-garage day.JPG
+#     - https://www.simtropolis.com/objects/screens/0009/49d6b9ef9211c432b8262f0089fbcf93-garage night.JPG
+# assets:
+#   - assetId: mikeseith-park-n-pay-by-mikeseith
 
----
-assetId: mikeseith-park-n-pay-by-mikeseith
-version: "1.0"
-lastModified: "2004-02-26T18:47:52Z"
-url: https://community.simtropolis.com/files/file/2519-park-n-pay-by-mikeseith/?do=download&r=26097
+# ---
+# assetId: mikeseith-park-n-pay-by-mikeseith
+# version: "1.0"
+# lastModified: "2004-02-26T18:47:52Z"
+# url: https://community.simtropolis.com/files/file/2519-park-n-pay-by-mikeseith/?do=download&r=26097


### PR DESCRIPTION
Brought to attention via STEX report 2802
> This upload is missing the main parking garage model. The main model (probably) and several car models/props were used to be hosted on Mikeseiths own website 22 years ago, but when the site ceased to exist those models were not restored anywhere. Though the site still can be visited via webarchive, most of the files (including the missing models and props from this lot) are long gone, lost in time.  