### PR TITLE
enable `test-install` action for pull requests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Lint
 on:
-  pull_request:
+  pull_request_target:  # with this trigger, be careful not to execute any scripts from the pull request in this workflow, which would be unsafe
     paths:
       - 'src/yaml/**'
     branches:
@@ -10,7 +10,26 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: memo33/sc4pac-actions/actions/lint@main
-        with:
-          path: src/yaml
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+        # For pull_request_target:
+        # As merge_commit_sha is not up-to-date due to mergeability check, we use actual PR head for now; see https://github.com/actions/checkout/issues/518#issuecomment-1757453837
+        # (This merge might correspond to a newer commit than the one that triggered this workflow, in case the PR was updated in the meantime -> ok)
+        ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+        sparse-checkout: |
+          src/yaml
+    - uses: memo33/sc4pac-actions/actions/lint@main
+      with:
+        path: src/yaml
+
+  test:
+    needs: lint
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Test installing modified packages
+      uses: memo33/sc4pac-actions/actions/test-install@main
+      with:
+        path: src/yaml
+        sc4pac-simtropolis-token: ${{ secrets.SC4PAC_SIMTROPOLIS_TOKEN }}


### PR DESCRIPTION
Proposal to enable the [test-install action](https://github.com/memo33/sc4pac-actions/blob/main/actions/test-install/action.yaml) for pull requests on this channel. It's already in use on the other two channels.

The action can detect some issues, especially related to variants, as it downloads the relevant assets and installs several variants in one go, using the `sc4pac test` command.

This means the assets will be downloaded once more from the STEX. (This could be avoided if you have an existing `sc4pac-cache` available though, e.g. combined with [actions/cache](https://github.com/actions/cache).)

To be able to access the ST token secret, I had to switch the trigger from `pull_request` to `pull_request_target`. (This comes with a caveat, as exposing the secrets is generally a bit unsafer if not handled carefully. The executed GH workflow script then always comes from the `main` branch instead of the PR, and the workflow uses sparse checkouts on `src/yaml` to ensure that no executable code from the PR is checked out or executed.)

Open question: Do PRs only get auto-merged if the `lint` _workflow_ on the PR passed? It seems the linter is also run outside the `lint` workflow.