### PR TITLE
Handle Simtropolis outage

### DIFF
--- a/actions/fetch/action.js
+++ b/actions/fetch/action.js
@@ -36,6 +36,10 @@ try {
 	}
 
 } catch (e) {
-	core.error(e.message);
-	throw e;
+	if (e.code === 'simtropolis_offline_error') {
+		core.notice('Simtropolis appears to be offline');
+	} else {
+		core.error(e.message);
+		throw e;
+	}
 }

--- a/actions/fetch/errors.js
+++ b/actions/fetch/errors.js
@@ -7,3 +7,11 @@ export class SimtropolisError extends Error {
 		this.status = res.status;
 	}
 }
+
+export class SimtropolisOfflineError extends Error {
+	code = 'simtropolis_offline_error';
+	status = 503;
+	constructor() {
+		super(`Simtropolis is offline`);
+	}
+}

--- a/actions/fetch/fetch.js
+++ b/actions/fetch/fetch.js
@@ -5,7 +5,10 @@ import { parse } from 'yaml';
 import handleUpload from './handle-upload.js';
 import Permissions from './permissions.js';
 import { urlToFileId } from './util.js';
-import { SimtropolisError } from './errors.js';
+import {
+	SimtropolisError,
+	SimtropolisOfflineError,
+} from './errors.js';
 
 // # fetch(opts)
 // Main entrypoint for fetching the latest plugins released from the STEX.
@@ -62,6 +65,15 @@ export default async function fetchPackage(opts) {
 	// frame, it will return 404! We have to handle this appropriately!
 	let nextLastRun = new Date().toISOString();
 	let res = await fetch(url);
+
+	// If Simtropolis has redirected us to offline.simtropolis.com, we do 
+	// nothing, but we also don't log this as an error.
+	if (res.url.includes('offline.simtropolis.com')) {
+		throw new SimtropolisOfflineError();
+	}
+
+	// Continue processing. Anything with status 400+ should get logged as an 
+	// error.
 	if (res.status >= 400 && res.status !== 404) {
 		throw new SimtropolisError(res);
 	}


### PR DESCRIPTION
The Simtropolis outage is flooding my Github notifications with failed action runs. This PR should fix that.

The annoying thing is that calling the API does not return an http 503, but 403 instead. However, we don't want to ignore 403 errors, as it might indicate that the STEX api key is no longer valid as well. Hence we do it by detecting whether Simtropolis redirected to offline.simtropolis.com.

Let's hope ST returns 🤞 