### PR TITLE
fix: pass secrets to `deploy` when called from `add-packages`

### DIFF
--- a/.github/workflows/add-packages.yaml
+++ b/.github/workflows/add-packages.yaml
@@ -74,3 +74,5 @@ jobs:
     needs: add-packages
     if: ${{ needs.add-packages.outputs.has-new-content == 'true' }}
     uses: ./.github/workflows/deploy.yaml
+    secrets:
+      STEX_API_KEY: ${{ secrets.STEX_API_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,9 @@ name: Deploy channel
 on:
   workflow_dispatch: #
   workflow_call: #
+    secrets:
+      STEX_API_KEY:
+        required: true
   push:
     paths:
       - 'src/yaml/**'


### PR DESCRIPTION
Related to and possibly addresses #389 