### PR TITLE
mass-update of recently restored STEX files

### DIFF
--- a/src/yaml/andreas-roth/36530-random-seasonal-birch-trees.yaml
+++ b/src/yaml/andreas-roth/36530-random-seasonal-birch-trees.yaml
@@ -1,6 +1,6 @@
 group: sfbt
 name: random-seasonal-birch-trees
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Random Seasonal Birch Trees
@@ -77,7 +77,7 @@ assets:
 ---
 group: sfbt
 name: random-seasonal-birch-trees-props
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Random Seasonal Birch Trees props
@@ -93,6 +93,6 @@ assets:
 
 ---
 assetId: andreas-roth-sfbt-arkenbergejoe-random-seasonal-birch-trees
-version: "1.0.0"
-lastModified: "2024-10-28T11:07:32Z"
-url: https://community.simtropolis.com/files/file/36530-sfbt-arkenbergejoe-random-seasonal-birch-trees/?do=download&r=204148
+version: "1.0.0-1"
+lastModified: "2026-06-04T14:33:58Z"
+url: https://community.simtropolis.com/files/file/36530-sfbt-arkenbergejoe-random-seasonal-birch-trees/?do=download

--- a/src/yaml/anubis89/17267-big-elementary-school.yaml
+++ b/src/yaml/anubis89/17267-big-elementary-school.yaml
@@ -1,6 +1,6 @@
 group: anubis89
 name: big-elementary-school
-version: "1.1"
+version: "1.1-1"
 subfolder: 620-education
 info:
   summary: Big Elementary School
@@ -30,6 +30,6 @@ assets:
 
 ---
 assetId: anubis89-bigelementaryschool
-version: "1.1"
-lastModified: "2025-08-22T23:45:46Z"
-url: https://community.simtropolis.com/files/file/17267-bigelementaryschool/?do=download&r=40433
+version: "1.1-1"
+lastModified: "2026-06-03T23:39:56Z"
+url: https://community.simtropolis.com/files/file/17267-bigelementaryschool/?do=download

--- a/src/yaml/ap/36335-historic-navy-pack-27-ammo-lighters.yaml
+++ b/src/yaml/ap/36335-historic-navy-pack-27-ammo-lighters.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-27-ammo-lighters
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 27 - Ammo Lighters
@@ -33,6 +33,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-27-ammo-lighters
-version: "1.0.0"
-lastModified: "2024-07-11T21:36:25Z"
-url: https://community.simtropolis.com/files/file/36335-historic-navy-pack-27-ammo-lighters/?do=download&r=201946
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:41:47Z"
+url: https://community.simtropolis.com/files/file/36335-historic-navy-pack-27-ammo-lighters/?do=download

--- a/src/yaml/ap/36351-historic-navy-pack-28-proteus-class-collier.yaml
+++ b/src/yaml/ap/36351-historic-navy-pack-28-proteus-class-collier.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-28-proteus-class-collier
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 28 - Proteus Class Collier
@@ -41,6 +41,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-28-proteus-class-collier
-version: "1.1"
-lastModified: "2024-08-08T16:44:44Z"
-url: https://community.simtropolis.com/files/file/36351-historic-navy-pack-28-proteus-class-collier/?do=download&r=202326
+version: "1.1-1"
+lastModified: "2026-06-11T05:43:00Z"
+url: https://community.simtropolis.com/files/file/36351-historic-navy-pack-28-proteus-class-collier/?do=download

--- a/src/yaml/ap/36378-historic-navy-pack-29-collier-vestal.yaml
+++ b/src/yaml/ap/36378-historic-navy-pack-29-collier-vestal.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-29-collier-vestal
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 29 - Collier Vestal
@@ -44,6 +44,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-29-collier-vestal
-version: "1.0.0"
-lastModified: "2024-08-08T19:46:56Z"
-url: https://community.simtropolis.com/files/file/36378-historic-navy-pack-29-collier-vestal/?do=download&r=202333
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:38:31Z"
+url: https://community.simtropolis.com/files/file/36378-historic-navy-pack-29-collier-vestal/?do=download

--- a/src/yaml/ap/36407-historic-navy-pack-30-provisions.yaml
+++ b/src/yaml/ap/36407-historic-navy-pack-30-provisions.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-30-provisions
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 30 - Provisions
@@ -39,6 +39,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-30-provisions
-version: "1.0.0"
-lastModified: "2024-08-22T16:39:29Z"
-url: https://community.simtropolis.com/files/file/36407-historic-navy-pack-30-provisions/?do=download&r=202669
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:37:35Z"
+url: https://community.simtropolis.com/files/file/36407-historic-navy-pack-30-provisions/?do=download

--- a/src/yaml/ap/36455-historic-navy-pack-31-propulsion-components.yaml
+++ b/src/yaml/ap/36455-historic-navy-pack-31-propulsion-components.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-31-propulsion-components
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 31 - Propulsion Components
@@ -37,6 +37,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-31-propulsion-components
-version: "1.0.0"
-lastModified: "2024-09-20T23:04:54Z"
-url: https://community.simtropolis.com/files/file/36455-historic-navy-pack-31-propulsion-components/?do=download&r=203494
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:36:27Z"
+url: https://community.simtropolis.com/files/file/36455-historic-navy-pack-31-propulsion-components/?do=download

--- a/src/yaml/ap/36510-historic-navy-pack-32-armament-components.yaml
+++ b/src/yaml/ap/36510-historic-navy-pack-32-armament-components.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-32-armament-components
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 32 - Armament Components
@@ -37,6 +37,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-32-armament-components
-version: "1.0.0"
-lastModified: "2024-10-18T21:32:56Z"
-url: https://community.simtropolis.com/files/file/36510-historic-navy-pack-32-armament-components/?do=download&r=203935
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:35:26Z"
+url: https://community.simtropolis.com/files/file/36510-historic-navy-pack-32-armament-components/?do=download

--- a/src/yaml/ap/36551-historic-navy-pack-33-motor-lighter.yaml
+++ b/src/yaml/ap/36551-historic-navy-pack-33-motor-lighter.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-33-motor-lighter
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 33 - Motor Lighter
@@ -38,6 +38,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-33-motor-lighter
-version: "1.0.0"
-lastModified: "2024-11-15T19:51:47Z"
-url: https://community.simtropolis.com/files/file/36551-historic-navy-pack-33-motor-lighter/?do=download&r=204403
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:34:18Z"
+url: https://community.simtropolis.com/files/file/36551-historic-navy-pack-33-motor-lighter/?do=download

--- a/src/yaml/ap/36618-historic-navy-pack-34-mooring-dolphins.yaml
+++ b/src/yaml/ap/36618-historic-navy-pack-34-mooring-dolphins.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-34-mooring-dolphins
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 34 - Mooring Dolphins
@@ -36,6 +36,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-34-mooring-dolphins
-version: "1.0.0"
-lastModified: "2024-12-21T16:51:02Z"
-url: https://community.simtropolis.com/files/file/36618-historic-navy-pack-34-mooring-dolphins/?do=download&r=204782
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:33:06Z"
+url: https://community.simtropolis.com/files/file/36618-historic-navy-pack-34-mooring-dolphins/?do=download

--- a/src/yaml/ap/36689-historic-navy-pack-35-boat-fenders.yaml
+++ b/src/yaml/ap/36689-historic-navy-pack-35-boat-fenders.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-35-boat-fenders
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 35 - Boat Fenders
@@ -38,6 +38,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-35-boat-fenders
-version: "1.0.0"
-lastModified: "2025-02-06T22:00:57Z"
-url: https://community.simtropolis.com/files/file/36689-historic-navy-pack-35-boat-fenders/?do=download&r=205557
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:31:58Z"
+url: https://community.simtropolis.com/files/file/36689-historic-navy-pack-35-boat-fenders/?do=download

--- a/src/yaml/ap/36733-historic-navy-pack-36-hindenburg.yaml
+++ b/src/yaml/ap/36733-historic-navy-pack-36-hindenburg.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-36-hindenburg
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 36 - Hindenburg
@@ -40,6 +40,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-36-hindenburg
-version: "1.0.0"
-lastModified: "2025-02-20T22:26:28Z"
-url: https://community.simtropolis.com/files/file/36733-historic-navy-pack-36-hindenburg/?do=download&r=206098
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:30:58Z"
+url: https://community.simtropolis.com/files/file/36733-historic-navy-pack-36-hindenburg/?do=download

--- a/src/yaml/ap/36759-historic-navy-pack-37-ersatz-yorck.yaml
+++ b/src/yaml/ap/36759-historic-navy-pack-37-ersatz-yorck.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-37-ersatz-yorck
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 37 - Ersatz Yorck
@@ -44,6 +44,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-37-ersatz-yorck
-version: "1.0.0"
-lastModified: "2025-03-08T17:41:49Z"
-url: https://community.simtropolis.com/files/file/36759-historic-navy-pack-37-ersatz-yorck/?do=download&r=206337
+version: "1.0.0-1"
+lastModified: "2026-06-08T06:40:05Z"
+url: https://community.simtropolis.com/files/file/36759-historic-navy-pack-37-ersatz-yorck/?do=download

--- a/src/yaml/ap/36904-historic-navy-pack-38-boats.yaml
+++ b/src/yaml/ap/36904-historic-navy-pack-38-boats.yaml
@@ -1,6 +1,6 @@
 group: ap
 name: historic-navy-pack-38-boats
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Historic Navy - pack 38 - Boats
@@ -41,6 +41,6 @@ assets:
 
 ---
 assetId: ap-historic-navy-pack-38-boats
-version: "1.0.0"
-lastModified: "2025-06-15T17:08:33Z"
-url: https://community.simtropolis.com/files/file/36904-historic-navy-pack-38-boats/?do=download&r=208058
+version: "1.0.0-1"
+lastModified: "2026-06-11T05:29:17Z"
+url: https://community.simtropolis.com/files/file/36904-historic-navy-pack-38-boats/?do=download

--- a/src/yaml/blam-french-connections/17913-garden-and-plaza-props.yaml
+++ b/src/yaml/blam-french-connections/17913-garden-and-plaza-props.yaml
@@ -1,6 +1,6 @@
 group: blam-french-connections
 name: garden-and-plaza-props
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: BLaM FC Garden and Plaza Props 1
@@ -58,6 +58,6 @@ assets:
 
 ---
 assetId: blam-french-connections-blam-fc-garden-and-plaza-props
-version: "1.1"
-lastModified: "2025-03-09T23:38:24Z"
-url: https://community.simtropolis.com/files/file/17913-blam-fc-garden-and-plaza-props-1/?do=download&r=41533
+version: "1.1-1"
+lastModified: "2026-06-06T02:35:43Z"
+url: https://community.simtropolis.com/files/file/17913-blam-fc-garden-and-plaza-props-1/?do=download

--- a/src/yaml/burrodiablo/18848-nuclear-power-plant.yaml
+++ b/src/yaml/burrodiablo/18848-nuclear-power-plant.yaml
@@ -1,6 +1,6 @@
 group: burrodiablo
 name: nuclear-power-plant
-version: "2.0"
+version: "2.0-1"
 subfolder: 500-utilities
 info:
   summary: Nuclear Power Plant
@@ -35,6 +35,6 @@ assets:
 
 ---
 assetId: bd-nuclear-power-plant
-version: "2.0"
-lastModified: "2025-11-15T22:47:34Z"
+version: "2.0-1"
+lastModified: "2026-05-30T00:10:15Z"
 url: https://community.simtropolis.com/files/file/18848-nuclear-power-plant/?do=download

--- a/src/yaml/burrodiablo/19367-krushkova-apartments.yaml
+++ b/src/yaml/burrodiablo/19367-krushkova-apartments.yaml
@@ -1,6 +1,6 @@
 group: burrodiablo
 name: krushkova-apartments
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 info:
   summary: Krushkova Apartments
@@ -41,6 +41,6 @@ assets:
 
 ---
 assetId: bd-krushkova-apartments
-version: "2.0"
-lastModified: "2025-11-15T22:30:15Z"
+version: "2.0-1"
+lastModified: "2026-05-30T00:07:51Z"
 url: https://community.simtropolis.com/files/file/19367-krushkova-apartments/?do=download

--- a/src/yaml/burrodiablo/20176-nuclear-power-plant-vver-1000-pressurised-reactor.yaml
+++ b/src/yaml/burrodiablo/20176-nuclear-power-plant-vver-1000-pressurised-reactor.yaml
@@ -1,6 +1,6 @@
 group: burrodiablo
 name: nuclear-power-plant-vver-1000-pressurised-reactor
-version: "2.0"
+version: "2.0-1"
 subfolder: 500-utilities
 info:
   summary: Nuclear Power Plant - VVER 1000 Pressurised Reactor 
@@ -54,6 +54,6 @@ assets:
 
 ---
 assetId: bd-vver-1000-pressurised-reactor
-version: "2.0"
-lastModified: "2025-11-15T22:51:32Z"
+version: "2.0-1"
+lastModified: "2026-05-30T00:10:39Z"
 url: https://community.simtropolis.com/files/file/20176-nuclear-power-plant-vver-1000-pressurised-reactor/?do=download

--- a/src/yaml/ceafus-88/36467-billboard-set-1.yaml
+++ b/src/yaml/ceafus-88/36467-billboard-set-1.yaml
@@ -1,6 +1,6 @@
 group: ceafus-88
 name: billboard-set-1
-version: "1.0.1"
+version: "1.0.2"
 subfolder: 660-parks
 info:
   summary: C88- Billboard Set 1
@@ -33,6 +33,6 @@ dependencies:
 
 ---
 assetId: ceafus-88-c88-billboard-set-1
-version: "1.0.1"
-lastModified: "2024-09-27T03:06:18Z"
-url: https://community.simtropolis.com/files/file/36467-c88-billboard-set-1/?do=download&r=203623
+version: "1.0.2"
+lastModified: "2026-06-06T02:03:31Z"
+url: https://community.simtropolis.com/files/file/36467-c88-billboard-set-1/?do=download

--- a/src/yaml/cockatoo/18739-yau-ma-tei-currency-exchange.yaml
+++ b/src/yaml/cockatoo/18739-yau-ma-tei-currency-exchange.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: yau-ma-tei-currency-exchange
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Yau Ma Tei Currency Exchange
@@ -78,6 +78,6 @@ assets:
 
 ---
 assetId: cockatoo-yau-ma-tei-currency-exchange
-version: "2.0"
-lastModified: "2025-09-24T23:24:39Z"
-url: https://community.simtropolis.com/files/file/18739-yau-ma-tei-currency-exchange/?do=download&r=209336
+version: "2.0-1"
+lastModified: "2026-05-29T01:07:37Z"
+url: https://community.simtropolis.com/files/file/18739-yau-ma-tei-currency-exchange/?do=download

--- a/src/yaml/cockatoo/18840-sceneway-garden-phase-1.yaml
+++ b/src/yaml/cockatoo/18840-sceneway-garden-phase-1.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: sceneway-garden-phase-1
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 info:
   summary: Sceneway Garden Phase 1 New Lot
@@ -59,6 +59,6 @@ assets:
 
 ---
 assetId: cockatoo-sceneway-garden-phase-1-new-lot
-version: "2.0"
-lastModified: "2025-09-24T23:31:29Z"
-url: https://community.simtropolis.com/files/file/18840-hk-sceneway-garden-phase-1-new-lot/?do=download&r=209339
+version: "2.0-1"
+lastModified: "2026-05-29T01:09:12Z"
+url: https://community.simtropolis.com/files/file/18840-hk-sceneway-garden-phase-1-new-lot/?do=download

--- a/src/yaml/cockatoo/18905-immigration-tower.yaml
+++ b/src/yaml/cockatoo/18905-immigration-tower.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: immigration-tower
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Immigration Tower
@@ -76,6 +76,6 @@ assets:
 
 ---
 assetId: cockatoo-immigration-tower
-version: "2.0"
-lastModified: "2025-09-24T23:39:23Z"
-url: https://community.simtropolis.com/files/file/18905-hong-kong-immigration-tower/?do=download&r=209342
+version: "2.0-1"
+lastModified: "2026-05-29T01:09:50Z"
+url: https://community.simtropolis.com/files/file/18905-hong-kong-immigration-tower/?do=download

--- a/src/yaml/cockatoo/19190-aig-tower-legacy-version.yaml
+++ b/src/yaml/cockatoo/19190-aig-tower-legacy-version.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: aig-tower-legacy-version
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: AIG Tower (Legacy Version)
@@ -80,6 +80,6 @@ assets:
 
 ---
 assetId: cockatoo-aig-tower-legacy-version
-version: "2.0"
-lastModified: "2025-09-24T23:51:54Z"
-url: https://community.simtropolis.com/files/file/19190-hong-kong-aig-tower-legacy-version/?do=download&r=209345
+version: "2.0-1"
+lastModified: "2026-05-29T01:10:23Z"
+url: https://community.simtropolis.com/files/file/19190-hong-kong-aig-tower-legacy-version/?do=download

--- a/src/yaml/cockatoo/19584-mok-tin-yin-building.yaml
+++ b/src/yaml/cockatoo/19584-mok-tin-yin-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: mok-tin-yin-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Mok Tin Yin Building
@@ -110,6 +110,6 @@ assets:
 
 ---
 assetId: cockatoo-mok-tin-yin-building
-version: "2.0"
-lastModified: "2025-09-24T23:55:48Z"
-url: https://community.simtropolis.com/files/file/19584-hk-mok-tin-yin-building/?do=download&r=209348
+version: "2.0-1"
+lastModified: "2026-05-29T01:11:01Z"
+url: https://community.simtropolis.com/files/file/19584-hk-mok-tin-yin-building/?do=download

--- a/src/yaml/cockatoo/19739-junker-ship-pack.yaml
+++ b/src/yaml/cockatoo/19739-junker-ship-pack.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: junker-ship-pack
-version: "1.0"
+version: "2"
 subfolder: 700-transit
 info:
   summary: Junker Ship Pack
@@ -102,6 +102,6 @@ assets:
 
 ---
 assetId: cockatoo-junker-ship-pack
-version: "1.0"
-lastModified: "2008-04-27T01:31:49Z"
-url: https://community.simtropolis.com/files/file/19739-hong-kong-junker-ship-pack/?do=download&r=44657
+version: "2"
+lastModified: "2026-05-29T01:26:20Z"
+url: https://community.simtropolis.com/files/file/19739-hong-kong-junker-ship-pack/?do=download

--- a/src/yaml/cockatoo/19740-marina-dock-pack.yaml
+++ b/src/yaml/cockatoo/19740-marina-dock-pack.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: marina-dock-pack
-version: "1.0"
+version: "2"
 subfolder: 700-transit
 info:
   summary: Marina Dock Pack
@@ -98,6 +98,6 @@ assets:
 
 ---
 assetId: cockatoo-marina-dock-pack
-version: "1.0"
-lastModified: "2008-04-27T01:42:49Z"
-url: https://community.simtropolis.com/files/file/19740-hong-kong-marina-dock-pack/?do=download&r=44659
+version: "2"
+lastModified: "2026-05-29T01:25:33Z"
+url: https://community.simtropolis.com/files/file/19740-hong-kong-marina-dock-pack/?do=download

--- a/src/yaml/cockatoo/19741-marina-wall.yaml
+++ b/src/yaml/cockatoo/19741-marina-wall.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: marina-wall
-version: "1.0"
+version: "2"
 subfolder: 660-parks
 info:
   summary: Marina Wall
@@ -96,6 +96,6 @@ assets:
 
 ---
 assetId: cockatoo-marina-wall
-version: "1.0"
-lastModified: "2008-04-27T01:52:24Z"
-url: https://community.simtropolis.com/files/file/19741-hong-kong-marina-wall/?do=download&r=44661
+version: "2"
+lastModified: "2026-05-29T01:24:58Z"
+url: https://community.simtropolis.com/files/file/19741-hong-kong-marina-wall/?do=download

--- a/src/yaml/cockatoo/19896-admiralty-centre-legacy.yaml
+++ b/src/yaml/cockatoo/19896-admiralty-centre-legacy.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: admiralty-centre-legacy
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Admiralty Centre (Legacy Version)
@@ -136,6 +136,6 @@ assets:
 
 ---
 assetId: cockatoo-admiralty-centre-legacy-version
-version: "2.0"
-lastModified: "2025-09-25T19:14:47Z"
-url: https://community.simtropolis.com/files/file/19896-hk-admiralty-centre-legacy-version/?do=download&r=209385
+version: "2.0-1"
+lastModified: "2026-05-29T01:14:51Z"
+url: https://community.simtropolis.com/files/file/19896-hk-admiralty-centre-legacy-version/?do=download

--- a/src/yaml/cockatoo/20018-gateway-tower-six.yaml
+++ b/src/yaml/cockatoo/20018-gateway-tower-six.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: gateway-tower-six
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Gateway Tower Six
@@ -130,6 +130,6 @@ assets:
 
 ---
 assetId: cockatoo-gateway-tower-six
-version: "2.0"
-lastModified: "2025-09-25T18:15:19Z"
-url: https://community.simtropolis.com/files/file/20018-hk-gateway-tower-six/?do=download&r=209373
+version: "2.0-1"
+lastModified: "2026-05-29T01:13:02Z"
+url: https://community.simtropolis.com/files/file/20018-hk-gateway-tower-six/?do=download

--- a/src/yaml/cockatoo/20331-luckys-hang-ten.yaml
+++ b/src/yaml/cockatoo/20331-luckys-hang-ten.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: luckys-hang-ten
-version: "2.0"
+version: "2.0-1"
 subfolder: 360-landmark
 info:
   summary: Luckys Hang Ten
@@ -140,6 +140,6 @@ assets:
 
 ---
 assetId: cockatoo-luckys-hang-ten
-version: "2.0"
-lastModified: "2025-09-25T20:16:39Z"
-url: https://community.simtropolis.com/files/file/20331-luckys-hang-ten/?do=download&r=209402
+version: "2.0-1"
+lastModified: "2026-05-29T00:59:47Z"
+url: https://community.simtropolis.com/files/file/20331-luckys-hang-ten/?do=download

--- a/src/yaml/cockatoo/20536-harbour-centre-great-eagle-centre.yaml
+++ b/src/yaml/cockatoo/20536-harbour-centre-great-eagle-centre.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: harbour-centre-great-eagle-centre
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Harbour Centre Great Eagle Centre
@@ -129,6 +129,6 @@ variants:
 
 ---
 assetId: cockatoo-harbour-centre-great-eagle-centre-cam
-version: "2.0"
-lastModified: "2025-09-25T18:23:13Z"
-url: https://community.simtropolis.com/files/file/20536-hk-harbour-centre-great-eagle-centre/?do=download&r=209379
+version: "2.0-1"
+lastModified: "2026-05-29T01:14:15Z"
+url: https://community.simtropolis.com/files/file/20536-hk-harbour-centre-great-eagle-centre/?do=download

--- a/src/yaml/cockatoo/20551-lun-man-building.yaml
+++ b/src/yaml/cockatoo/20551-lun-man-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: lun-man-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 info:
   summary: Lun Man Building
@@ -110,6 +110,6 @@ assets:
 
 ---
 assetId: cockatoo-lun-man-building
-version: "2.0"
-lastModified: "2025-09-27T17:43:35Z"
-url: https://community.simtropolis.com/files/file/20551-hk-lun-man-building/?do=download&r=209449
+version: "2.0-1"
+lastModified: "2026-05-29T01:18:00Z"
+url: https://community.simtropolis.com/files/file/20551-hk-lun-man-building/?do=download

--- a/src/yaml/cockatoo/20652-fairmont-house.yaml
+++ b/src/yaml/cockatoo/20652-fairmont-house.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: fairmont-house
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Fairmont House
@@ -136,6 +136,6 @@ assets:
 
 ---
 assetId: cockatoo-fairmont-house
-version: "2.0"
-lastModified: "2025-09-27T17:40:35Z"
-url: https://community.simtropolis.com/files/file/20652-hk-fairmont-house/?do=download&r=209446
+version: "2.0-1"
+lastModified: "2026-05-29T01:17:32Z"
+url: https://community.simtropolis.com/files/file/20652-hk-fairmont-house/?do=download

--- a/src/yaml/cockatoo/20653-prince-of-wales-building.yaml
+++ b/src/yaml/cockatoo/20653-prince-of-wales-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: prince-of-wales-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Prince of Wales Building
@@ -132,6 +132,6 @@ assets:
 
 ---
 assetId: cockatoo-prince-of-wales-building
-version: "2.0"
-lastModified: "2025-09-27T17:46:41Z"
-url: https://community.simtropolis.com/files/file/20653-hk-prince-of-wales-building/?do=download&r=209452
+version: "2.0-1"
+lastModified: "2026-05-29T01:18:26Z"
+url: https://community.simtropolis.com/files/file/20653-hk-prince-of-wales-building/?do=download

--- a/src/yaml/cockatoo/20893-majestic-hotel.yaml
+++ b/src/yaml/cockatoo/20893-majestic-hotel.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: majestic-hotel
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Majestic Hotel
@@ -160,6 +160,6 @@ variants:
 
 ---
 assetId: cockatoo-majestic-hotel-cam
-version: "2.0"
-lastModified: "2025-09-25T19:50:04Z"
-url: https://community.simtropolis.com/files/file/20893-hk-majestic-hotel/?do=download&r=209394
+version: "2.0-1"
+lastModified: "2026-05-29T01:16:19Z"
+url: https://community.simtropolis.com/files/file/20893-hk-majestic-hotel/?do=download

--- a/src/yaml/cockatoo/20990-admiralty-centre.yaml
+++ b/src/yaml/cockatoo/20990-admiralty-centre.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: admiralty-centre
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Admiralty Centre
@@ -157,6 +157,6 @@ assets:
 
 ---
 assetId: cockatoo-admiralty-centre
-version: "2.0"
-lastModified: "2025-09-25T19:20:19Z"
-url: https://community.simtropolis.com/files/file/20990-hk-admiralty-centre/?do=download&r=209388
+version: "2.0-1"
+lastModified: "2026-05-29T01:15:36Z"
+url: https://community.simtropolis.com/files/file/20990-hk-admiralty-centre/?do=download

--- a/src/yaml/cockatoo/21007-grow-the-empire-state-building.yaml
+++ b/src/yaml/cockatoo/21007-grow-the-empire-state-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: grow-the-empire-state-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Grow the Empire State Building
@@ -70,6 +70,6 @@ assets:
 
 ---
 assetId: cockatoo-grow-the-empire-state-building
-version: "2.0"
-lastModified: "2025-09-25T20:19:35Z"
-url: https://community.simtropolis.com/files/file/21007-grow-the-empire-state-building/?do=download&r=209405
+version: "2.0-1"
+lastModified: "2026-05-29T00:58:55Z"
+url: https://community.simtropolis.com/files/file/21007-grow-the-empire-state-building/?do=download

--- a/src/yaml/cockatoo/21660-yongfu-house.yaml
+++ b/src/yaml/cockatoo/21660-yongfu-house.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: yongfu-house
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Yongfu House
@@ -138,6 +138,6 @@ assets:
 
 ---
 assetId: cockatoo-yongfu-house
-version: "2.0"
-lastModified: "2025-09-27T17:49:36Z"
-url: https://community.simtropolis.com/files/file/21660-hk-yongfu-house/?do=download&r=209455
+version: "2.0-1"
+lastModified: "2026-05-29T01:19:06Z"
+url: https://community.simtropolis.com/files/file/21660-hk-yongfu-house/?do=download

--- a/src/yaml/cockatoo/22249-standard-chartered-bank-building-legacy.yaml
+++ b/src/yaml/cockatoo/22249-standard-chartered-bank-building-legacy.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: standard-chartered-bank-building-legacy
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Standard Chartered Bank Building (Legacy Version)
@@ -132,6 +132,6 @@ assets:
 
 ---
 assetId: cockatoo-standard-chartered-bank-building-legacy-version
-version: "2.0"
-lastModified: "2025-09-27T17:52:44Z"
-url: https://community.simtropolis.com/files/file/22249-hk-standard-chartered-bank-building-legacy-version/?do=download&r=209458
+version: "2.0-1"
+lastModified: "2026-05-29T01:19:58Z"
+url: https://community.simtropolis.com/files/file/22249-hk-standard-chartered-bank-building-legacy-version/?do=download

--- a/src/yaml/cockatoo/22473-elizabeth-house.yaml
+++ b/src/yaml/cockatoo/22473-elizabeth-house.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: elizabeth-house
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 info:
   summary: Elizabeth House
@@ -108,6 +108,6 @@ assets:
 
 ---
 assetId: cockatoo-elizabeth-house
-version: "2.0"
-lastModified: "2025-09-27T17:34:26Z"
-url: https://community.simtropolis.com/files/file/22473-hk-elizabeth-house/?do=download&r=209443
+version: "2.0-1"
+lastModified: "2026-05-29T01:16:58Z"
+url: https://community.simtropolis.com/files/file/22473-hk-elizabeth-house/?do=download

--- a/src/yaml/cockatoo/22792-standard-chartered-bank-building.yaml
+++ b/src/yaml/cockatoo/22792-standard-chartered-bank-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: standard-chartered-bank-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Standard Chartered Bank Building
@@ -148,6 +148,6 @@ variants:
 
 ---
 assetId: cockatoo-standard-chartered-bank-building
-version: "2.0"
-lastModified: "2025-09-27T17:56:51Z"
-url: https://community.simtropolis.com/files/file/22792-hk-standard-chartered-bank-building/?do=download&r=209463
+version: "2.0-1"
+lastModified: "2026-05-29T01:20:36Z"
+url: https://community.simtropolis.com/files/file/22792-hk-standard-chartered-bank-building/?do=download

--- a/src/yaml/cockatoo/22876-aurora-plaza.yaml
+++ b/src/yaml/cockatoo/22876-aurora-plaza.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: aurora-plaza
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Aurora Plaza
@@ -108,6 +108,6 @@ variantInfo:
 
 ---
 assetId: cockatoo-aurora-plaza-cam
-version: "2.0"
-lastModified: "2025-11-02T20:25:21Z"
-url: https://community.simtropolis.com/files/file/22876-aurora-plaza/?do=download&r=209966
+version: "2.0-1"
+lastModified: "2026-05-29T01:24:23Z"
+url: https://community.simtropolis.com/files/file/22876-aurora-plaza/?do=download

--- a/src/yaml/cockatoo/22985-aig-tower.yaml
+++ b/src/yaml/cockatoo/22985-aig-tower.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: aig-tower
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: AIG Tower
@@ -68,6 +68,6 @@ variants:
 
 ---
 assetId: cockatoo-aig-tower-cam
-version: "2.0"
-lastModified: "2025-09-25T00:15:20Z"
-url: https://community.simtropolis.com/files/file/22985-hk-aig-tower/?do=download&r=209351
+version: "2.0-1"
+lastModified: "2026-05-29T01:11:26Z"
+url: https://community.simtropolis.com/files/file/22985-hk-aig-tower/?do=download

--- a/src/yaml/cockatoo/24342-kowloon-terrace.yaml
+++ b/src/yaml/cockatoo/24342-kowloon-terrace.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: kowloon-terrace
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 info:
   summary: Kowloon Terrace
@@ -89,6 +89,6 @@ variants:
 
 ---
 assetId: cockatoo-kowloon-terrace-cam
-version: "2.0"
-lastModified: "2025-09-27T18:15:00Z"
-url: https://community.simtropolis.com/files/file/24342-hk-kowloon-terrace/?do=download&r=209469
+version: "2.0-1"
+lastModified: "2026-05-29T01:21:55Z"
+url: https://community.simtropolis.com/files/file/24342-hk-kowloon-terrace/?do=download

--- a/src/yaml/cockatoo/25352-tomorrow-square.yaml
+++ b/src/yaml/cockatoo/25352-tomorrow-square.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: tomorrow-square
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Tomorrow Square
@@ -87,6 +87,6 @@ variants:
 
 ---
 assetId: cockatoo-tomorrow-square-cam
-version: "2.0"
-lastModified: "2025-09-27T18:02:15Z"
-url: https://community.simtropolis.com/files/file/25352-hk-tomorrow-square/?do=download&r=209466
+version: "2.0-1"
+lastModified: "2026-05-29T01:21:15Z"
+url: https://community.simtropolis.com/files/file/25352-hk-tomorrow-square/?do=download

--- a/src/yaml/cockatoo/25503-emerald-plaza.yaml
+++ b/src/yaml/cockatoo/25503-emerald-plaza.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: emerald-plaza
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Emerald Plaza
@@ -89,6 +89,6 @@ variants:
 
 ---
 assetId: cockatoo-emerald-plaza-cam
-version: "2.0"
-lastModified: "2025-09-25T19:03:43Z"
-url: https://community.simtropolis.com/files/file/25503-emerald-plaza/?do=download&r=209382
+version: "2.0-1"
+lastModified: "2026-05-29T01:01:02Z"
+url: https://community.simtropolis.com/files/file/25503-emerald-plaza/?do=download

--- a/src/yaml/cockatoo/26516-comalco-place.yaml
+++ b/src/yaml/cockatoo/26516-comalco-place.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: comalco-place
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Comalco Place
@@ -69,6 +69,6 @@ variants:
 
 ---
 assetId: cockatoo-comalco-place
-version: "2.0"
-lastModified: "2025-09-25T21:12:29Z"
-url: https://community.simtropolis.com/files/file/26516-comalco-place/?do=download&r=209414
+version: "2.0-1"
+lastModified: "2026-05-29T00:58:25Z"
+url: https://community.simtropolis.com/files/file/26516-comalco-place/?do=download

--- a/src/yaml/cockatoo/27089-united-nations-building.yaml
+++ b/src/yaml/cockatoo/27089-united-nations-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: united-nations-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: United Nations Building
@@ -108,6 +108,6 @@ variants:
 
 ---
 assetId: cockatoo-united-nations-building-cam
-version: "2.0"
-lastModified: "2025-09-30T18:00:11Z"
-url: https://community.simtropolis.com/files/file/27089-united-nations-building/?do=download&r=209498
+version: "2.0-1"
+lastModified: "2026-05-29T00:53:32Z"
+url: https://community.simtropolis.com/files/file/27089-united-nations-building/?do=download

--- a/src/yaml/cockatoo/27532-un-fountain.yaml
+++ b/src/yaml/cockatoo/27532-un-fountain.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: un-fountain
-version: "2.0"
+version: "2.0-1"
 subfolder: 660-parks
 info:
   summary: UN Fountain
@@ -56,6 +56,6 @@ variants:
 
 ---
 assetId: cockatoo-un-fountain
-version: "2.0"
-lastModified: "2025-09-30T18:04:17Z"
-url: https://community.simtropolis.com/files/file/27532-un-fountain/?do=download&r=209512
+version: "2.0-1"
+lastModified: "2026-05-29T00:51:39Z"
+url: https://community.simtropolis.com/files/file/27532-un-fountain/?do=download

--- a/src/yaml/cockatoo/27533-un-park.yaml
+++ b/src/yaml/cockatoo/27533-un-park.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: un-park
-version: "2.0"
+version: "2.0-1"
 subfolder: 660-parks
 info:
   summary: UN Park
@@ -56,6 +56,6 @@ variants:
 
 ---
 assetId: cockatoo-un-park
-version: "2.0"
-lastModified: "2025-09-30T18:06:12Z"
-url: https://community.simtropolis.com/files/file/27533-un-park/?do=download&r=209514
+version: "2.0-1"
+lastModified: "2026-05-29T00:52:03Z"
+url: https://community.simtropolis.com/files/file/27533-un-park/?do=download

--- a/src/yaml/cockatoo/27534-secretariat-building.yaml
+++ b/src/yaml/cockatoo/27534-secretariat-building.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: secretariat-building
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Secretariat Building
@@ -88,6 +88,6 @@ variants:
 
 ---
 assetId: cockatoo-secretariat-building
-version: "2.0"
-lastModified: "2025-09-30T18:10:45Z"
-url: https://community.simtropolis.com/files/file/27534-secretariat-building/?do=download&r=209516
+version: "2.0-1"
+lastModified: "2026-05-29T00:54:08Z"
+url: https://community.simtropolis.com/files/file/27534-secretariat-building/?do=download

--- a/src/yaml/cockatoo/28070-asakusa-tourist-centre.yaml
+++ b/src/yaml/cockatoo/28070-asakusa-tourist-centre.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: asakusa-tourist-centre
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Asakusa Tourist Centre
@@ -44,6 +44,6 @@ variants:
 
 ---
 assetId: cockatoo-asakusa-tourist-centre
-version: "2.0"
-lastModified: "2025-09-27T17:30:19Z"
-url: https://community.simtropolis.com/files/file/28070-asakusa-tourist-centre/?do=download&r=209438
+version: "2.0-1"
+lastModified: "2026-05-29T00:56:39Z"
+url: https://community.simtropolis.com/files/file/28070-asakusa-tourist-centre/?do=download

--- a/src/yaml/cockatoo/37029-wtc-complex-sc4d-lex-legacy-world-trade-plaza.yaml
+++ b/src/yaml/cockatoo/37029-wtc-complex-sc4d-lex-legacy-world-trade-plaza.yaml
@@ -1,6 +1,6 @@
 group: cockatoo
 name: wtc-complex-sc4d-lex-legacy-world-trade-plaza
-version: "2.0"
+version: "2.0-1"
 subfolder: 660-parks
 info:
   summary: WTC Complex - SC4D LEX Legacy - World Trade Plaza
@@ -178,6 +178,6 @@ assets:
 
 ---
 assetId: cockatoo-wtc-complex-sc4d-lex-legacy-world-trade-plaza
-version: "2.0"
-lastModified: "2025-09-25T20:47:31Z"
-url: https://community.simtropolis.com/files/file/37029-wtc-complex-sc4d-lex-legacy-world-trade-plaza/?do=download&r=209411
+version: "2.0-1"
+lastModified: "2026-05-29T00:57:30Z"
+url: https://community.simtropolis.com/files/file/37029-wtc-complex-sc4d-lex-legacy-world-trade-plaza/?do=download

--- a/src/yaml/deadwoods/12913-elrail-shops.yaml
+++ b/src/yaml/deadwoods/12913-elrail-shops.yaml
@@ -166,6 +166,6 @@ assets:
 
 ---
 assetId: deadwoods-elrail-shops
-version: "3"
-lastModified: "2024-07-21T22:54:09Z"
-url: https://community.simtropolis.com/files/file/12913-bsc-dedwd-elrail-shops/?do=download&r=202072
+version: "3-1"
+lastModified: "2026-05-31T01:30:54Z"
+url: https://community.simtropolis.com/files/file/12913-bsc-dedwd-elrail-shops/?do=download

--- a/src/yaml/dono/37232-texture-pack.yaml
+++ b/src/yaml/dono/37232-texture-pack.yaml
@@ -1,6 +1,6 @@
 group: dono
 name: texture-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: DONO Texture Pack
@@ -15,6 +15,6 @@ assets:
 
 ---
 assetId: dono-dono-texture-pack
-version: "1.0.0"
-lastModified: "2026-02-03T09:51:04Z"
-url: https://community.simtropolis.com/files/file/37232-dono-texture-pack/?do=download&r=211030
+version: "1.0.0-1"
+lastModified: "2026-06-09T00:19:34Z"
+url: https://community.simtropolis.com/files/file/37232-dono-texture-pack/?do=download

--- a/src/yaml/dono/37233-prop-pack.yaml
+++ b/src/yaml/dono/37233-prop-pack.yaml
@@ -1,6 +1,6 @@
 group: dono
 name: prop-pack
-version: "1.0.2"
+version: "1.0.2-1"
 subfolder: 100-props-textures
 info:
   summary: DONO Prop Pack
@@ -18,6 +18,6 @@ assets:
 
 ---
 assetId: dono-dono-prop-pack
-version: "1.0.2"
-lastModified: "2026-04-09T05:20:44Z"
-url: https://community.simtropolis.com/files/file/37233-dono-prop-pack/?do=download&r=212507
+version: "1.0.2-1"
+lastModified: "2026-06-09T02:53:24Z"
+url: https://community.simtropolis.com/files/file/37233-dono-prop-pack/?do=download

--- a/src/yaml/dono/37240-airport-sf-fillers.yaml
+++ b/src/yaml/dono/37240-airport-sf-fillers.yaml
@@ -1,6 +1,6 @@
 group: dono
 name: airport-sf-fillers
-version: "1.0.1"
+version: "1.0.1-1"
 subfolder: 700-transit
 info:
   summary: DONO Airport Security Fence Roads and Fillers
@@ -57,6 +57,6 @@ assets:
 
 ---
 assetId: dono-dono-airport-security-fence-roads-and-fillers
-version: "1.0.1"
-lastModified: "2026-02-08T10:34:53Z"
-url: https://community.simtropolis.com/files/file/37240-dono-airport-security-fence-roads-and-fillers/?do=download&r=211118
+version: "1.0.1-1"
+lastModified: "2026-06-09T20:22:50Z"
+url: https://community.simtropolis.com/files/file/37240-dono-airport-security-fence-roads-and-fillers/?do=download

--- a/src/yaml/dragonsteincole/36757-dsc-elrail-glasgow-subway-tram-version.yaml
+++ b/src/yaml/dragonsteincole/36757-dsc-elrail-glasgow-subway-tram-version.yaml
@@ -1,6 +1,6 @@
 group: dragonsteincole
 name: dsc-elrail-glasgow-subway-tram-version
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 710-automata
 info:
   summary: Elrail (Tram) automata, shortened version of the Glasgow Subway 3rd Gen set
@@ -37,6 +37,6 @@ assets:
 
 ---
 assetId: dragonsteincole-dsc-elrail-glasgow-subway-tram-version
-version: "1.0.0"
-lastModified: "2025-03-09T00:17:03Z"
-url: https://community.simtropolis.com/files/file/36757-dsc-elrail-glasgow-subway-tram-version/?do=download&r=206347
+version: "1.0.0-1"
+lastModified: "2026-06-09T00:56:16Z"
+url: https://community.simtropolis.com/files/file/36757-dsc-elrail-glasgow-subway-tram-version/?do=download

--- a/src/yaml/dragonsteincole/36796-dsc-rail-dsc-rail-dd-regional-passenger-set.yaml
+++ b/src/yaml/dragonsteincole/36796-dsc-rail-dsc-rail-dd-regional-passenger-set.yaml
@@ -1,6 +1,6 @@
 group: dragonsteincole
 name: dsc-rail-dsc-rail-dd-regional-passenger-set
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 710-automata
 info:
   summary: Fictional single and double deck passenger set, three locos and four coaches
@@ -36,6 +36,6 @@ assets:
 
 ---
 assetId: dragonsteincole-dsc-rail-dsc-rail-dd-regional-passenger-set
-version: "1.0.0"
-lastModified: "2025-03-26T00:15:07Z"
-url: https://community.simtropolis.com/files/file/36796-dsc-rail-dsc-rail-dd-regional-passenger-set/?do=download&r=206644
+version: "1.0.0-1"
+lastModified: "2026-06-09T00:57:11Z"
+url: https://community.simtropolis.com/files/file/36796-dsc-rail-dsc-rail-dd-regional-passenger-set/?do=download

--- a/src/yaml/ferox/19733-ujazdowskie-avenue-18.yaml
+++ b/src/yaml/ferox/19733-ujazdowskie-avenue-18.yaml
@@ -1,6 +1,6 @@
 group: ferox
 name: ujazdowskie-avenue-18
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: Ujazdowskie Avenue 18, Warsaw BSC
@@ -36,6 +36,6 @@ assets:
 
 ---
 assetId: ferox-ujazdowskie-avenue-18-warsaw-bsc
-version: "1.1"
-lastModified: "2025-08-23T14:50:01Z"
-url: https://community.simtropolis.com/files/file/19733-ujazdowskie-avenue-18-warsaw-bsc/?do=download&r=44645
+version: "1.1-1"
+lastModified: "2026-06-03T16:12:22Z"
+url: https://community.simtropolis.com/files/file/19733-ujazdowskie-avenue-18-warsaw-bsc/?do=download

--- a/src/yaml/fonzyfb73/24594-california-highway-sign-pack-1.yaml
+++ b/src/yaml/fonzyfb73/24594-california-highway-sign-pack-1.yaml
@@ -1,13 +1,12 @@
----
 assetId: fonzyfb73-california-highway-sign-pack-1
-version: "2.0.0"
-lastModified: "2024-09-09T23:41:27Z"
+version: "2.0.0-1"
+lastModified: "2026-05-30T00:01:11Z"
 url: https://community.simtropolis.com/files/file/24594-california-highway-sign-pack-1/?do=download
 
 ---
 group: fonzyfb73
 name: california-highway-sign-pack-1
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: California Highway Sign Pack 1

--- a/src/yaml/fonzyfb73/25604-highway-sign-pack-dec-2010.yaml
+++ b/src/yaml/fonzyfb73/25604-highway-sign-pack-dec-2010.yaml
@@ -1,13 +1,12 @@
----
 assetId: fonzyfb73-highway-sign-pack-dec-2010
-version: "2.0.0"
-lastModified: "2025-10-05T13:05:48Z"
+version: "2.0.0-1"
+lastModified: "2026-05-30T00:00:24Z"
 url: https://community.simtropolis.com/files/file/25604-highway-sign-pack-dec-2010/?do=download
 
 ---
 group: fonzyfb73
 name: highway-sign-pack-dec-2010
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: Highway Sign Pack Dec 2010

--- a/src/yaml/fonzyfb73/25605-highway-sign-pack-modesto-ca.yaml
+++ b/src/yaml/fonzyfb73/25605-highway-sign-pack-modesto-ca.yaml
@@ -1,13 +1,12 @@
----
 assetId: fonzyfb73-highway-sign-pack-modesto-ca
-version: "2.0.0"
-lastModified: "2024-09-09T23:37:22Z"
+version: "2.0.0-1"
+lastModified: "2026-05-29T23:59:33Z"
 url: https://community.simtropolis.com/files/file/25605-highway-sign-pack-modesto-ca/?do=download
 
 ---
 group: fonzyfb73
 name: highway-sign-pack-modesto-ca
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: Highway Sign Pack - Modesto, CA

--- a/src/yaml/fonzyfb73/25860-highway-sign-pack-stockton-ca.yaml
+++ b/src/yaml/fonzyfb73/25860-highway-sign-pack-stockton-ca.yaml
@@ -1,13 +1,12 @@
----
 assetId: fonzyfb73-highway-sign-pack-stockton-ca
-version: "2.0.0"
-lastModified: "2024-09-09T23:44:35Z"
+version: "2.0.0-1"
+lastModified: "2026-05-30T00:02:04Z"
 url: https://community.simtropolis.com/files/file/25860-highway-sign-pack-stockton-ca/?do=download
 
 ---
 group: fonzyfb73
 name: highway-sign-pack-stockton-ca
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: Highway Sign Pack - Stockton, CA

--- a/src/yaml/fonzyfb73/26155-variable-message-sign-pack.yaml
+++ b/src/yaml/fonzyfb73/26155-variable-message-sign-pack.yaml
@@ -1,13 +1,12 @@
----
 assetId: fonzyfb73-variable-message-sign-pack
-version: "2.0.0"
-lastModified: "2024-09-09T23:46:33Z"
+version: "2.0.0-1"
+lastModified: "2026-05-30T00:03:04Z"
 url: https://community.simtropolis.com/files/file/26155-variable-message-sign-pack/?do=download
 
 ---
 group: fonzyfb73
 name: variable-message-sign-pack
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: Variable Message Sign Pack 

--- a/src/yaml/heblem/19968-treasure-island-hotel-and-casino.yaml
+++ b/src/yaml/heblem/19968-treasure-island-hotel-and-casino.yaml
@@ -1,6 +1,6 @@
 group: heblem
 name: treasure-island-hotel-and-casino
-version: "1.0"
+version: "2"
 subfolder: 600-civics
 info:
   summary: Treasure Island Hotel and Casino
@@ -68,9 +68,6 @@ assets:
 
 ---
 assetId: heblem-treasure-island-hotel-and-casino
-version: "1.0"
-lastModified: "2008-06-20T15:00:10Z"
-url: https://community.simtropolis.com/files/file/19968-lbt-treasure-island-hotel-and-casino/?do=download&r=45009
-archiveType:
-  format: Clickteam
-  version: "40"
+version: "2"
+lastModified: "2026-06-07T23:12:05Z"
+url: https://community.simtropolis.com/files/file/19968-lbt-treasure-island-hotel-and-casino/?do=download

--- a/src/yaml/ids2/36424-doubletree-hotel.yaml
+++ b/src/yaml/ids2/36424-doubletree-hotel.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: doubletree-hotel
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: DoubleTree Hotel
@@ -36,12 +36,11 @@ variants:
 
 ---
 assetId: ids2-doubletree-hotel-darknite
-version: "1.0.0"
-lastModified: "2024-09-03T00:53:06Z"
-url: https://community.simtropolis.com/files/file/36424-doubletree-hotel/?do=download&r=203083
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:53:26Z"
+url: https://community.simtropolis.com/files/file/36424-doubletree-hotel/?do=download&r=214121
 ---
 assetId: ids2-doubletree-hotel-maxisnite
-version: "1.0.0"
-lastModified: "2024-09-03T00:53:06Z"
-url: https://community.simtropolis.com/files/file/36424-doubletree-hotel/?do=download&r=203084
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:53:26Z"
+url: https://community.simtropolis.com/files/file/36424-doubletree-hotel/?do=download&r=214122

--- a/src/yaml/ids2/36778-tj-maxx-and-homegoods.yaml
+++ b/src/yaml/ids2/36778-tj-maxx-and-homegoods.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: tj-maxx-and-homegoods
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: TJ Maxx and HomeGoods
@@ -43,12 +43,11 @@ variants:
 
 ---
 assetId: ids2-tj-maxx-and-homegoods-darknite
-version: "1.0.0"
-lastModified: "2025-03-18T17:54:03Z"
-url: https://community.simtropolis.com/files/file/36778-tj-maxx-and-homegoods/?do=download&r=206534
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:54:52Z"
+url: https://community.simtropolis.com/files/file/36778-tj-maxx-and-homegoods/?do=download&r=214127
 ---
 assetId: ids2-tj-maxx-and-homegoods-maxisnite
-version: "1.0.0"
-lastModified: "2025-03-18T17:54:03Z"
-url: https://community.simtropolis.com/files/file/36778-tj-maxx-and-homegoods/?do=download&r=206535
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:54:52Z"
+url: https://community.simtropolis.com/files/file/36778-tj-maxx-and-homegoods/?do=download&r=214128

--- a/src/yaml/ids2/36780-lalumiere-hall.yaml
+++ b/src/yaml/ids2/36780-lalumiere-hall.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: lalumiere-hall
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 620-education
 info:
   summary: Lalumiere Hall
@@ -34,12 +34,11 @@ variants:
 
 ---
 assetId: ids2-lalumiere-hall-darknite
-version: "1.0.0"
-lastModified: "2025-03-19T01:28:34Z"
-url: https://community.simtropolis.com/files/file/36780-lalumiere-hall/?do=download&r=206543
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:55:43Z"
+url: https://community.simtropolis.com/files/file/36780-lalumiere-hall/?do=download&r=214134
 ---
 assetId: ids2-lalumiere-hall-maxisnite
-version: "1.0.0"
-lastModified: "2025-03-19T01:28:34Z"
-url: https://community.simtropolis.com/files/file/36780-lalumiere-hall/?do=download&r=206544
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:55:43Z"
+url: https://community.simtropolis.com/files/file/36780-lalumiere-hall/?do=download&r=214135

--- a/src/yaml/ids2/36800-equitable-building.yaml
+++ b/src/yaml/ids2/36800-equitable-building.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: equitable-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Equitable Building
@@ -52,18 +52,16 @@ variants:
 
 ---
 assetId: ids2-equitable-building-darknite
-version: "1.0.0"
-lastModified: "2025-03-31T00:26:39Z"
-url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=206682
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:30Z"
+url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=214141
 ---
 assetId: ids2-equitable-building-maxisnite
-version: "1.0.0"
-lastModified: "2025-03-31T00:26:39Z"
-url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=206683
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:30Z"
+url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=214142
 ---
 assetId: ids2-equitable-building-cam
-version: "1.0.0"
-lastModified: "2025-03-31T00:26:39Z"
-url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=206684
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:30Z"
+url: https://community.simtropolis.com/files/file/36800-equitable-building/?do=download&r=214140

--- a/src/yaml/ids2/36847-broadway-ridge-office-plaza.yaml
+++ b/src/yaml/ids2/36847-broadway-ridge-office-plaza.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: broadway-ridge-office-plaza
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Broadway Ridge Office Plaza
@@ -47,24 +47,24 @@ variants:
 
 ---
 assetId: ids2-broadway-ridge-office-plaza-darknite-part-1
-version: "1.0.0"
-lastModified: "2025-04-29T23:40:05Z"
-url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=207164
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:43Z"
+url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=214148
 
 ---
 assetId: ids2-broadway-ridge-office-plaza-maxisnite-part-1
-version: "1.0.0"
-lastModified: "2025-04-29T23:40:05Z"
-url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=207165
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:43Z"
+url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=214149
 
 ---
 assetId: ids2-broadway-ridge-office-plaza-darknite-part-2
-version: "1.0.0"
-lastModified: "2025-04-29T23:40:05Z"
-url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=207166
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:43Z"
+url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=214150
 
 ---
 assetId: ids2-broadway-ridge-office-plaza-maxisnite-part-2
-version: "1.0.0"
-lastModified: "2025-04-29T23:40:05Z"
-url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=207167
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:57:43Z"
+url: https://community.simtropolis.com/files/file/36847-broadway-ridge-office-plaza/?do=download&r=214151

--- a/src/yaml/ids2/36895-la-tulipe.yaml
+++ b/src/yaml/ids2/36895-la-tulipe.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: la-tulipe
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 630-health
 info:
   summary: La Tulipe
@@ -37,12 +37,11 @@ variants:
 
 ---
 assetId: ids2-la-tulipe-darknite
-version: "1.0.0"
-lastModified: "2025-05-31T23:42:04Z"
-url: https://community.simtropolis.com/files/file/36895-la-tulipe/?do=download&r=207902
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:58:46Z"
+url: https://community.simtropolis.com/files/file/36895-la-tulipe/?do=download&r=214158
 ---
 assetId: ids2-la-tulipe-maxisnite
-version: "1.0.0"
-lastModified: "2025-05-31T23:42:04Z"
-url: https://community.simtropolis.com/files/file/36895-la-tulipe/?do=download&r=207903
+version: "1.0.0-1"
+lastModified: "2026-05-31T12:58:46Z"
+url: https://community.simtropolis.com/files/file/36895-la-tulipe/?do=download&r=214159

--- a/src/yaml/ids2/36922-crossroads-executive-center.yaml
+++ b/src/yaml/ids2/36922-crossroads-executive-center.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: crossroads-executive-center
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Crossroads Executive Center
@@ -46,12 +46,11 @@ variants:
 
 ---
 assetId: ids2-crossroads-executive-center-darknite
-version: "1.0.0"
-lastModified: "2025-06-30T23:31:43Z"
-url: https://community.simtropolis.com/files/file/36922-crossroads-executive-center/?do=download&r=208217
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:26Z"
+url: https://community.simtropolis.com/files/file/36922-crossroads-executive-center/?do=download&r=214179
 ---
 assetId: ids2-crossroads-executive-center-maxisnite
-version: "1.0.0"
-lastModified: "2025-06-30T23:31:43Z"
-url: https://community.simtropolis.com/files/file/36922-crossroads-executive-center/?do=download&r=208218
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:26Z"
+url: https://community.simtropolis.com/files/file/36922-crossroads-executive-center/?do=download&r=214180

--- a/src/yaml/ids2/36958-silberturm.yaml
+++ b/src/yaml/ids2/36958-silberturm.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: silberturm
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Silberturm
@@ -38,12 +38,11 @@ variants:
 
 ---
 assetId: ids2-silberturm-darknite
-version: "1.0.0"
-lastModified: "2025-07-26T22:15:26Z"
-url: https://community.simtropolis.com/files/file/36958-silberturm/?do=download&r=208538
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:40Z"
+url: https://community.simtropolis.com/files/file/36958-silberturm/?do=download&r=214186
 ---
 assetId: ids2-silberturm-maxisnite
-version: "1.0.0"
-lastModified: "2025-07-26T22:15:26Z"
-url: https://community.simtropolis.com/files/file/36958-silberturm/?do=download&r=208539
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:40Z"
+url: https://community.simtropolis.com/files/file/36958-silberturm/?do=download&r=214187

--- a/src/yaml/ids2/36999-pop-building-brussels.yaml
+++ b/src/yaml/ids2/36999-pop-building-brussels.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: pop-building-brussels
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: POP Building, Brussels
@@ -38,12 +38,11 @@ variants:
 
 ---
 assetId: ids2-pop-building-brussels-darknite
-version: "1.0.0"
-lastModified: "2025-08-28T13:48:51Z"
-url: https://community.simtropolis.com/files/file/36999-pop-building-brussels/?do=download&r=209056
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:47Z"
+url: https://community.simtropolis.com/files/file/36999-pop-building-brussels/?do=download&r=214193
 ---
 assetId: ids2-pop-building-brussels-maxisnite
-version: "1.0.0"
-lastModified: "2025-08-28T13:48:51Z"
-url: https://community.simtropolis.com/files/file/36999-pop-building-brussels/?do=download&r=209057
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:00:47Z"
+url: https://community.simtropolis.com/files/file/36999-pop-building-brussels/?do=download&r=214194

--- a/src/yaml/ids2/37000-binnenhof-observation-tower.yaml
+++ b/src/yaml/ids2/37000-binnenhof-observation-tower.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: binnenhof-observation-tower
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Binnenhof Observation Tower
@@ -31,12 +31,11 @@ variants:
 
 ---
 assetId: ids2-binnenhof-observation-tower-darknite
-version: "1.0.0"
-lastModified: "2025-08-28T13:55:53Z"
-url: https://community.simtropolis.com/files/file/37000-binnenhof-observation-tower/?do=download&r=209063
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:01:25Z"
+url: https://community.simtropolis.com/files/file/37000-binnenhof-observation-tower/?do=download&r=214200
 ---
 assetId: ids2-binnenhof-observation-tower-maxisnite
-version: "1.0.0"
-lastModified: "2025-08-28T13:55:53Z"
-url: https://community.simtropolis.com/files/file/37000-binnenhof-observation-tower/?do=download&r=209064
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:01:25Z"
+url: https://community.simtropolis.com/files/file/37000-binnenhof-observation-tower/?do=download&r=214201

--- a/src/yaml/ids2/37001-hedge-maze.yaml
+++ b/src/yaml/ids2/37001-hedge-maze.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: hedge-maze
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Hedge Maze
@@ -33,12 +33,11 @@ variants:
 
 ---
 assetId: ids2-hedge-maze-darknite
-version: "1.0.0"
-lastModified: "2025-08-28T14:08:59Z"
-url: https://community.simtropolis.com/files/file/37001-hedge-maze/?do=download&r=209070
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:01:32Z"
+url: https://community.simtropolis.com/files/file/37001-hedge-maze/?do=download&r=214207
 ---
 assetId: ids2-hedge-maze-maxisnite
-version: "1.0.0"
-lastModified: "2025-08-28T14:08:59Z"
-url: https://community.simtropolis.com/files/file/37001-hedge-maze/?do=download&r=209071
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:01:32Z"
+url: https://community.simtropolis.com/files/file/37001-hedge-maze/?do=download&r=214208

--- a/src/yaml/ids2/37036-bren-road-office-park.yaml
+++ b/src/yaml/ids2/37036-bren-road-office-park.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: bren-road-office-park
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Bren Road Office Park
@@ -46,12 +46,11 @@ variants:
 
 ---
 assetId: ids2-bren-road-office-park-darknite
-version: "1.0.0"
-lastModified: "2025-09-28T21:12:14Z"
-url: https://community.simtropolis.com/files/file/37036-bren-road-office-park/?do=download&r=209484
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:14Z"
+url: https://community.simtropolis.com/files/file/37036-bren-road-office-park/?do=download&r=214212
 ---
 assetId: ids2-bren-road-office-park-maxisnite
-version: "1.0.0"
-lastModified: "2025-09-28T21:12:14Z"
-url: https://community.simtropolis.com/files/file/37036-bren-road-office-park/?do=download&r=209485
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:14Z"
+url: https://community.simtropolis.com/files/file/37036-bren-road-office-park/?do=download&r=214213

--- a/src/yaml/ids2/37037-tritech-center.yaml
+++ b/src/yaml/ids2/37037-tritech-center.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: tritech-center
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: TriTech Center
@@ -35,12 +35,11 @@ variants:
 
 ---
 assetId: ids2-tritech-center-darknite
-version: "1.0.0"
-lastModified: "2025-09-28T21:23:08Z"
-url: https://community.simtropolis.com/files/file/37037-tritech-center/?do=download&r=209491
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:19Z"
+url: https://community.simtropolis.com/files/file/37037-tritech-center/?do=download&r=214219
 ---
 assetId: ids2-tritech-center-maxisnite
-version: "1.0.0"
-lastModified: "2025-09-28T21:23:08Z"
-url: https://community.simtropolis.com/files/file/37037-tritech-center/?do=download&r=209492
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:19Z"
+url: https://community.simtropolis.com/files/file/37037-tritech-center/?do=download&r=214220

--- a/src/yaml/ids2/37064-one-sherman-place.yaml
+++ b/src/yaml/ids2/37064-one-sherman-place.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: one-sherman-place
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: One Sherman Place
@@ -34,12 +34,11 @@ variants:
 
 ---
 assetId: ids2-one-sherman-place-darknite
-version: "1.0.0"
-lastModified: "2025-10-20T01:41:16Z"
-url: https://community.simtropolis.com/files/file/37064-one-sherman-place/?do=download&r=209706
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:25Z"
+url: https://community.simtropolis.com/files/file/37064-one-sherman-place/?do=download&r=214226
 ---
 assetId: ids2-one-sherman-place-maxisnite
-version: "1.0.0"
-lastModified: "2025-10-20T01:41:16Z"
-url: https://community.simtropolis.com/files/file/37064-one-sherman-place/?do=download&r=209707
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:25Z"
+url: https://community.simtropolis.com/files/file/37064-one-sherman-place/?do=download&r=214227

--- a/src/yaml/ids2/37065-patisserie-46.yaml
+++ b/src/yaml/ids2/37065-patisserie-46.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: patisserie-46
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Patisserie 46
@@ -32,12 +32,11 @@ variants:
 
 ---
 assetId: ids2-patisserie-46-darknite
-version: "1.0.0"
-lastModified: "2025-10-20T01:49:02Z"
-url: https://community.simtropolis.com/files/file/37065-patisserie-46/?do=download&r=209712
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:31Z"
+url: https://community.simtropolis.com/files/file/37065-patisserie-46/?do=download&r=214232
 ---
 assetId: ids2-patisserie-46-maxisnite
-version: "1.0.0"
-lastModified: "2025-10-20T01:49:02Z"
-url: https://community.simtropolis.com/files/file/37065-patisserie-46/?do=download&r=209713
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:31Z"
+url: https://community.simtropolis.com/files/file/37065-patisserie-46/?do=download&r=214233

--- a/src/yaml/ids2/37122-701-building.yaml
+++ b/src/yaml/ids2/37122-701-building.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: 701-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: 701 Building
@@ -38,12 +38,11 @@ variants:
 
 ---
 assetId: ids2-701-building-darknite
-version: "1.0.0"
-lastModified: "2025-11-29T22:49:02Z"
-url: https://community.simtropolis.com/files/file/37122-701-building/?do=download&r=210295
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:36Z"
+url: https://community.simtropolis.com/files/file/37122-701-building/?do=download&r=214236
 ---
 assetId: ids2-701-building-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-29T22:49:02Z"
-url: https://community.simtropolis.com/files/file/37122-701-building/?do=download&r=210296
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:36Z"
+url: https://community.simtropolis.com/files/file/37122-701-building/?do=download&r=214237

--- a/src/yaml/ids2/37160-lilydale-picnic-shelter.yaml
+++ b/src/yaml/ids2/37160-lilydale-picnic-shelter.yaml
@@ -1,6 +1,6 @@
 group: ids2
 name: lilydale-picnic-shelter
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Lilydale Picnic Shelter
@@ -28,12 +28,11 @@ variants:
 
 ---
 assetId: ids2-lilydale-picnic-shelter-darknite
-version: "1.0.0"
-lastModified: "2025-12-22T00:56:24Z"
-url: https://community.simtropolis.com/files/file/37160-lilydale-picnic-shelter/?do=download&r=210545
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:41Z"
+url: https://community.simtropolis.com/files/file/37160-lilydale-picnic-shelter/?do=download&r=214243
 ---
 assetId: ids2-lilydale-picnic-shelter-maxisnite
-version: "1.0.0"
-lastModified: "2025-12-22T00:56:24Z"
-url: https://community.simtropolis.com/files/file/37160-lilydale-picnic-shelter/?do=download&r=210546
+version: "1.0.0-1"
+lastModified: "2026-05-31T13:04:41Z"
+url: https://community.simtropolis.com/files/file/37160-lilydale-picnic-shelter/?do=download&r=214244

--- a/src/yaml/jasoncw/26920-us-bank-center.yaml
+++ b/src/yaml/jasoncw/26920-us-bank-center.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: us-bank-center
-version: "1.1"
+version: "1.1-1"
 subfolder: 300-commercial
 info:
   summary: US Bank Center
@@ -49,12 +49,11 @@ variants:
 
 ---
 assetId: jasoncw-us-bank-center-maxisnite
-version: "1.1"
-lastModified: "2024-10-10T03:24:40Z"
-url: https://community.simtropolis.com/files/file/26920-us-bank-center/?do=download&r=203821
-
+version: "1.1-1"
+lastModified: "2026-05-31T00:11:16Z"
+url: https://community.simtropolis.com/files/file/26920-us-bank-center/?do=download&r=213922
 ---
 assetId: jasoncw-us-bank-center-darknite
-version: "1.1"
-lastModified: "2024-10-10T03:24:40Z"
-url: https://community.simtropolis.com/files/file/26920-us-bank-center/?do=download&r=203822
+version: "1.1-1"
+lastModified: "2026-05-31T00:11:16Z"
+url: https://community.simtropolis.com/files/file/26920-us-bank-center/?do=download&r=213923

--- a/src/yaml/jasoncw/36442-model-discount-furniture.yaml
+++ b/src/yaml/jasoncw/36442-model-discount-furniture.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: model-discount-furniture
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Model Discount Furniture
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-model-discount-furniture-maxisnite
-version: "1.0.0"
-lastModified: "2024-09-11T19:29:33Z"
-url: https://community.simtropolis.com/files/file/36442-model-discount-furniture/?do=download&r=203385
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:26:27Z"
+url: https://community.simtropolis.com/files/file/36442-model-discount-furniture/?do=download&r=213795
 ---
 assetId: jasoncw-model-discount-furniture-darknite
-version: "1.0.0"
-lastModified: "2024-09-11T19:29:33Z"
-url: https://community.simtropolis.com/files/file/36442-model-discount-furniture/?do=download&r=203386
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:26:27Z"
+url: https://community.simtropolis.com/files/file/36442-model-discount-furniture/?do=download&r=213796

--- a/src/yaml/jasoncw/36453-pizza-ribs-sushi.yaml
+++ b/src/yaml/jasoncw/36453-pizza-ribs-sushi.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: pizza-ribs-sushi
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Pizza Ribs Sushi
@@ -30,12 +30,11 @@ variants:
 
 ---
 assetId: jasoncw-pizza-ribs-sushi-maxisnite
-version: "1.0.0"
-lastModified: "2024-09-18T19:59:49Z"
-url: https://community.simtropolis.com/files/file/36453-pizza-ribs-sushi/?do=download&r=203487
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:31:54Z"
+url: https://community.simtropolis.com/files/file/36453-pizza-ribs-sushi/?do=download&r=213799
 ---
 assetId: jasoncw-pizza-ribs-sushi-darknite
-version: "1.0.0"
-lastModified: "2024-09-18T19:59:49Z"
-url: https://community.simtropolis.com/files/file/36453-pizza-ribs-sushi/?do=download&r=203488
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:31:54Z"
+url: https://community.simtropolis.com/files/file/36453-pizza-ribs-sushi/?do=download&r=213800

--- a/src/yaml/jasoncw/36465-magasin-valois.yaml
+++ b/src/yaml/jasoncw/36465-magasin-valois.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: magasin-valois
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Magasin Valois
@@ -31,12 +31,11 @@ variants:
 
 ---
 assetId: jasoncw-magasin-valois-maxisnite
-version: "1.0.0"
-lastModified: "2024-09-25T23:56:22Z"
-url: https://community.simtropolis.com/files/file/36465-magasin-valois/?do=download&r=203589
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:34:51Z"
+url: https://community.simtropolis.com/files/file/36465-magasin-valois/?do=download&r=213805
 ---
 assetId: jasoncw-magasin-valois-darknite
-version: "1.0.0"
-lastModified: "2024-09-25T23:56:22Z"
-url: https://community.simtropolis.com/files/file/36465-magasin-valois/?do=download&r=203590
+version: "1.0.0-1"
+lastModified: "2026-05-30T20:34:51Z"
+url: https://community.simtropolis.com/files/file/36465-magasin-valois/?do=download&r=213806

--- a/src/yaml/jasoncw/36496-innovation-center.yaml
+++ b/src/yaml/jasoncw/36496-innovation-center.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: innovation-center
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 400-industrial
 info:
   summary: Innovation Center
@@ -29,12 +29,11 @@ variants:
 
 ---
 assetId: jasoncw-innovation-center-maxisnite
-version: "1.0.0"
-lastModified: "2024-10-10T03:05:13Z"
-url: https://community.simtropolis.com/files/file/36496-innovation-center/?do=download&r=203813
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:11:52Z"
+url: https://community.simtropolis.com/files/file/36496-innovation-center/?do=download&r=213809
 ---
 assetId: jasoncw-innovation-center-darknite
-version: "1.0.0"
-lastModified: "2024-10-10T03:05:13Z"
-url: https://community.simtropolis.com/files/file/36496-innovation-center/?do=download&r=203814
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:11:52Z"
+url: https://community.simtropolis.com/files/file/36496-innovation-center/?do=download&r=213810

--- a/src/yaml/jasoncw/36497-webb-chapel-park-pavilion.yaml
+++ b/src/yaml/jasoncw/36497-webb-chapel-park-pavilion.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: webb-chapel-park-pavilion
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Webb Chapel Park Pavilion
@@ -28,12 +28,11 @@ variants:
 
 ---
 assetId: jasoncw-webb-chapel-park-pavilion-maxisnite
-version: "1.0.0"
-lastModified: "2024-10-10T03:08:05Z"
-url: https://community.simtropolis.com/files/file/36497-webb-chapel-park-pavilion/?do=download&r=203817
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:13:50Z"
+url: https://community.simtropolis.com/files/file/36497-webb-chapel-park-pavilion/?do=download&r=213814
 ---
 assetId: jasoncw-webb-chapel-park-pavilion-darknite
-version: "1.0.0"
-lastModified: "2024-10-10T03:08:05Z"
-url: https://community.simtropolis.com/files/file/36497-webb-chapel-park-pavilion/?do=download&r=203818
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:13:50Z"
+url: https://community.simtropolis.com/files/file/36497-webb-chapel-park-pavilion/?do=download&r=213815

--- a/src/yaml/jasoncw/36507-delitz-designer-gallery.yaml
+++ b/src/yaml/jasoncw/36507-delitz-designer-gallery.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: delitz-designer-gallery
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Delitz Designer Gallery
@@ -31,12 +31,11 @@ variants:
 
 ---
 assetId: jasoncw-delitz-designer-gallery-maxisnite
-version: "1.0.0"
-lastModified: "2024-10-17T00:45:28Z"
-url: https://community.simtropolis.com/files/file/36507-delitz-designer-gallery/?do=download&r=203920
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:33:12Z"
+url: https://community.simtropolis.com/files/file/36507-delitz-designer-gallery/?do=download&r=213818
 ---
 assetId: jasoncw-delitz-designer-gallery-darknite
-version: "1.0.0"
-lastModified: "2024-10-17T00:45:28Z"
-url: https://community.simtropolis.com/files/file/36507-delitz-designer-gallery/?do=download&r=203921
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:33:12Z"
+url: https://community.simtropolis.com/files/file/36507-delitz-designer-gallery/?do=download&r=213819

--- a/src/yaml/jasoncw/36524-miu-miu.yaml
+++ b/src/yaml/jasoncw/36524-miu-miu.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: miu-miu
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Miu Miu
@@ -28,12 +28,11 @@ variants:
 
 ---
 assetId: jasoncw-miu-miu-maxisnite
-version: "1.0.0"
-lastModified: "2024-10-24T01:39:26Z"
-url: https://community.simtropolis.com/files/file/36524-miu-miu/?do=download&r=204054
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:40:29Z"
+url: https://community.simtropolis.com/files/file/36524-miu-miu/?do=download&r=213826
 ---
 assetId: jasoncw-miu-miu-darknite
-version: "1.0.0"
-lastModified: "2024-10-24T01:39:26Z"
-url: https://community.simtropolis.com/files/file/36524-miu-miu/?do=download&r=204055
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:40:29Z"
+url: https://community.simtropolis.com/files/file/36524-miu-miu/?do=download&r=213827

--- a/src/yaml/jasoncw/36532-elks-building.yaml
+++ b/src/yaml/jasoncw/36532-elks-building.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: elks-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Elks Building
@@ -29,12 +29,11 @@ variants:
 
 ---
 assetId: jasoncw-elks-building-maxisnite
-version: "1.0.0"
-lastModified: "2024-10-30T21:00:35Z"
-url: https://community.simtropolis.com/files/file/36532-elks-building/?do=download&r=204153
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:43:33Z"
+url: https://community.simtropolis.com/files/file/36532-elks-building/?do=download&r=213830
 ---
 assetId: jasoncw-elks-building-darknite
-version: "1.0.0"
-lastModified: "2024-10-30T21:00:35Z"
-url: https://community.simtropolis.com/files/file/36532-elks-building/?do=download&r=204154
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:43:33Z"
+url: https://community.simtropolis.com/files/file/36532-elks-building/?do=download&r=213831

--- a/src/yaml/jasoncw/36542-sp-building.yaml
+++ b/src/yaml/jasoncw/36542-sp-building.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: sp-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: S&P Building
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-sp-building-maxisnite
-version: "1.0.0"
-lastModified: "2024-11-08T02:26:55Z"
-url: https://community.simtropolis.com/files/file/36542-sp-building/?do=download&r=204274
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:46:37Z"
+url: https://community.simtropolis.com/files/file/36542-sp-building/?do=download&r=213834
 ---
 assetId: jasoncw-sp-building-darknite
-version: "1.0.0"
-lastModified: "2024-11-08T02:26:55Z"
-url: https://community.simtropolis.com/files/file/36542-sp-building/?do=download&r=204275
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:46:37Z"
+url: https://community.simtropolis.com/files/file/36542-sp-building/?do=download&r=213835

--- a/src/yaml/jasoncw/36549-pietzsch-house.yaml
+++ b/src/yaml/jasoncw/36549-pietzsch-house.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: pietzsch-house
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Pietzsch House
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-pietzsch-house-maxisnite
-version: "1.0.0"
-lastModified: "2024-11-14T05:06:01Z"
-url: https://community.simtropolis.com/files/file/36549-pietzsch-house/?do=download&r=204365
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:48:32Z"
+url: https://community.simtropolis.com/files/file/36549-pietzsch-house/?do=download&r=213838
 ---
 assetId: jasoncw-pietzsch-house-darknite
-version: "1.0.0"
-lastModified: "2024-11-14T05:06:01Z"
-url: https://community.simtropolis.com/files/file/36549-pietzsch-house/?do=download&r=204366
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:48:32Z"
+url: https://community.simtropolis.com/files/file/36549-pietzsch-house/?do=download&r=213839

--- a/src/yaml/jasoncw/36579-skycliffe-tower.yaml
+++ b/src/yaml/jasoncw/36579-skycliffe-tower.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: skycliffe-tower
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Skycliffe Tower
@@ -51,18 +51,16 @@ variants:
 
 ---
 assetId: jasoncw-skycliffe-tower-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-05T03:44:31Z"
-url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=204577
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:51:42Z"
+url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=213842
 ---
 assetId: jasoncw-skycliffe-tower-darknite
-version: "1.0.0"
-lastModified: "2024-12-05T03:44:31Z"
-url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=204578
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:51:42Z"
+url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=213843
 ---
 assetId: jasoncw-skycliffe-tower-cam
-version: "1.0.0"
-lastModified: "2024-12-05T03:44:31Z"
-url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=204579
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:51:42Z"
+url: https://community.simtropolis.com/files/file/36579-skycliffe-tower/?do=download&r=213844

--- a/src/yaml/jasoncw/36580-otautahi-mews.yaml
+++ b/src/yaml/jasoncw/36580-otautahi-mews.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: otautahi-mews
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Otautahi Mews
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-otautahi-mews-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-05T04:06:43Z"
-url: https://community.simtropolis.com/files/file/36580-otautahi-mews/?do=download&r=204582
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:54:36Z"
+url: https://community.simtropolis.com/files/file/36580-otautahi-mews/?do=download&r=213847
 ---
 assetId: jasoncw-otautahi-mews-darknite
-version: "1.0.0"
-lastModified: "2024-12-05T04:06:43Z"
-url: https://community.simtropolis.com/files/file/36580-otautahi-mews/?do=download&r=204583
+version: "1.0.0-1"
+lastModified: "2026-05-30T21:54:36Z"
+url: https://community.simtropolis.com/files/file/36580-otautahi-mews/?do=download&r=213848

--- a/src/yaml/jasoncw/36581-newport-house.yaml
+++ b/src/yaml/jasoncw/36581-newport-house.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: newport-house
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Newport House
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-newport-house-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-05T04:10:52Z"
-url: https://community.simtropolis.com/files/file/36581-newport-house/?do=download&r=204586
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:00:37Z"
+url: https://community.simtropolis.com/files/file/36581-newport-house/?do=download&r=213851
 ---
 assetId: jasoncw-newport-house-darknite
-version: "1.0.0"
-lastModified: "2024-12-05T04:10:52Z"
-url: https://community.simtropolis.com/files/file/36581-newport-house/?do=download&r=204587
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:00:37Z"
+url: https://community.simtropolis.com/files/file/36581-newport-house/?do=download&r=213852

--- a/src/yaml/jasoncw/36593-basildon-terraces.yaml
+++ b/src/yaml/jasoncw/36593-basildon-terraces.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: basildon-terraces
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Basildon Terraces
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-basildon-terraces-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-12T05:46:27Z"
-url: https://community.simtropolis.com/files/file/36593-basildon-terraces/?do=download&r=204649
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:11:04Z"
+url: https://community.simtropolis.com/files/file/36593-basildon-terraces/?do=download&r=213855
 ---
 assetId: jasoncw-basildon-terraces-darknite
-version: "1.0.0"
-lastModified: "2024-12-12T05:46:27Z"
-url: https://community.simtropolis.com/files/file/36593-basildon-terraces/?do=download&r=204650
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:11:04Z"
+url: https://community.simtropolis.com/files/file/36593-basildon-terraces/?do=download&r=213856

--- a/src/yaml/jasoncw/36612-hook-and-ladder-company-8-ghostbusters-hq.yaml
+++ b/src/yaml/jasoncw/36612-hook-and-ladder-company-8-ghostbusters-hq.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: hook-and-ladder-company-8-ghostbusters-hq
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 610-safety
 info:
   summary: Hook and Ladder Company 8 (Ghostbusters HQ)
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-hook-and-ladder-company-8-ghostbusters-hq-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-19T04:24:08Z"
-url: https://community.simtropolis.com/files/file/36612-hook-and-ladder-company-8-ghostbusters-hq/?do=download&r=204739
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:14:13Z"
+url: https://community.simtropolis.com/files/file/36612-hook-and-ladder-company-8-ghostbusters-hq/?do=download&r=213859
 ---
 assetId: jasoncw-hook-and-ladder-company-8-ghostbusters-hq-darknite
-version: "1.0.0"
-lastModified: "2024-12-19T04:24:08Z"
-url: https://community.simtropolis.com/files/file/36612-hook-and-ladder-company-8-ghostbusters-hq/?do=download&r=204740
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:14:13Z"
+url: https://community.simtropolis.com/files/file/36612-hook-and-ladder-company-8-ghostbusters-hq/?do=download&r=213860

--- a/src/yaml/jasoncw/36626-wade-patton-insurance-and-interim-healthcare.yaml
+++ b/src/yaml/jasoncw/36626-wade-patton-insurance-and-interim-healthcare.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: wade-patton-insurance-and-interim-healthcare
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Wade Patton Insurance and Interim Healthcare
@@ -38,12 +38,11 @@ variants:
 
 ---
 assetId: jasoncw-wade-patton-insurance-and-interim-healthcare-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-24T21:53:00Z"
-url: https://community.simtropolis.com/files/file/36626-wade-patton-insurance-and-interim-healthcare/?do=download&r=204875
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:16:34Z"
+url: https://community.simtropolis.com/files/file/36626-wade-patton-insurance-and-interim-healthcare/?do=download&r=213863
 ---
 assetId: jasoncw-wade-patton-insurance-and-interim-healthcare-darknite
-version: "1.0.0"
-lastModified: "2024-12-24T21:53:00Z"
-url: https://community.simtropolis.com/files/file/36626-wade-patton-insurance-and-interim-healthcare/?do=download&r=204876
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:16:34Z"
+url: https://community.simtropolis.com/files/file/36626-wade-patton-insurance-and-interim-healthcare/?do=download&r=213864

--- a/src/yaml/jasoncw/36627-mettlen-inc-and-mid-kansas-seamless-gutter.yaml
+++ b/src/yaml/jasoncw/36627-mettlen-inc-and-mid-kansas-seamless-gutter.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: mettlen-inc-and-mid-kansas-seamless-gutter
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Mettlen Inc and Mid Kansas Seamless Gutter
@@ -31,12 +31,11 @@ variants:
 
 ---
 assetId: jasoncw-mettlen-inc-and-mid-kansas-seamless-gutter-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-24T21:56:23Z"
-url: https://community.simtropolis.com/files/file/36627-mettlen-inc-and-mid-kansas-seamless-gutter/?do=download&r=204880
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:23:37Z"
+url: https://community.simtropolis.com/files/file/36627-mettlen-inc-and-mid-kansas-seamless-gutter/?do=download&r=213868
 ---
 assetId: jasoncw-mettlen-inc-and-mid-kansas-seamless-gutter-darknite
-version: "1.0.0"
-lastModified: "2024-12-24T21:56:23Z"
-url: https://community.simtropolis.com/files/file/36627-mettlen-inc-and-mid-kansas-seamless-gutter/?do=download&r=204881
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:23:37Z"
+url: https://community.simtropolis.com/files/file/36627-mettlen-inc-and-mid-kansas-seamless-gutter/?do=download&r=213869

--- a/src/yaml/jasoncw/36628-seaside-building.yaml
+++ b/src/yaml/jasoncw/36628-seaside-building.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: seaside-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Seaside Building
@@ -26,12 +26,11 @@ variants:
 
 ---
 assetId: jasoncw-seaside-building-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-24T21:58:39Z"
-url: https://community.simtropolis.com/files/file/36628-seaside-building/?do=download&r=204884
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:26:06Z"
+url: https://community.simtropolis.com/files/file/36628-seaside-building/?do=download&r=213872
 ---
 assetId: jasoncw-seaside-building-darknite
-version: "1.0.0"
-lastModified: "2024-12-24T21:58:39Z"
-url: https://community.simtropolis.com/files/file/36628-seaside-building/?do=download&r=204885
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:26:06Z"
+url: https://community.simtropolis.com/files/file/36628-seaside-building/?do=download&r=213873

--- a/src/yaml/jasoncw/36629-xenon-center.yaml
+++ b/src/yaml/jasoncw/36629-xenon-center.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: xenon-center
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Xenon Center
@@ -48,18 +48,16 @@ variants:
 
 ---
 assetId: jasoncw-xenon-center-maxisnite
-version: "1.0.0"
-lastModified: "2024-12-24T22:01:11Z"
-url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=204888
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:30:55Z"
+url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=213876
 ---
 assetId: jasoncw-xenon-center-darknite
-version: "1.0.0"
-lastModified: "2024-12-24T22:01:11Z"
-url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=204889
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:30:55Z"
+url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=213877
 ---
 assetId: jasoncw-xenon-center-cam
-version: "1.0.0"
-lastModified: "2024-12-24T22:01:11Z"
-url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=204890
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:30:55Z"
+url: https://community.simtropolis.com/files/file/36629-xenon-center/?do=download&r=213878

--- a/src/yaml/jasoncw/36838-mendenhall-building.yaml
+++ b/src/yaml/jasoncw/36838-mendenhall-building.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: mendenhall-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Mendenhall Building
@@ -27,12 +27,11 @@ variants:
 
 ---
 assetId: jasoncw-mendenhall-building-maxisnite
-version: "1.0.0"
-lastModified: "2025-04-23T02:55:46Z"
-url: https://community.simtropolis.com/files/file/36838-mendenhall-building/?do=download&r=207087
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:36:57Z"
+url: https://community.simtropolis.com/files/file/36838-mendenhall-building/?do=download&r=213881
 ---
 assetId: jasoncw-mendenhall-building-darknite
-version: "1.0.0"
-lastModified: "2025-04-23T02:55:46Z"
-url: https://community.simtropolis.com/files/file/36838-mendenhall-building/?do=download&r=207088
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:36:57Z"
+url: https://community.simtropolis.com/files/file/36838-mendenhall-building/?do=download&r=213882

--- a/src/yaml/jasoncw/37113-alvertstone-financial.yaml
+++ b/src/yaml/jasoncw/37113-alvertstone-financial.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: alvertstone-financial
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Alvertstone Financial
@@ -28,12 +28,11 @@ variants:
 
 ---
 assetId: jasoncw-alvertstone-financial-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:14:33Z"
-url: https://community.simtropolis.com/files/file/37113-alvertstone-financial/?do=download&r=210254
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:43:07Z"
+url: https://community.simtropolis.com/files/file/37113-alvertstone-financial/?do=download&r=213885
 ---
 assetId: jasoncw-alvertstone-financial-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:14:33Z"
-url: https://community.simtropolis.com/files/file/37113-alvertstone-financial/?do=download&r=210255
+version: "1.0.0-1"
+lastModified: "2026-05-30T22:43:07Z"
+url: https://community.simtropolis.com/files/file/37113-alvertstone-financial/?do=download&r=213886

--- a/src/yaml/jasoncw/37114-trapezium-house.yaml
+++ b/src/yaml/jasoncw/37114-trapezium-house.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: trapezium-house
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Trapezium House
@@ -27,12 +27,11 @@ variants:
 
 ---
 assetId: jasoncw-trapezium-house-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:19:42Z"
-url: https://community.simtropolis.com/files/file/37114-trapezium-house/?do=download&r=210258
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:45:07Z"
+url: https://community.simtropolis.com/files/file/37114-trapezium-house/?do=download&r=213889
 ---
 assetId: jasoncw-trapezium-house-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:19:42Z"
-url: https://community.simtropolis.com/files/file/37114-trapezium-house/?do=download&r=210259
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:45:07Z"
+url: https://community.simtropolis.com/files/file/37114-trapezium-house/?do=download&r=213890

--- a/src/yaml/jasoncw/37115-stonewall-inn.yaml
+++ b/src/yaml/jasoncw/37115-stonewall-inn.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: stonewall-inn
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Stonewall Inn
@@ -27,12 +27,11 @@ variants:
 
 ---
 assetId: jasoncw-stonewall-inn-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:23:26Z"
-url: https://community.simtropolis.com/files/file/37115-stonewall-inn/?do=download&r=210262
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:46:43Z"
+url: https://community.simtropolis.com/files/file/37115-stonewall-inn/?do=download&r=213893
 ---
 assetId: jasoncw-stonewall-inn-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:23:26Z"
-url: https://community.simtropolis.com/files/file/37115-stonewall-inn/?do=download&r=210263
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:46:43Z"
+url: https://community.simtropolis.com/files/file/37115-stonewall-inn/?do=download&r=213894

--- a/src/yaml/jasoncw/37116-curiosity-incorporated.yaml
+++ b/src/yaml/jasoncw/37116-curiosity-incorporated.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: curiosity-incorporated
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Curiosity Incorporated
@@ -27,12 +27,11 @@ variants:
 
 ---
 assetId: jasoncw-curiosity-incorporated-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:26:01Z"
-url: https://community.simtropolis.com/files/file/37116-curiosity-incorporated/?do=download&r=210266
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:49:15Z"
+url: https://community.simtropolis.com/files/file/37116-curiosity-incorporated/?do=download&r=213897
 ---
 assetId: jasoncw-curiosity-incorporated-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:26:01Z"
-url: https://community.simtropolis.com/files/file/37116-curiosity-incorporated/?do=download&r=210267
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:49:15Z"
+url: https://community.simtropolis.com/files/file/37116-curiosity-incorporated/?do=download&r=213898

--- a/src/yaml/jasoncw/37117-scalloped-tower.yaml
+++ b/src/yaml/jasoncw/37117-scalloped-tower.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: scalloped-tower
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Scalloped Tower
@@ -50,18 +50,16 @@ variants:
 
 ---
 assetId: jasoncw-scalloped-tower-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:31:26Z"
-url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=210270
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:51:25Z"
+url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=213901
 ---
 assetId: jasoncw-scalloped-tower-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:31:26Z"
-url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=210271
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:51:25Z"
+url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=213902
 ---
 assetId: jasoncw-scalloped-tower-cam
-version: "1.0.0"
-lastModified: "2025-11-27T21:31:26Z"
-url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=210272
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:51:25Z"
+url: https://community.simtropolis.com/files/file/37117-scalloped-tower/?do=download&r=213903

--- a/src/yaml/jasoncw/37118-chimney-cake-company.yaml
+++ b/src/yaml/jasoncw/37118-chimney-cake-company.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: chimney-cake-company
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Chimney Cake Company
@@ -27,12 +27,11 @@ variants:
 
 ---
 assetId: jasoncw-chimney-cake-company-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:33:58Z"
-url: https://community.simtropolis.com/files/file/37118-chimney-cake-company/?do=download&r=210275
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:57:56Z"
+url: https://community.simtropolis.com/files/file/37118-chimney-cake-company/?do=download&r=213906
 ---
 assetId: jasoncw-chimney-cake-company-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:33:58Z"
-url: https://community.simtropolis.com/files/file/37118-chimney-cake-company/?do=download&r=210276
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:57:56Z"
+url: https://community.simtropolis.com/files/file/37118-chimney-cake-company/?do=download&r=213907

--- a/src/yaml/jasoncw/37119-marzahn-building.yaml
+++ b/src/yaml/jasoncw/37119-marzahn-building.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: marzahn-building
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Marzahn Building
@@ -28,12 +28,11 @@ variants:
 
 ---
 assetId: jasoncw-marzahn-building-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:36:33Z"
-url: https://community.simtropolis.com/files/file/37119-marzahn-building/?do=download&r=210279
-
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:59:45Z"
+url: https://community.simtropolis.com/files/file/37119-marzahn-building/?do=download&r=213910
 ---
 assetId: jasoncw-marzahn-building-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:36:33Z"
-url: https://community.simtropolis.com/files/file/37119-marzahn-building/?do=download&r=210280
+version: "1.0.0-1"
+lastModified: "2026-05-30T23:59:45Z"
+url: https://community.simtropolis.com/files/file/37119-marzahn-building/?do=download&r=213911

--- a/src/yaml/jasoncw/37120-mainframe-solutions.yaml
+++ b/src/yaml/jasoncw/37120-mainframe-solutions.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: mainframe-solutions
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Mainframe Solutions
@@ -25,12 +25,11 @@ variants:
 
 ---
 assetId: jasoncw-mainframe-solutions-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:38:05Z"
-url: https://community.simtropolis.com/files/file/37120-mainframe-solutions/?do=download&r=210283
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T00:01:29Z"
+url: https://community.simtropolis.com/files/file/37120-mainframe-solutions/?do=download&r=213914
 ---
 assetId: jasoncw-mainframe-solutions-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:38:05Z"
-url: https://community.simtropolis.com/files/file/37120-mainframe-solutions/?do=download&r=210284
+version: "1.0.0-1"
+lastModified: "2026-05-31T00:01:29Z"
+url: https://community.simtropolis.com/files/file/37120-mainframe-solutions/?do=download&r=213915

--- a/src/yaml/jasoncw/37121-laurasia-investments.yaml
+++ b/src/yaml/jasoncw/37121-laurasia-investments.yaml
@@ -1,6 +1,6 @@
 group: jasoncw
 name: laurasia-investments
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Laurasia Investments
@@ -25,12 +25,11 @@ variants:
 
 ---
 assetId: jasoncw-laurasia-investments-maxisnite
-version: "1.0.0"
-lastModified: "2025-11-27T21:39:49Z"
-url: https://community.simtropolis.com/files/file/37121-laurasia-investments/?do=download&r=210287
-
+version: "1.0.0-1"
+lastModified: "2026-05-31T00:03:43Z"
+url: https://community.simtropolis.com/files/file/37121-laurasia-investments/?do=download&r=213918
 ---
 assetId: jasoncw-laurasia-investments-darknite
-version: "1.0.0"
-lastModified: "2025-11-27T21:39:49Z"
-url: https://community.simtropolis.com/files/file/37121-laurasia-investments/?do=download&r=210288
+version: "1.0.0-1"
+lastModified: "2026-05-31T00:03:43Z"
+url: https://community.simtropolis.com/files/file/37121-laurasia-investments/?do=download&r=213919

--- a/src/yaml/kellydale2003/31873-eighth-avenue-place-east-tower.yaml
+++ b/src/yaml/kellydale2003/31873-eighth-avenue-place-east-tower.yaml
@@ -1,6 +1,6 @@
 group: kellydale2003
 name: eighth-avenue-place-east-tower
-version: "1.0a"
+version: "1.0a-1"
 subfolder: 300-commercial
 info:
   summary: Eighth Avenue Place - East Tower
@@ -28,9 +28,6 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2017_07/59753debd548a_St.Paul-Oct.141521500854135.jpg.4c15297f206bc7982ed98aebdec05738.jpg
 assets:
   - assetId: kellydale2003-eighth-avenue-place-east-tower
-    exclude:
-    - "/PLOP_3x5_Eighth Avenue Place - East Tower_402448f5.SC4Lot"
-  - assetId: kellydale2003-eighth-avenue-place-east-tower-ils-fix
 variants:
   - variant: { nightmode: standard }
   - variant: { nightmode: dark }
@@ -38,12 +35,6 @@ variants:
 
 ---
 assetId: kellydale2003-eighth-avenue-place-east-tower
-version: "1.0a"
-lastModified: "2025-02-15T00:11:15Z"
-url: https://community.simtropolis.com/files/file/31873-eighth-avenue-place-east-tower/?do=download&r=205990
-
----
-assetId: kellydale2003-eighth-avenue-place-east-tower-ils-fix
-version: "1.0a"
-lastModified: "2025-02-15T00:11:15Z"
-url: https://community.simtropolis.com/files/file/31873-eighth-avenue-place-east-tower/?do=download&r=205991
+version: "1.0a-1"
+lastModified: "2026-06-06T04:44:30Z"
+url: https://community.simtropolis.com/files/file/31873-eighth-avenue-place-east-tower/?do=download

--- a/src/yaml/kryptowhite/36996-17-state-street.yaml
+++ b/src/yaml/kryptowhite/36996-17-state-street.yaml
@@ -1,6 +1,6 @@
 group: kryptowhite
 name: 17-state-street
-version: "1.0.0"
+version: "1.1"
 subfolder: 300-commercial
 info:
   summary: 17 State Street
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: pikachu-sq-17-state-street
-version: "1.0.0"
-lastModified: "2025-08-28T07:55:59Z"
-url: https://community.simtropolis.com/files/file/36996-17-state-street/?do=download&r=209041
+version: "1.1"
+lastModified: "2026-06-04T11:11:40Z"
+url: https://community.simtropolis.com/files/file/36996-17-state-street/?do=download

--- a/src/yaml/kryptowhite/37007-hatch-memorial-shell.yaml
+++ b/src/yaml/kryptowhite/37007-hatch-memorial-shell.yaml
@@ -1,6 +1,6 @@
 group: kryptowhite
 name: hatch-memorial-shell
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 660-parks
 info:
   summary: Hatch Memorial Shell
@@ -31,6 +31,6 @@ assets:
 
 ---
 assetId: pikachu-sq-hatch-memorial-shell
-version: "1.0.0"
-lastModified: "2025-08-29T07:48:17Z"
-url: https://community.simtropolis.com/files/file/37007-kw-hatch-memorial-shell/?do=download&r=209092
+version: "1.0.0-1"
+lastModified: "2026-06-04T17:26:10Z"
+url: https://community.simtropolis.com/files/file/37007-kw-hatch-memorial-shell/?do=download

--- a/src/yaml/lordlucifer/24261-cafe-siciliana.yaml
+++ b/src/yaml/lordlucifer/24261-cafe-siciliana.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: cafe-siciliana
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 dependencies:
 - "bsc:mega-props-mbear-vol01"
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: lord-lucifer-cafe-siciliana
-version: "2.0"
-lastModified: "2025-08-06T02:09:25Z"
+version: "2.0-1"
+lastModified: "2026-06-13T04:00:22Z"
 url: https://community.simtropolis.com/files/file/24261-caf%C3%A9-siciliana/?do=download

--- a/src/yaml/lordlucifer/24263-ristorante-di-manolo.yaml
+++ b/src/yaml/lordlucifer/24263-ristorante-di-manolo.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: ristorante-di-manolo
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 dependencies:
 - "bsc:mega-props-mbear-vol01"
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: lord-lucifer-ristorante-di-manolo
-version: "2.0"
-lastModified: "2025-08-06T02:03:40Z"
+version: "2.0-1"
+lastModified: "2026-06-13T04:01:20Z"
 url: https://community.simtropolis.com/files/file/24263-ristorante-di-manolo/?do=download

--- a/src/yaml/lordlucifer/24264-cappella-di-vitaleta.yaml
+++ b/src/yaml/lordlucifer/24264-cappella-di-vitaleta.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: cappella-di-vitaleta
-version: "2.0"
+version: "2.0-1"
 subfolder: 650-religion
 dependencies:
 - "bsc:mega-props-mbear-vol03"
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: lord-lucifer-cappella-di-vitaleta
-version: "2.0"
-lastModified: "2025-08-06T01:50:10Z"
+version: "2.0-1"
+lastModified: "2026-06-13T03:58:20Z"
 url: https://community.simtropolis.com/files/file/24264-cappella-di-vitaleta/?do=download

--- a/src/yaml/lordlucifer/24280-gare-quissac.yaml
+++ b/src/yaml/lordlucifer/24280-gare-quissac.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: gare-quissac
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 dependencies:
 - "bsc:mega-props-mbear-vol01"
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: lord-lucifer-gare-quissac
-version: "2.0"
-lastModified: "2025-08-06T01:52:59Z"
+version: "2.0-1"
+lastModified: "2026-06-13T03:59:05Z"
 url: https://community.simtropolis.com/files/file/24280-gare-quissac/?do=download

--- a/src/yaml/lordlucifer/24430-r-set-rue-de-prato.yaml
+++ b/src/yaml/lordlucifer/24430-r-set-rue-de-prato.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: rue-de-prato
-version: "2.0"
+version: "2.0-1"
 subfolder: 200-residential
 dependencies:
 - "peg:mtp-super-pack"
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: lord-lucifer-rue-de-prato
-version: "2.0"
-lastModified: "2025-08-06T02:09:25Z"
+version: "2.0-1"
+lastModified: "2026-06-13T04:01:57Z"
 url: https://community.simtropolis.com/files/file/24430-r-set-rue-de-prato/?do=download

--- a/src/yaml/lordlucifer/24437-plaza-toretto.yaml
+++ b/src/yaml/lordlucifer/24437-plaza-toretto.yaml
@@ -1,6 +1,6 @@
 group: lord-lucifer
 name: plaza-toretto
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 dependencies:
 - "bsc:mega-props-mbear-vol01"
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: lord-lucifer-plaza-toretto
-version: "2.0"
-lastModified: "2025-08-06T02:09:25Z"
+version: "2.0-1"
+lastModified: "2026-06-13T03:59:45Z"
 url: https://community.simtropolis.com/files/file/24437-plaza-toretto/?do=download

--- a/src/yaml/mandelsoft/21592-gtr-signs.yaml
+++ b/src/yaml/mandelsoft/21592-gtr-signs.yaml
@@ -1,6 +1,6 @@
 group: mandelsoft
 name: gtr-signs
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: GTR Signs - Version 2
@@ -70,6 +70,6 @@ assets:
 
 ---
 assetId: mandelsoft-gtr-signs-version-2
-version: "2.0"
-lastModified: "2024-09-07T01:04:43Z"
-url: https://community.simtropolis.com/files/file/21592-gtr-signs-version-2/?do=download&r=203327
+version: "2.0-1"
+lastModified: "2026-05-29T23:24:27Z"
+url: https://community.simtropolis.com/files/file/21592-gtr-signs-version-2/?do=download

--- a/src/yaml/mandelsoft/25179-gtr-sign-pack-01.yaml
+++ b/src/yaml/mandelsoft/25179-gtr-sign-pack-01.yaml
@@ -1,6 +1,6 @@
 group: mandelsoft
 name: gtr-sign-pack-01
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: GTR Sign Pack 01 - Basic Freeway Signs
@@ -84,6 +84,6 @@ assets:
 
 ---
 assetId: mandelsoft-gtr-sign-pack-01-basic-freeway-signs
-version: "2.0"
-lastModified: "2024-09-07T01:07:37Z"
-url: https://community.simtropolis.com/files/file/25179-sc4dot-gtr-sign-pack-01-basic-freeway-signs/?do=download&r=203330
+version: "2.0-1"
+lastModified: "2026-05-29T23:32:12Z"
+url: https://community.simtropolis.com/files/file/25179-sc4dot-gtr-sign-pack-01-basic-freeway-signs/?do=download

--- a/src/yaml/mandelsoft/27708-gtr-sign-pack-02.yaml
+++ b/src/yaml/mandelsoft/27708-gtr-sign-pack-02.yaml
@@ -1,6 +1,6 @@
 group: mandelsoft
 name: gtr-sign-pack-02
-version: "2,0"
+version: "2,0-1"
 subfolder: 700-transit
 info:
   summary: GTR Sign Pack 02 - Advanced Freeway Signs
@@ -77,6 +77,6 @@ assets:
 
 ---
 assetId: mandelsoft-gtr-sign-pack-02-advanced-freeway-signs
-version: "2,0"
-lastModified: "2024-09-07T01:10:06Z"
-url: https://community.simtropolis.com/files/file/27708-gtr-sign-pack-02-advanced-freeway-signs/?do=download&r=203333
+version: "2,0-1"
+lastModified: "2026-05-29T23:34:35Z"
+url: https://community.simtropolis.com/files/file/27708-gtr-sign-pack-02-advanced-freeway-signs/?do=download

--- a/src/yaml/mandelsoft/28662-frickinhuge-signage-set.yaml
+++ b/src/yaml/mandelsoft/28662-frickinhuge-signage-set.yaml
@@ -1,6 +1,6 @@
 group: mandelsoft
 name: frickinhuge-signage-set
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: Frickinhuge Signage Set
@@ -70,6 +70,6 @@ assets:
 
 ---
 assetId: mandelsoft-frickinhuge-signage-set
-version: "2.0"
-lastModified: "2024-09-03T01:07:12Z"
-url: https://community.simtropolis.com/files/file/28662-frickinhuge-signage-set/?do=download&r=203094
+version: "2.0-1"
+lastModified: "2026-05-29T23:51:08Z"
+url: https://community.simtropolis.com/files/file/28662-frickinhuge-signage-set/?do=download

--- a/src/yaml/mipro/29130-essentials.yaml
+++ b/src/yaml/mipro/29130-essentials.yaml
@@ -1,6 +1,6 @@
 group: mipro
 name: essentials
-version: "2019.1-1"
+version: "2025.12"
 subfolder: 110-resources
 info:
   summary: Essentials
@@ -37,6 +37,6 @@ assets:
 
 ---
 assetId: mipro-essentials
-version: "2019.1"
-lastModified: "2019-02-01T00:16:15Z"
-url: https://community.simtropolis.com/files/file/29130-mipro-essentials/?do=download&r=174514
+version: "2025.12"
+lastModified: "2026-06-09T23:12:32Z"
+url: https://community.simtropolis.com/files/file/29130-mipro-essentials/?do=download

--- a/src/yaml/nbvc/24528-modular-breakwater-set.yaml
+++ b/src/yaml/nbvc/24528-modular-breakwater-set.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: modular-breakwater-set
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: Modular Breakwater Set
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: nbvc-modular-breakwater-set
-version: "2.0"
-lastModified: "2025-07-26T19:21:21Z"
-url: https://community.simtropolis.com/files/file/24528-modular-breakwater-set/?do=download&r=51851
+version: "2.0-1"
+lastModified: "2026-05-29T22:54:26Z"
+url: https://community.simtropolis.com/files/file/24528-modular-breakwater-set/?do=download

--- a/src/yaml/nbvc/26574-surfers.yaml
+++ b/src/yaml/nbvc/26574-surfers.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: surfers-mmp
-version: "2.0"
+version: "2.0-1"
 subfolder: 180-flora
 info:
   summary: Surfers MMP
@@ -22,7 +22,7 @@ assets:
 ---
 group: nbvc
 name: surfers-lots
-version: "2.0"
+version: "2.0-1"
 subfolder: 660-parks
 info:
   summary: Surfers Lots
@@ -45,7 +45,7 @@ assets:
 ---
 group: nbvc
 name: surfers-props
-version: "2.0-1"
+version: "2.0-2"
 subfolder: 110-resources
 info:
   summary: Surfers Props
@@ -65,6 +65,6 @@ assets:
 
 ---
 assetId: nbvc-surfers
-version: "2.0"
-lastModified: "2025-07-26T19:20:42Z"
-url: https://community.simtropolis.com/files/file/26574-surfers/?do=download&r=89728
+version: "2.0-1"
+lastModified: "2026-05-29T22:53:29Z"
+url: https://community.simtropolis.com/files/file/26574-surfers/?do=download

--- a/src/yaml/nbvc/28146-divers-and-boats.yaml
+++ b/src/yaml/nbvc/28146-divers-and-boats.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: divers-and-boats
-version: "2.0"
+version: "2.0-1"
 subfolder: 180-flora
 info:
   summary: Divers And Boats
@@ -39,7 +39,7 @@ assets:
 ---
 group: nbvc
 name: divers-and-boats-resources
-version: "2.0-1"
+version: "2.0-2"
 subfolder: 110-resources
 info:
   summary: Divers And Boats resources
@@ -55,6 +55,6 @@ assets:
 
 ---
 assetId: nbvc-divers-and-boats
-version: "2.0"
-lastModified: "2025-07-26T19:20:01Z"
-url: https://community.simtropolis.com/files/file/28146-divers-and-boats/?do=download&r=107979
+version: "2.0-1"
+lastModified: "2026-05-29T22:52:15Z"
+url: https://community.simtropolis.com/files/file/28146-divers-and-boats/?do=download

--- a/src/yaml/nbvc/28477-sailboats.yaml
+++ b/src/yaml/nbvc/28477-sailboats.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: sailboats
-version: "2.0"
+version: "2.0-1"
 subfolder: 180-flora
 info:
   summary: Sailboats
@@ -38,7 +38,7 @@ assets:
 ---
 group: nbvc
 name: sailboats-resources
-version: "2.0-1"
+version: "2.0-2"
 subfolder: 110-resources
 info:
   summary: Sailboats resources
@@ -54,6 +54,6 @@ assets:
 
 ---
 assetId: nbvc-sailboats
-version: "2.0"
-lastModified: "2025-07-26T19:19:37Z"
-url: https://community.simtropolis.com/files/file/28477-sailboats/?do=download&r=111997
+version: "2.0-1"
+lastModified: "2026-05-29T22:50:39Z"
+url: https://community.simtropolis.com/files/file/28477-sailboats/?do=download

--- a/src/yaml/nbvc/28951-marina.yaml
+++ b/src/yaml/nbvc/28951-marina.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: marina
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: Marina
@@ -71,7 +71,7 @@ dependencies:
 ---
 group: nbvc
 name: marina-resources
-version: "2.0-1"
+version: "2.0-2"
 subfolder: 110-resources
 info:
   summary: Marina resources
@@ -87,6 +87,6 @@ assets:
 
 ---
 assetId: nbvc-marina
-version: "2.0"
-lastModified: "2025-07-26T19:23:32Z"
-url: https://community.simtropolis.com/files/file/28951-marina/?do=download&r=119581
+version: "2.0-1"
+lastModified: "2026-05-29T22:58:18Z"
+url: https://community.simtropolis.com/files/file/28951-marina/?do=download

--- a/src/yaml/nbvc/29045-modular-marina-addon.yaml
+++ b/src/yaml/nbvc/29045-modular-marina-addon.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: modular-marina-addon
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: Modular Marina AddOn
@@ -41,7 +41,7 @@ assets:
 ---
 group: nbvc
 name: modular-marina-addon-resources
-version: "2.0-1"
+version: "2.0-2"
 subfolder: 110-resources
 info:
   summary: Modular Marina AddOn resources
@@ -57,6 +57,6 @@ assets:
 
 ---
 assetId: nbvc-modular-marina-addon
-version: "2.0"
-lastModified: "2025-07-26T19:22:54Z"
-url: https://community.simtropolis.com/files/file/29045-modular-marina-addon/?do=download&r=120824
+version: "2.0-1"
+lastModified: "2026-05-29T22:56:51Z"
+url: https://community.simtropolis.com/files/file/29045-modular-marina-addon/?do=download

--- a/src/yaml/nbvc/29498-boats-and-buoys.yaml
+++ b/src/yaml/nbvc/29498-boats-and-buoys.yaml
@@ -1,7 +1,7 @@
 group: nbvc
 name: boats-and-buoys
 subfolder: 700-transit
-version: "2.0"
+version: "2.0-1"
 info:
   summary: Boats And Buoys
   description: |-
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: nbvc-boats-and-buoys
-version: "2.0"
-lastModified: "2025-07-27T02:22:25Z"
-url: https://community.simtropolis.com/files/file/29498-boats-and-buoys/?do=download&r=132409
+version: "2.0-1"
+lastModified: "2026-06-13T04:02:34Z"
+url: https://community.simtropolis.com/files/file/29498-boats-and-buoys/?do=download

--- a/src/yaml/nbvc/29870-marina-round-corners.yaml
+++ b/src/yaml/nbvc/29870-marina-round-corners.yaml
@@ -1,6 +1,6 @@
 group: nbvc
 name: marina-round-corners
-version: "2.0"
+version: "2.0-1"
 subfolder: 700-transit
 info:
   summary: Marina Round Corners
@@ -41,7 +41,7 @@ assets:
 ---
 group: nbvc
 name: marina-round-corners-resources
-version: "2.0"
+version: "2.0-1"
 subfolder: 110-resources
 info:
   summary: Marina Round Corners resources
@@ -57,6 +57,6 @@ assets:
 
 ---
 assetId: nbvc-marina-round-corners
-version: "2.0"
-lastModified: "2025-07-26T19:22:12Z"
-url: https://community.simtropolis.com/files/file/29870-marina-round-corners/?do=download&r=141424
+version: "2.0-1"
+lastModified: "2026-05-29T22:55:32Z"
+url: https://community.simtropolis.com/files/file/29870-marina-round-corners/?do=download

--- a/src/yaml/nos-17/30815-the-forsaken-files-vol01.yaml
+++ b/src/yaml/nos-17/30815-the-forsaken-files-vol01.yaml
@@ -1,6 +1,6 @@
 group: b62
 name: the-forsaken-files-vol01
-version: "2.0.6"
+version: "2.0.7"
 subfolder: 300-commercial
 info:
   summary: "b62 Remastered: The Forsaken Files"
@@ -70,6 +70,6 @@ assets:
 
 ---
 assetId: nos-17-b62-remastered-the-forsaken-files
-version: "2.0.6"
-lastModified: "2025-01-05T15:54:08Z"
-url: https://community.simtropolis.com/files/file/30815-b62-remastered-the-forsaken-files/?do=download&r=205141
+version: "2.0.7"
+lastModified: "2026-06-10T22:49:47Z"
+url: https://community.simtropolis.com/files/file/30815-b62-remastered-the-forsaken-files/?do=download

--- a/src/yaml/nos-17/31289-andrew-s-fashion-centre.yaml
+++ b/src/yaml/nos-17/31289-andrew-s-fashion-centre.yaml
@@ -1,6 +1,6 @@
 group: nos-17
 name: andrew-s-fashion-centre
-version: "1.1"
+version: "1.1.1"
 subfolder: 300-commercial
 info:
   summary: Andrew's Fashion Centre
@@ -44,6 +44,6 @@ assets:
 
 ---
 assetId: nos-17-andrew-s-fashion-centre
-version: "1.1"
-lastModified: "2025-01-24T23:50:15Z"
-url: https://community.simtropolis.com/files/file/31289-andrews-fashion-centre/?do=download&r=205462
+version: "1.1.1"
+lastModified: "2026-06-10T23:14:07Z"
+url: https://community.simtropolis.com/files/file/31289-andrews-fashion-centre/?do=download

--- a/src/yaml/null-45/36091-sc4-graphics-options.yaml
+++ b/src/yaml/null-45/36091-sc4-graphics-options.yaml
@@ -1,14 +1,14 @@
 group: "null-45"
 name: "sc4-graphics-options"
-version: "1.3.1"
+version: "1.4"
 subfolder: "150-mods"
 assets:
 - assetId: "null-45-sc4-graphics-options"
   withChecksum:
   - include: "/SC4GraphicsOptions.dll"
-    sha256: 7039FB204BAC541B3B560CE7FC2774991214DA454ADF57B6640E9F5285D53D02
+    sha256: ddfd1723bb61652b4c533e68922b156029d35bea9d00cf9efbb87058dd08009c
   - include: "/SC4GraphicsOptions.ini"
-    sha256: C6F2E326099ECE47760DDC21E0384768E857AA42C2B6B733D806036AEA8640E7
+    sha256: 4b572b941a16701addcb7d646649e8985bf37c6ede2b79fa460da0e569c3f6d5
     isIni: true
 
 
@@ -100,7 +100,7 @@ info:
 
 ---
 assetId: "null-45-sc4-graphics-options"
-version: "1.3.1"
-lastModified: "2025-06-21T00:39:51Z"
+version: "1.4"
+lastModified: "2026-05-29T15:30:50Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36091-sc4-graphics-options/?do=download"
-url: "https://github.com/0xC0000054/sc4-graphics-options/releases/download/v1.3.0/SC4GraphicsOptions.zip"
+url: "https://github.com/0xC0000054/sc4-graphics-options/releases/download/v1.4.0/SC4GraphicsOptions.zip"

--- a/src/yaml/null-45/36120-sc4-cpu-options.yaml
+++ b/src/yaml/null-45/36120-sc4-cpu-options.yaml
@@ -1,6 +1,6 @@
 group: "null-45"
 name: "sc4-cpu-options"
-version: "1.0.2"
+version: "1.0.2-1"
 subfolder: "150-mods"
 assets:
 - assetId: "null-45-sc4-cpu-options"
@@ -74,7 +74,7 @@ info:
 
 ---
 assetId: "null-45-sc4-cpu-options"
-version: "1.0.2"
-lastModified: "2025-04-27T06:30:26Z"
+version: "1.0.2-1"
+lastModified: "2026-05-29T15:37:16Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36120-sc4-cpu-options/?do=download"
 url: "https://github.com/0xC0000054/sc4-cpu-options/releases/download/v1.0.2/SC4CPUOptions.zip"

--- a/src/yaml/null-45/36257-sc4-discord-rich-presence.yaml
+++ b/src/yaml/null-45/36257-sc4-discord-rich-presence.yaml
@@ -1,6 +1,6 @@
 group: "null-45"
 name: "sc4-discord-rich-presence"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "150-mods"
 assets:
 - assetId: "null-45-sc4-discord-rich-presence"
@@ -82,7 +82,7 @@ info:
 
     * `discord_game_sdk.dll`
 
-    To complete the installation, copy these files from the package subfolder into the Apps folder of your Installation folder.
+    To complete the installation, move this file from the package subfolder into the Apps folder of your Installation folder. (It does not belong into the Plugins folder.)
   author: "Null 45"
   website: "https://community.simtropolis.com/files/file/36257-discord-rich-presence-dll-for-simcity-4/"
   images:
@@ -90,7 +90,7 @@ info:
 
 ---
 assetId: "null-45-sc4-discord-rich-presence"
-version: "1.1.0"
-lastModified: "2024-06-29T01:45:43Z"
+version: "1.1.0-1"
+lastModified: "2026-05-29T15:48:42Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36257-discord-rich-presence-dll-for-simcity-4/?do=download"
 url: "https://github.com/0xC0000054/sc4-discord-rich-presence/releases/download/v1.1.0/SC4DiscordRichPresence.zip"

--- a/src/yaml/null-45/36384-sc4-auto-run-cheats.yaml
+++ b/src/yaml/null-45/36384-sc4-auto-run-cheats.yaml
@@ -101,6 +101,6 @@ info:
 ---
 assetId: "null-45-sc4-auto-run-cheats"
 version: "1.2.1"
-lastModified: "2024-08-26T21:55:33Z"
-nonPersistentUrl: "https://community.simtropolis.com/files/file/36257-discord-rich-presence-dll-for-simcity-4/?do=download"
+lastModified: "2026-05-29T15:45:55Z"
+nonPersistentUrl: "https://community.simtropolis.com/files/file/36384-sc4-auto-run-cheats-dll-plugin/?do=download"
 url: "https://github.com/0xC0000054/sc4-auto-run-cheats/releases/download/v1.2.1/SC4AutoRunCheats.zip"

--- a/src/yaml/null-45/36437-sc4-remove-phantom-budget-items.yaml
+++ b/src/yaml/null-45/36437-sc4-remove-phantom-budget-items.yaml
@@ -1,6 +1,6 @@
 group: "null-45"
 name: "sc4-remove-phantom-budget-items"
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: "150-mods"
 assets:
 - assetId: "null-45-sc4-remove-phantom-budget-items"
@@ -60,7 +60,7 @@ info:
 
 ---
 assetId: "null-45-sc4-remove-phantom-budget-items"
-version: "1.0.0"
-lastModified: "2024-09-07T05:11:45Z"
+version: "1.0.0-1"
+lastModified: "2026-06-10T07:18:58Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36437-remove-phantom-budget-items-dll-plugin/?do=download"
 url: "https://github.com/0xC0000054/sc4-remove-phantom-budget-items/releases/download/v1.0.0/SC4RemovePhantomBudgetItems.zip"

--- a/src/yaml/null-45/36571-bulldoze-extensions-dll-plugin.yaml
+++ b/src/yaml/null-45/36571-bulldoze-extensions-dll-plugin.yaml
@@ -1,6 +1,6 @@
 group: "null-45"
 name: "bulldoze-extensions"
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: "150-mods"
 assets:
 - assetId: "null-45-bulldoze-extensions"
@@ -60,7 +60,7 @@ info:
 
 ---
 assetId: "null-45-bulldoze-extensions"
-version: "2.0.0"
-lastModified: "2025-09-16T22:31:08Z"
+version: "2.0.0-1"
+lastModified: "2026-05-29T15:17:01Z"
 nonPersistentUrl: "https://community.simtropolis.com/files/file/36571-bulldoze-extensions-dll-plugin/?do=download"
 url: "https://github.com/0xC0000054/sc4-bulldoze-extensions/releases/download/v2.0/SC4BulldozeExtensions.zip"

--- a/src/yaml/paeng/26557-turbulences-and-transitions.yaml
+++ b/src/yaml/paeng/26557-turbulences-and-transitions.yaml
@@ -1,6 +1,6 @@
 group: paeng
 name: turbulences-and-transitions
-version: "1.0"
+version: "1.1"
 subfolder: 660-parks
 info:
   summary: Turbulences and Transitions Volume 01 and Volume 2
@@ -64,17 +64,10 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_07_2011/4fbdf491c30ec0d9ced73ea95252e417-turb_pieces04.jpg
     - https://www.simtropolis.com/objects/screens/monthly_07_2011/e6bd49c7877c7465a7d4abcf781bc2c7-turb_pieces05.jpg
 assets:
-  - assetId: paeng-turbulences-and-transitions-volume-02
-  - assetId: paeng-turbulences-and-transitions-volume-01
+  - assetId: paeng-turbulences-and-transitions
 
 ---
-assetId: paeng-turbulences-and-transitions-volume-02
-version: "1.0"
-lastModified: "2017-05-31T17:41:44Z"
-url: https://community.simtropolis.com/files/file/26557-paengs-turbulences-and-transitions-volume-01-and-volume-2/?do=download&r=166147
-
----
-assetId: paeng-turbulences-and-transitions-volume-01
-version: "1.0"
-lastModified: "2017-05-31T17:41:44Z"
-url: https://community.simtropolis.com/files/file/26557-paengs-turbulences-and-transitions-volume-01-and-volume-2/?do=download&r=166148
+assetId: paeng-turbulences-and-transitions
+version: "1.1"
+lastModified: "2026-05-29T00:14:21Z"
+url: https://community.simtropolis.com/files/file/26557-paengs-turbulences-and-transitions-volume-01-and-volume-2/?do=download

--- a/src/yaml/paeng/32028-urban-recreational-canal-set.yaml
+++ b/src/yaml/paeng/32028-urban-recreational-canal-set.yaml
@@ -1,6 +1,6 @@
 group: paeng
 name: urban-recreational-canal-set
-version: "1.0"
+version: "1.1"
 subfolder: 660-parks
 info:
   summary: Urban Recreational Canal set
@@ -105,6 +105,6 @@ assets:
 
 ---
 assetId: paeng-urban-recreational-canal-set
-version: "1.0"
-lastModified: "2017-12-09T00:08:45Z"
-url: https://community.simtropolis.com/files/file/32028-paengs-urban-recreational-canal-set/?do=download&r=169350
+version: "1.1"
+lastModified: "2026-05-29T00:15:08Z"
+url: https://community.simtropolis.com/files/file/32028-paengs-urban-recreational-canal-set/?do=download

--- a/src/yaml/pclark06/32635-small-shop-set-3.yaml
+++ b/src/yaml/pclark06/32635-small-shop-set-3.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: small-shop-set-3
-version: "2.0"
+version: "2.0-1"
 subfolder: 300-commercial
 info:
   summary: Small Shop Set 3
@@ -66,6 +66,6 @@ assets:
 
 ---
 assetId: pclark06-small-shop-set-3
-version: "2.0"
-lastModified: "2025-01-02T14:34:39Z"
-url: https://community.simtropolis.com/files/file/32635-pc-small-shop-set-3/?do=download&r=173701
+version: "2.0-1"
+lastModified: "2026-05-29T20:01:11Z"
+url: https://community.simtropolis.com/files/file/32635-pc-small-shop-set-3/?do=download

--- a/src/yaml/pclark06/33838-international-trucks-dealer.yaml
+++ b/src/yaml/pclark06/33838-international-trucks-dealer.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: international-trucks-dealer
-version: "1.0.2"
+version: "1.0.2-1"
 subfolder: 400-industrial
 info:
   summary: International Trucks Dealer
@@ -44,6 +44,6 @@ assets:
 
 ---
 assetId: pclark06-international-trucks-dealer
-version: "1.0.2"
-lastModified: "2025-01-09T14:50:45Z"
-url: https://community.simtropolis.com/files/file/33838-pc-international-trucks-dealer/?do=download&r=190722
+version: "1.0.2-1"
+lastModified: "2026-06-01T15:07:01Z"
+url: https://community.simtropolis.com/files/file/33838-pc-international-trucks-dealer/?do=download

--- a/src/yaml/pclark06/36325-midcentury-grocery-pharmacy-set-modern-brands.yaml
+++ b/src/yaml/pclark06/36325-midcentury-grocery-pharmacy-set-modern-brands.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: midcentury-grocery-pharmacy-set-modern-brands
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Midcentury Grocery & Pharmacy Set - Modern Brands
@@ -234,6 +234,6 @@ assets:
 
 ---
 assetId: pclark06-midcentury-grocery-pharmacy-set-modern-brands
-version: "1.0.0"
-lastModified: "2024-07-02T14:47:33Z"
-url: https://community.simtropolis.com/files/file/36325-pc-midcentury-grocery-pharmacy-set-modern-brands/?do=download&r=201872
+version: "1.0.0-1"
+lastModified: "2026-05-29T16:13:46Z"
+url: https://community.simtropolis.com/files/file/36325-pc-midcentury-grocery-pharmacy-set-modern-brands/?do=download

--- a/src/yaml/pclark06/36326-midcentury-grocery-pharmacy-set-retro-brands.yaml
+++ b/src/yaml/pclark06/36326-midcentury-grocery-pharmacy-set-retro-brands.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: midcentury-grocery-pharmacy-set-retro-brands
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Midcentury Grocery & Pharmacy Set - Retro Brands
@@ -130,6 +130,6 @@ assets:
 
 ---
 assetId: pclark06-midcentury-grocery-pharmacy-set-retro-brands
-version: "1.0.0"
-lastModified: "2024-07-02T15:13:28Z"
-url: https://community.simtropolis.com/files/file/36326-pc-midcentury-grocery-pharmacy-set-retro-brands/?do=download&r=201878
+version: "1.0.0-1"
+lastModified: "2026-05-29T16:15:02Z"
+url: https://community.simtropolis.com/files/file/36326-pc-midcentury-grocery-pharmacy-set-retro-brands/?do=download

--- a/src/yaml/pclark06/36327-office-park-10-12.yaml
+++ b/src/yaml/pclark06/36327-office-park-10-12.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: office-park-10-12
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Office Park 10-12
@@ -48,6 +48,6 @@ assets:
 
 ---
 assetId: pclark06-office-park-10-12
-version: "1.0.0"
-lastModified: "2024-07-02T18:08:50Z"
-url: https://community.simtropolis.com/files/file/36327-pc-office-park-10-12/?do=download&r=201902
+version: "1.0.0-1"
+lastModified: "2026-06-01T13:43:49Z"
+url: https://community.simtropolis.com/files/file/36327-pc-office-park-10-12/?do=download

--- a/src/yaml/pclark06/36452-parking-garages-with-retail.yaml
+++ b/src/yaml/pclark06/36452-parking-garages-with-retail.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: parking-garages-with-retail
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 700-transit
 info:
   summary: Parking Garages With Retail
@@ -247,6 +247,6 @@ assets:
 
 ---
 assetId: pclark06-parking-garages-with-retail
-version: "1.0.0"
-lastModified: "2024-09-16T18:53:41Z"
-url: https://community.simtropolis.com/files/file/36452-pc-parking-garages-with-retail/?do=download&r=203478
+version: "1.0.0-1"
+lastModified: "2026-05-29T16:58:03Z"
+url: https://community.simtropolis.com/files/file/36452-pc-parking-garages-with-retail/?do=download

--- a/src/yaml/pclark06/36473-ifly-indoor-skydiving.yaml
+++ b/src/yaml/pclark06/36473-ifly-indoor-skydiving.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: ifly-indoor-skydiving
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: iFLY Indoor Skydiving
@@ -40,6 +40,6 @@ assets:
 
 ---
 assetId: pclark06-ifly-indoor-skydiving
-version: "1.0.0"
-lastModified: "2024-09-27T13:47:03Z"
-url: https://community.simtropolis.com/files/file/36473-pc-ifly-indoor-skydiving/?do=download&r=203629
+version: "1.0.0-1"
+lastModified: "2026-05-29T17:13:31Z"
+url: https://community.simtropolis.com/files/file/36473-pc-ifly-indoor-skydiving/?do=download

--- a/src/yaml/pclark06/36525-hotels-motels.yaml
+++ b/src/yaml/pclark06/36525-hotels-motels.yaml
@@ -1,6 +1,6 @@
 group: pclark06
 name: hotels-motels
-version: "2.1"
+version: "2.1-1"
 subfolder: 300-commercial
 info:
   summary: Hotels & Motels
@@ -205,6 +205,6 @@ assets:
 
 ---
 assetId: pclark06-hotels-motels
-version: "2.1"
-lastModified: "2025-01-21T15:03:43Z"
-url: https://community.simtropolis.com/files/file/36525-pc-hotels-motels/?do=download&r=204357
+version: "2.1-1"
+lastModified: "2026-05-29T21:45:22Z"
+url: https://community.simtropolis.com/files/file/36525-pc-hotels-motels/?do=download

--- a/src/yaml/peg/10886-subterranean-mall.yaml
+++ b/src/yaml/peg/10886-subterranean-mall.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: subterranean-mall
-version: "1.1"
+version: "1.1-1"
 subfolder: 300-commercial
 info:
   summary: Subterranean Mall
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-subterranean-mall
-version: "1.1"
-lastModified: "2025-05-02T23:35:19Z"
-url: https://community.simtropolis.com/files/file/10886-peg-subterranean-mall-v206/?do=download&r=207353
+version: "1.1-1"
+lastModified: "2026-05-30T18:58:55Z"
+url: https://community.simtropolis.com/files/file/10886-peg-subterranean-mall-v206/?do=download

--- a/src/yaml/peg/10893-ore-cars-prop-pack.yaml
+++ b/src/yaml/peg/10893-ore-cars-prop-pack.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: ore-cars-prop-pack
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: Ore Cars Prop Pack
@@ -17,6 +17,6 @@ assets:
 
 ---
 assetId: peg-ore-cars-prop-pack
-version: "1.1"
-lastModified: "2025-05-02T23:33:03Z"
-url: https://community.simtropolis.com/files/file/10893-peg-ore-cars-prop-pack/?do=download&r=207351
+version: "1.1-1"
+lastModified: "2026-05-30T18:59:41Z"
+url: https://community.simtropolis.com/files/file/10893-peg-ore-cars-prop-pack/?do=download

--- a/src/yaml/peg/10897-rtk3-recreational-style.yaml
+++ b/src/yaml/peg/10897-rtk3-recreational-style.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rtk3-recreational-style
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: RTK3 Recreational Style
@@ -23,6 +23,6 @@ assets:
 
 ---
 assetId: peg-rtk3-recreational-style
-version: "1.1"
-lastModified: "2025-02-08T17:46:43Z"
-url: https://community.simtropolis.com/files/file/10897-peg-rtk3-recreational-style/?do=download&r=205676
+version: "1.1-1"
+lastModified: "2026-05-31T18:43:34Z"
+url: https://community.simtropolis.com/files/file/10897-peg-rtk3-recreational-style/?do=download

--- a/src/yaml/peg/10934-rtk3-rec-addon1.yaml
+++ b/src/yaml/peg/10934-rtk3-rec-addon1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rtk3-rec-addon1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: RTK3 REC AddOn1
@@ -21,6 +21,6 @@ assets:
 
 ---
 assetId: peg-rtk3-rec-addon1
-version: "1.1"
-lastModified: "2025-02-08T17:47:52Z"
-url: https://community.simtropolis.com/files/file/10934-peg-rtk3-rec-addon1/?do=download&r=205678
+version: "1.1-1"
+lastModified: "2026-05-31T18:45:00Z"
+url: https://community.simtropolis.com/files/file/10934-peg-rtk3-rec-addon1/?do=download

--- a/src/yaml/peg/10937-big-johns-mine.yaml
+++ b/src/yaml/peg/10937-big-johns-mine.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: big-johns-mine
-version: "1.1"
+version: "1.1-1"
 subfolder: 400-industrial
 info:
   summary: Big Johns Mine
@@ -28,6 +28,6 @@ assets:
 
 ---
 assetId: peg-big-johns-mine-v205a
-version: "1.1"
-lastModified: "2025-05-02T03:05:16Z"
-url: https://community.simtropolis.com/files/file/10937-peg-big-johns-mine-v205a/?do=download&r=207283
+version: "1.1-1"
+lastModified: "2026-05-31T18:58:50Z"
+url: https://community.simtropolis.com/files/file/10937-peg-big-johns-mine-v205a/?do=download

--- a/src/yaml/peg/10938-oceanographic-institute.yaml
+++ b/src/yaml/peg/10938-oceanographic-institute.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: oceanographic-institute
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Oceanographic Institute
@@ -27,6 +27,6 @@ assets:
 
 ---
 assetId: peg-oceanographic-institute
-version: "1.1"
-lastModified: "2025-05-02T23:36:36Z"
-url: https://community.simtropolis.com/files/file/10938-peg-oceanographic-institute-v205/?do=download&r=207356
+version: "1.1-1"
+lastModified: "2026-05-30T18:57:43Z"
+url: https://community.simtropolis.com/files/file/10938-peg-oceanographic-institute-v205/?do=download

--- a/src/yaml/peg/11001-trail-parks-iii.yaml
+++ b/src/yaml/peg/11001-trail-parks-iii.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: trail-parks-iii
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Trail Parks III
@@ -21,6 +21,6 @@ assets:
 
 ---
 assetId: peg-trail-parks-iii
-version: "1.1"
-lastModified: "2025-01-19T17:58:04Z"
-url: https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/?do=download&r=205368
+version: "1.1-1"
+lastModified: "2026-05-30T04:31:06Z"
+url: https://community.simtropolis.com/files/file/11001-peg-trail-parks-iii/?do=download

--- a/src/yaml/peg/11054-seasonal-trail-parks.yaml
+++ b/src/yaml/peg/11054-seasonal-trail-parks.yaml
@@ -21,6 +21,6 @@ assets:
 
 ---
 assetId: peg-seasonal-trail-parks-v305
-version: "3.0.5"
-lastModified: "2025-02-08T18:02:34Z"
-url: https://community.simtropolis.com/files/file/11054-peg-seasonal-trail-parks-v305/?do=download&r=205682
+version: "3.0.5-1"
+lastModified: "2026-05-30T04:26:08Z"
+url: https://community.simtropolis.com/files/file/11054-peg-seasonal-trail-parks-v305/?do=download

--- a/src/yaml/peg/11055-cdk-rec-recreational-style.yaml
+++ b/src/yaml/peg/11055-cdk-rec-recreational-style.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-rec-recreational-style
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-REC Recreational Style
@@ -28,6 +28,6 @@ assets:
 
 ---
 assetId: peg-cdk-rec-recreational-style
-version: "1.1"
-lastModified: "2025-06-07T22:09:57Z"
-url: https://community.simtropolis.com/files/file/11055-peg-cdk-rec-recreational-style/?do=download&r=207998
+version: "1.1-1"
+lastModified: "2026-05-31T19:50:51Z"
+url: https://community.simtropolis.com/files/file/11055-peg-cdk-rec-recreational-style/?do=download

--- a/src/yaml/peg/11115-seasonal-lot.yaml
+++ b/src/yaml/peg/11115-seasonal-lot.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: seasonal-lot
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Seasonal Lot
@@ -42,6 +42,6 @@ assets:
 
 ---
 assetId: peg-seasonal-lot
-version: "1.1"
-lastModified: "2025-05-03T00:14:57Z"
-url: https://community.simtropolis.com/files/file/11115-peg-seasonal-lot/?do=download&r=207392
+version: "1.1-1"
+lastModified: "2026-05-30T16:36:48Z"
+url: https://community.simtropolis.com/files/file/11115-peg-seasonal-lot/?do=download

--- a/src/yaml/peg/11129-refuse-relocation-kit.yaml
+++ b/src/yaml/peg/11129-refuse-relocation-kit.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: refuse-relocation-kit
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: Refuse Relocation Kit
@@ -50,6 +50,6 @@ variants:
 
 ---
 assetId: peg-refuse-relocation-kit
-version: "1.1"
-lastModified: "2025-01-19T15:00:39Z"
-url: https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/?do=download&r=205359
+version: "1.1-1"
+lastModified: "2026-05-30T04:29:38Z"
+url: https://community.simtropolis.com/files/file/11129-peg-refuse-relocation-kit/?do=download

--- a/src/yaml/peg/11186-cop-car-mod.yaml
+++ b/src/yaml/peg/11186-cop-car-mod.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cop-car-mod
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: COP CAR MOD
@@ -119,6 +119,6 @@ variantInfo:
 
 ---
 assetId: peg-cop-car-mod
-version: "1.1"
-lastModified: "2025-05-02T23:41:01Z"
-url: https://community.simtropolis.com/files/file/11186-peg-cop-car-mod/?do=download&r=207358
+version: "1.1-1"
+lastModified: "2026-05-30T18:53:55Z"
+url: https://community.simtropolis.com/files/file/11186-peg-cop-car-mod/?do=download

--- a/src/yaml/peg/11210-alley-kit.yaml
+++ b/src/yaml/peg/11210-alley-kit.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: alley-kit
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: Alley Kit
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-alley-kit
-version: "1.1"
-lastModified: "2025-01-22T23:36:10Z"
-url: https://community.simtropolis.com/files/file/11210-peg-alley-kit/?do=download&r=205438
+version: "1.1-1"
+lastModified: "2026-05-31T07:53:58Z"
+url: https://community.simtropolis.com/files/file/11210-peg-alley-kit/?do=download

--- a/src/yaml/peg/11212-hydroelectric-dam.yaml
+++ b/src/yaml/peg/11212-hydroelectric-dam.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: hydroelectric-dam
-version: "1.1"
+version: "1.1-1"
 subfolder: 500-utilities
 info:
   summary: Hydroelectric Dam
@@ -33,6 +33,6 @@ assets:
 
 ---
 assetId: peg-hydroelectric-dam
-version: "1.1"
-lastModified: "2025-05-02T23:20:49Z"
-url: https://community.simtropolis.com/files/file/11212-peg-hydroelectric-dam/?do=download&r=207335
+version: "1.1-1"
+lastModified: "2026-05-30T19:02:43Z"
+url: https://community.simtropolis.com/files/file/11212-peg-hydroelectric-dam/?do=download

--- a/src/yaml/peg/11334-observation-tower.yaml
+++ b/src/yaml/peg/11334-observation-tower.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: observation-tower
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Observation Tower
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-observation-tower
-version: "1.1"
-lastModified: "2025-02-08T16:32:05Z"
-url: https://community.simtropolis.com/files/file/11334-peg-observation-tower/?do=download&r=205640
+version: "1.1-1"
+lastModified: "2026-05-31T18:22:44Z"
+url: https://community.simtropolis.com/files/file/11334-peg-observation-tower/?do=download

--- a/src/yaml/peg/11423-lakeside-resort.yaml
+++ b/src/yaml/peg/11423-lakeside-resort.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: lakeside-resort
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Lakeside Resort
@@ -38,7 +38,7 @@ assets:
 ---
 group: peg
 name: lakeside-resort-props
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 110-resources
 info:
   summary: Props and models for `pkg=peg:lakeside-resort`
@@ -54,6 +54,6 @@ assets:
 
 ---
 assetId: peg-lakeside-resort
-version: "1.1"
-lastModified: "2025-05-02T23:25:04Z"
-url: https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/?do=download&r=207341
+version: "1.1-1"
+lastModified: "2026-05-30T19:01:25Z"
+url: https://community.simtropolis.com/files/file/11423-peg-lakeside-resort/?do=download

--- a/src/yaml/peg/11508-pine-trail-head.yaml
+++ b/src/yaml/peg/11508-pine-trail-head.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: pine-trail-head
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Pine Trail Head
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-pine-trail-head
-version: "1.1"
-lastModified: "2025-01-19T15:17:45Z"
-url: https://community.simtropolis.com/files/file/11508-peg-pine-trail-head/?do=download&r=205363
+version: "1.1-1"
+lastModified: "2026-05-31T17:51:54Z"
+url: https://community.simtropolis.com/files/file/11508-peg-pine-trail-head/?do=download

--- a/src/yaml/peg/11509-krispy-kremes-and-police-station.yaml
+++ b/src/yaml/peg/11509-krispy-kremes-and-police-station.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: krispy-kremes-and-police-station
-version: "1.1"
+version: "1.1-1"
 subfolder: 610-safety
 info:
   summary: Krispy Kremes and Police Station
@@ -36,6 +36,6 @@ assets:
 
 ---
 assetId: peg-krispy-kremes-and-police-station
-version: "1.1"
-lastModified: "2025-05-02T23:22:58Z"
-url: https://community.simtropolis.com/files/file/11509-peg-krispy-kremes-and-police-station/?do=download&r=207338
+version: "1.1-1"
+lastModified: "2026-05-30T19:02:05Z"
+url: https://community.simtropolis.com/files/file/11509-peg-krispy-kremes-and-police-station/?do=download

--- a/src/yaml/peg/11510-solar-collector-1.yaml
+++ b/src/yaml/peg/11510-solar-collector-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: solar-collector-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 500-utilities
 info:
   summary: Solar Collector 1
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: peg-solar-collector-1
-version: "1.1"
-lastModified: "2025-05-03T00:32:15Z"
-url: https://community.simtropolis.com/files/file/11510-peg-solar-collector-1/?do=download&r=207401
+version: "1.1-1"
+lastModified: "2026-06-03T05:45:43Z"
+url: https://community.simtropolis.com/files/file/11510-peg-solar-collector-1/?do=download

--- a/src/yaml/peg/11571-solar-collector-2.yaml
+++ b/src/yaml/peg/11571-solar-collector-2.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: solar-collector-2
-version: "1.1"
+version: "1.1-1"
 subfolder: 500-utilities
 info:
   summary: Solar Collector 2
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-solar-collector-2
-version: "1.1"
-lastModified: "2025-05-03T00:33:48Z"
-url: https://community.simtropolis.com/files/file/11571-peg-solar-collector-2/?do=download&r=207403
+version: "1.1-1"
+lastModified: "2026-06-03T05:46:26Z"
+url: https://community.simtropolis.com/files/file/11571-peg-solar-collector-2/?do=download

--- a/src/yaml/peg/11572-solar-collector-3.yaml
+++ b/src/yaml/peg/11572-solar-collector-3.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: solar-collector-3
-version: "1.1"
+version: "1.1-1"
 subfolder: 500-utilities
 info:
   summary: Solar Plant 3
@@ -31,6 +31,6 @@ assets:
 
 ---
 assetId: peg-solar-plant-3
-version: "1.1"
-lastModified: "2025-05-03T00:36:23Z"
-url: https://community.simtropolis.com/files/file/11572-peg-solar-plant-3/?do=download&r=207405
+version: "1.1-1"
+lastModified: "2026-06-03T05:47:10Z"
+url: https://community.simtropolis.com/files/file/11572-peg-solar-plant-3/?do=download

--- a/src/yaml/peg/11612-cdk-fire-dock.yaml
+++ b/src/yaml/peg/11612-cdk-fire-dock.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-fire-dock
-version: "1.1"
+version: "1.1-1"
 subfolder: 610-safety
 info:
   summary: CDK Fire Dock
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: peg-pegcdk-fire-dock
-version: "1.1"
-lastModified: "2025-06-07T22:03:22Z"
-url: https://community.simtropolis.com/files/file/11612-pegcdk-fire-dock/?do=download&r=207989
+version: "1.1-1"
+lastModified: "2026-06-03T01:03:57Z"
+url: https://community.simtropolis.com/files/file/11612-pegcdk-fire-dock/?do=download

--- a/src/yaml/peg/11688-tennis-park.yaml
+++ b/src/yaml/peg/11688-tennis-park.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: tennis-park
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Tennis Park
@@ -28,6 +28,6 @@ assets:
 
 ---
 assetId: peg-tennis-park
-version: "1.1"
-lastModified: "2025-05-03T00:39:50Z"
-url: https://community.simtropolis.com/files/file/11688-peg-tennis-park/?do=download&r=207408
+version: "1.1-1"
+lastModified: "2026-05-30T16:29:30Z"
+url: https://community.simtropolis.com/files/file/11688-peg-tennis-park/?do=download

--- a/src/yaml/peg/11695-charas-bt-records.yaml
+++ b/src/yaml/peg/11695-charas-bt-records.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: charas-bt-records
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Charas BT Records
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-presents-charas-bt-records
-version: "1.1"
-lastModified: "2025-05-02T03:07:12Z"
-url: https://community.simtropolis.com/files/file/11695-peg-presents-charas-bt-records/?do=download&r=207288
+version: "1.1-1"
+lastModified: "2026-05-31T01:54:34Z"
+url: https://community.simtropolis.com/files/file/11695-peg-presents-charas-bt-records/?do=download

--- a/src/yaml/peg/11775-cdk-rec-prop-pack-1.yaml
+++ b/src/yaml/peg/11775-cdk-rec-prop-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-rec-prop-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: CDK-REC Prop Pack 1
@@ -46,6 +46,6 @@ assets:
 
 ---
 assetId: peg-cdk-rec-prop-pack-1
-version: "1.1"
-lastModified: "2025-02-06T02:39:58Z"
-url: https://community.simtropolis.com/files/file/11775-peg-cdk-rec-prop-pack-1/?do=download&r=205554
+version: "1.1-1"
+lastModified: "2026-05-31T18:08:47Z"
+url: https://community.simtropolis.com/files/file/11775-peg-cdk-rec-prop-pack-1/?do=download

--- a/src/yaml/peg/11776-cdk-rec-fishermans-wharf.yaml
+++ b/src/yaml/peg/11776-cdk-rec-fishermans-wharf.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-rec-fishermans-wharf
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-REC Fishermans Wharf
@@ -34,6 +34,6 @@ dependencies:
 
 ---
 assetId: peg-cdk-rec-fishermans-wharf
-version: "1.1"
-lastModified: "2025-06-07T22:06:09Z"
-url: https://community.simtropolis.com/files/file/11776-peg-cdk-rec-fishermans-wharf/?do=download&r=207992
+version: "1.1-1"
+lastModified: "2026-06-03T01:02:03Z"
+url: https://community.simtropolis.com/files/file/11776-peg-cdk-rec-fishermans-wharf/?do=download

--- a/src/yaml/peg/11814-rock-mod-ii-dark-basalt.yaml
+++ b/src/yaml/peg/11814-rock-mod-ii-dark-basalt.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rock-mod-ii-dark-basalt
-version: "1.1"
+version: "1.1-1"
 subfolder: 170-terrain
 info:
   summary: ROCK MOD II Dark Basalt
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-rock-mod-ii-dark-basalt
-version: "1.1"
-lastModified: "2025-05-02T23:45:56Z"
-url: https://community.simtropolis.com/files/file/11814-peg-rock-mod-ii-dark-basalt/?do=download&r=207362
+version: "1.1-1"
+lastModified: "2026-05-30T18:51:15Z"
+url: https://community.simtropolis.com/files/file/11814-peg-rock-mod-ii-dark-basalt/?do=download

--- a/src/yaml/peg/11815-rock-mod-ii-weathered-granite.yaml
+++ b/src/yaml/peg/11815-rock-mod-ii-weathered-granite.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rock-mod-ii-weathered-granite
-version: "1.1"
+version: "1.1-1"
 subfolder: 170-terrain
 info:
   summary: ROCK MOD II Weathered Granite
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-rock-mod-ii-weathered-granite
-version: "1.1"
-lastModified: "2025-05-02T23:49:08Z"
-url: https://community.simtropolis.com/files/file/11815-peg-rock-mod-ii-weathered-granite/?do=download&r=207374
+version: "1.1-1"
+lastModified: "2026-05-30T18:44:38Z"
+url: https://community.simtropolis.com/files/file/11815-peg-rock-mod-ii-weathered-granite/?do=download

--- a/src/yaml/peg/11822-rock-mod-ii-golden-sandstone.yaml
+++ b/src/yaml/peg/11822-rock-mod-ii-golden-sandstone.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rock-mod-ii-golden-sandstone
-version: "1.1"
+version: "1.1-1"
 subfolder: 170-terrain
 info:
   summary: ROCK MOD II Golden Sandstone
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-rock-mod-ii-golden-sandstone
-version: "1.1"
-lastModified: "2025-05-02T23:47:05Z"
-url: https://community.simtropolis.com/files/file/11822-peg-rock-mod-ii-golden-sandstone/?do=download&r=207368
+version: "1.1-1"
+lastModified: "2026-05-30T18:49:37Z"
+url: https://community.simtropolis.com/files/file/11822-peg-rock-mod-ii-golden-sandstone/?do=download

--- a/src/yaml/peg/11823-rock-mod-ii-eroded-sandstone.yaml
+++ b/src/yaml/peg/11823-rock-mod-ii-eroded-sandstone.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rock-mod-ii-eroded-sandstone
-version: "1.1"
+version: "1.1-1"
 subfolder: 170-terrain
 info:
   summary: ROCK MOD II Eroded Sandstone
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-rock-mod-ii-eroded-sandstone
-version: "1.1"
-lastModified: "2025-05-02T23:46:21Z"
-url: https://community.simtropolis.com/files/file/11823-peg-rock-mod-ii-eroded-sandstone/?do=download&r=207365
+version: "1.1-1"
+lastModified: "2026-05-30T18:50:34Z"
+url: https://community.simtropolis.com/files/file/11823-peg-rock-mod-ii-eroded-sandstone/?do=download

--- a/src/yaml/peg/11826-rock-mod-ii-mossy-granite.yaml
+++ b/src/yaml/peg/11826-rock-mod-ii-mossy-granite.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rock-mod-ii-mossy-granite
-version: "1.1"
+version: "1.1-1"
 subfolder: 170-terrain
 info:
   summary: ROCK MOD II Mossy Granite
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-rock-mod-ii-mossy-granite
-version: "1.1"
-lastModified: "2025-05-02T23:48:35Z"
-url: https://community.simtropolis.com/files/file/11826-peg-rock-mod-ii-mossy-granite/?do=download&r=207371
+version: "1.1-1"
+lastModified: "2026-05-30T18:48:09Z"
+url: https://community.simtropolis.com/files/file/11826-peg-rock-mod-ii-mossy-granite/?do=download

--- a/src/yaml/peg/12007-cdk-oww-development-pack-vol1.yaml
+++ b/src/yaml/peg/12007-cdk-oww-development-pack-vol1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-development-pack-vol1
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: CDK-OWW Development Pack Vol 1
@@ -75,6 +75,6 @@ variants:
 
 ---
 assetId: peg-cdk-oww-development-pack-vol1
-version: "1.1"
-lastModified: "2025-02-06T02:33:25Z"
-url: https://community.simtropolis.com/files/file/12007-peg-cdk-oww-development-pack-vol-1/?do=download&r=205552
+version: "1.1-1"
+lastModified: "2026-05-31T18:07:28Z"
+url: https://community.simtropolis.com/files/file/12007-peg-cdk-oww-development-pack-vol-1/?do=download

--- a/src/yaml/peg/12008-cdk-oww-commercial-style.yaml
+++ b/src/yaml/peg/12008-cdk-oww-commercial-style.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-commercial-style
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW Commercial Style
@@ -39,6 +39,6 @@ dependencies:
 
 ---
 assetId: peg-cdk-oww-commercial-style
-version: "1.1"
-lastModified: "2025-06-07T21:55:05Z"
-url: https://community.simtropolis.com/files/file/12008-peg-cdk-oww-commercial-style/?do=download&r=207969
+version: "1.1-1"
+lastModified: "2026-06-03T05:32:16Z"
+url: https://community.simtropolis.com/files/file/12008-peg-cdk-oww-commercial-style/?do=download

--- a/src/yaml/peg/12063-cdk-oww-sv-random-shops.yaml
+++ b/src/yaml/peg/12063-cdk-oww-sv-random-shops.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-sv-random-shops
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW SV Random Shops
@@ -28,6 +28,6 @@ assets:
 
 ---
 assetId: peg-cdk-oww-sv-random-shops
-version: "1.1"
-lastModified: "2025-06-07T22:02:24Z"
-url: https://community.simtropolis.com/files/file/12063-peg-cdk-oww-sv-random-shops/?do=download&r=207986
+version: "1.1-1"
+lastModified: "2026-06-03T01:05:31Z"
+url: https://community.simtropolis.com/files/file/12063-peg-cdk-oww-sv-random-shops/?do=download

--- a/src/yaml/peg/12077-cdk-oww-sv-food-court-plazas.yaml
+++ b/src/yaml/peg/12077-cdk-oww-sv-food-court-plazas.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-sv-food-court-plazas
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW SV Food Court Plazas
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-cdk-oww-sv-food-court-plazas
-version: "1.1"
-lastModified: "2025-06-07T21:57:41Z"
-url: https://community.simtropolis.com/files/file/12077-peg-cdk-oww-sv-food-court-plazas/?do=download&r=207978
+version: "1.1-1"
+lastModified: "2026-06-03T05:29:32Z"
+url: https://community.simtropolis.com/files/file/12077-peg-cdk-oww-sv-food-court-plazas/?do=download

--- a/src/yaml/peg/12093-cdk-oww-sv-plaza-pack-1.yaml
+++ b/src/yaml/peg/12093-cdk-oww-sv-plaza-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-sv-plaza-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW SV Plaza Pack 1
@@ -35,6 +35,6 @@ assets:
 
 ---
 assetId: peg-cdk-oww-sv-plaza-pack-1
-version: "1.1"
-lastModified: "2025-06-07T22:01:33Z"
-url: https://community.simtropolis.com/files/file/12093-peg-cdk-oww-sv-plaza-pack-1/?do=download&r=207984
+version: "1.1-1"
+lastModified: "2026-06-03T01:06:26Z"
+url: https://community.simtropolis.com/files/file/12093-peg-cdk-oww-sv-plaza-pack-1/?do=download

--- a/src/yaml/peg/12094-cdk-oww-sv-plus-pack-1.yaml
+++ b/src/yaml/peg/12094-cdk-oww-sv-plus-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-sv-plus-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW SV Plus Pack 1
@@ -40,6 +40,6 @@ dependencies:
 
 ---
 assetId: peg-cdk-oww-sv-plus-pack-1
-version: "1.1"
-lastModified: "2025-06-07T22:00:40Z"
-url: https://community.simtropolis.com/files/file/12094-peg-cdk-oww-sv-plus-pack-1/?do=download&r=207981
+version: "1.1-1"
+lastModified: "2026-06-03T05:28:19Z"
+url: https://community.simtropolis.com/files/file/12094-peg-cdk-oww-sv-plus-pack-1/?do=download

--- a/src/yaml/peg/12145-rr-rural-rail-station.yaml
+++ b/src/yaml/peg/12145-rr-rural-rail-station.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rr-rural-rail-station
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: RR Rural Rail Station
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-rr-rural-rail-station
-version: "1.1"
-lastModified: "2025-05-02T23:54:39Z"
-url: https://community.simtropolis.com/files/file/12145-peg-rr-rural-rail-station/?do=download&r=207380
+version: "1.1-1"
+lastModified: "2026-05-31T21:07:09Z"
+url: https://community.simtropolis.com/files/file/12145-peg-rr-rural-rail-station/?do=download

--- a/src/yaml/peg/12150-rr-rural-freight-station.yaml
+++ b/src/yaml/peg/12150-rr-rural-freight-station.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rr-rural-freight-station
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: RR Rural Freight Station
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: peg-rr-rural-freight-station
-version: "1.1"
-lastModified: "2025-05-02T23:51:11Z"
-url: https://community.simtropolis.com/files/file/12150-peg-rr-rural-freight-station/?do=download&r=207377
+version: "1.1-1"
+lastModified: "2026-05-31T21:08:19Z"
+url: https://community.simtropolis.com/files/file/12150-peg-rr-rural-freight-station/?do=download

--- a/src/yaml/peg/12239-rr-whistle-stop.yaml
+++ b/src/yaml/peg/12239-rr-whistle-stop.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rr-whistle-stop
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: RR Whistle Stop
@@ -24,6 +24,6 @@ assets:
 
 ---
 assetId: peg-rr-whistle-stop
-version: "1.1"
-lastModified: "2025-05-02T23:56:57Z"
-url: https://community.simtropolis.com/files/file/12239-peg-rr-whistle-stop/?do=download&r=207386
+version: "1.1-1"
+lastModified: "2026-05-31T21:04:36Z"
+url: https://community.simtropolis.com/files/file/12239-peg-rr-whistle-stop/?do=download

--- a/src/yaml/peg/12271-rr-service-yard.yaml
+++ b/src/yaml/peg/12271-rr-service-yard.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rr-service-yard
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: RR Service Yard
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-rr-service-yard
-version: "1.1"
-lastModified: "2025-05-02T23:56:06Z"
-url: https://community.simtropolis.com/files/file/12271-peg-rr-service-yard/?do=download&r=207383
+version: "1.1-1"
+lastModified: "2026-05-31T21:05:55Z"
+url: https://community.simtropolis.com/files/file/12271-peg-rr-service-yard/?do=download

--- a/src/yaml/peg/12329-pond-kit-ii-deluxe-edition.yaml
+++ b/src/yaml/peg/12329-pond-kit-ii-deluxe-edition.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: pond-kit-ii-deluxe-edition
-version: "1.1-1"
+version: "1.2"
 subfolder: 660-parks
 info:
   summary: Pond Kit II Deluxe Edition v206
@@ -38,6 +38,6 @@ assets:
     - "/PEG_Ponds_3x2_Pond-Water_El-Extender_4fbd2b13.SC4Lot"
 ---
 assetId: peg-pond-kit-ii-deluxe-edition-v206
-version: "1.1"
-lastModified: "2025-01-22T23:27:28Z"
-url: https://community.simtropolis.com/files/file/12329-peg-pond-kit-ii-deluxe-edition-v206/?do=download&r=205432
+version: "1.2"
+lastModified: "2026-05-29T00:11:29Z"
+url: https://community.simtropolis.com/files/file/12329-peg-pond-kit-ii-deluxe-edition-v206/?do=download

--- a/src/yaml/peg/12330-pond-kit-transparent-patch.yaml
+++ b/src/yaml/peg/12330-pond-kit-transparent-patch.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: pond-kit-transparent-patch
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Pond Kit Transparent Patch
@@ -30,6 +30,6 @@ dependencies:
 
 ---
 assetId: peg-pond-kit-transparent-patch
-version: "1.1"
-lastModified: "2025-01-22T23:28:56Z"
-url: https://community.simtropolis.com/files/file/12330-peg-pond-kit-transparent-patch/?do=download&r=205435
+version: "1.1-1"
+lastModified: "2026-05-31T07:52:37Z"
+url: https://community.simtropolis.com/files/file/12330-peg-pond-kit-transparent-patch/?do=download

--- a/src/yaml/peg/12426-stream-kit-ii-deluxe-edition.yaml
+++ b/src/yaml/peg/12426-stream-kit-ii-deluxe-edition.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: stream-kit-ii-deluxe-edition
-version: "1.1-1"
+version: "1.2"
 subfolder: 360-landmark
 info:
   summary: Stream Kit  Deluxe Edition
@@ -36,6 +36,6 @@ dependencies:
 
 ---
 assetId: peg-stream-kit-ii-deluxe-edition
-version: "1.1-1"
-lastModified: "2025-01-19T18:31:36Z"
-url: https://community.simtropolis.com/files/file/12426-peg-stream-kit-deluxe-edition/?do=download&r=205378
+version: "1.2"
+lastModified: "2026-05-29T00:13:10Z"
+url: https://community.simtropolis.com/files/file/12426-peg-stream-kit-deluxe-edition/?do=download

--- a/src/yaml/peg/12455-cdk-oww-pond-and-stream-transitions.yaml
+++ b/src/yaml/peg/12455-cdk-oww-pond-and-stream-transitions.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-pond-and-stream-transitions
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CDK-OWW Pond and Stream Transitions
@@ -34,6 +34,6 @@ dependencies:
 
 ---
 assetId: peg-cdk-oww-pond-and-stream-transitions
-version: "1.1"
-lastModified: "2025-06-07T21:56:15Z"
-url: https://community.simtropolis.com/files/file/12455-peg-cdk-oww-pond-and-stream-transitions/?do=download&r=207972
+version: "1.1-1"
+lastModified: "2026-06-03T05:31:19Z"
+url: https://community.simtropolis.com/files/file/12455-peg-cdk-oww-pond-and-stream-transitions/?do=download

--- a/src/yaml/peg/12539-lighthouse-island.yaml
+++ b/src/yaml/peg/12539-lighthouse-island.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: lighthouse-island
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Lighthouse Island
@@ -28,6 +28,6 @@ assets:
 
 ---
 assetId: peg-lighthouse-island
-version: "1.1"
-lastModified: "2025-05-02T23:26:07Z"
-url: https://community.simtropolis.com/files/file/12539-peg-lighthouse-island/?do=download&r=207344
+version: "1.1-1"
+lastModified: "2026-06-03T05:41:22Z"
+url: https://community.simtropolis.com/files/file/12539-peg-lighthouse-island/?do=download

--- a/src/yaml/peg/12578-caisson-style-lighthouse.yaml
+++ b/src/yaml/peg/12578-caisson-style-lighthouse.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: caisson-style-lighthouse
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Caisson Style Lighthouse
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-caisson-style-lighthouse
-version: "1.1"
-lastModified: "2025-05-02T03:06:43Z"
-url: https://community.simtropolis.com/files/file/12578-peg-caisson-style-lighthouse/?do=download&r=207285
+version: "1.1-1"
+lastModified: "2026-06-03T05:42:07Z"
+url: https://community.simtropolis.com/files/file/12578-peg-caisson-style-lighthouse/?do=download

--- a/src/yaml/peg/12721-screw-pile-lighthouses.yaml
+++ b/src/yaml/peg/12721-screw-pile-lighthouses.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: screw-pile-lighthouses
-version: "1.1"
+version: "1.1-1"
 subfolder: 600-civics
 info:
   summary: Screw Pile Lighthouses
@@ -40,6 +40,6 @@ dependencies:
 
 ---
 assetId: peg-screw-pile-lighthouses
-version: "1.1"
-lastModified: "2025-05-03T00:13:11Z"
-url: https://community.simtropolis.com/files/file/12721-peg-screw-pile-lighthouses/?do=download&r=207389
+version: "1.1-1"
+lastModified: "2026-06-03T05:40:45Z"
+url: https://community.simtropolis.com/files/file/12721-peg-screw-pile-lighthouses/?do=download

--- a/src/yaml/peg/12727-chicken-ranch.yaml
+++ b/src/yaml/peg/12727-chicken-ranch.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: chicken-ranch
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 410-agriculture
 info:
   summary: Chicken Ranch
@@ -36,6 +36,6 @@ assets:
   
 ---
 assetId: peg-chicken-ranch
-version: "1.1-1"
-lastModified: "2025-05-02T22:54:39Z"
-url: https://community.simtropolis.com/files/file/12727-peg-chicken-ranch/?do=download&r=207327
+version: "1.1-2"
+lastModified: "2026-05-31T01:53:18Z"
+url: https://community.simtropolis.com/files/file/12727-peg-chicken-ranch/?do=download

--- a/src/yaml/peg/13059-trail-park-fountain-plaza.yaml
+++ b/src/yaml/peg/13059-trail-park-fountain-plaza.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: trail-park-fountain-plaza
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Trail Park Fountain Plaza
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-trail-park-fountain-plaza
-version: "1.1"
-lastModified: "2025-02-08T18:03:47Z"
-url: https://community.simtropolis.com/files/file/13059-peg-trail-park-fountain-plaza/?do=download&r=205684
+version: "1.1-1"
+lastModified: "2026-05-31T01:58:09Z"
+url: https://community.simtropolis.com/files/file/13059-peg-trail-park-fountain-plaza/?do=download

--- a/src/yaml/peg/13172-fountain-pack-1.yaml
+++ b/src/yaml/peg/13172-fountain-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: fountain-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Fountain Pack 1
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: peg-fountain-pack-1
-version: "1.1"
-lastModified: "2025-05-02T23:03:39Z"
-url: https://community.simtropolis.com/files/file/13172-peg-fountain-pack-1/?do=download&r=207332
+version: "1.1-1"
+lastModified: "2026-05-30T19:04:24Z"
+url: https://community.simtropolis.com/files/file/13172-peg-fountain-pack-1/?do=download

--- a/src/yaml/peg/13227-cdk-oww-sv-ferry-landing.yaml
+++ b/src/yaml/peg/13227-cdk-oww-sv-ferry-landing.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: cdk-oww-sv-ferry-landing
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: CDK-OWW SV Ferry Landing
@@ -40,6 +40,6 @@ dependencies:
 
 ---
 assetId: peg-cdk-oww-sv-ferry-landing
-version: "1.1"
-lastModified: "2025-06-07T21:56:40Z"
-url: https://community.simtropolis.com/files/file/13227-peg-cdk-oww-sv-ferry-landing/?do=download&r=207975
+version: "1.1-1"
+lastModified: "2026-06-03T05:30:14Z"
+url: https://community.simtropolis.com/files/file/13227-peg-cdk-oww-sv-ferry-landing/?do=download

--- a/src/yaml/peg/13431-red-brick-mod.yaml
+++ b/src/yaml/peg/13431-red-brick-mod.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: red-brick-mod
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: Red Brick Mod
@@ -25,6 +25,6 @@ assets:
 
 ---
 assetId: peg-red-brick-mod
-version: "1.1"
-lastModified: "2025-05-02T23:43:07Z"
-url: https://community.simtropolis.com/files/file/13431-peg-red-brick-mod/?do=download&r=207360
+version: "1.1-1"
+lastModified: "2026-05-30T18:52:36Z"
+url: https://community.simtropolis.com/files/file/13431-peg-red-brick-mod/?do=download

--- a/src/yaml/peg/13461-csk-channel-stream-kit.yaml
+++ b/src/yaml/peg/13461-csk-channel-stream-kit.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk-channel-stream-kit
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK - Channel Stream Kit
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-csk-channel-stream-kit
-version: "1.1"
-lastModified: "2025-06-07T22:12:34Z"
-url: https://community.simtropolis.com/files/file/13461-peg-csk-channel-stream-kit/?do=download&r=208001
+version: "1.1-1"
+lastModified: "2026-05-31T19:49:53Z"
+url: https://community.simtropolis.com/files/file/13461-peg-csk-channel-stream-kit/?do=download

--- a/src/yaml/peg/13493-csk-barges-prop-pack.yaml
+++ b/src/yaml/peg/13493-csk-barges-prop-pack.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk-barges-prop-pack
-version: "2.05a.1"
+version: "2.05a.1-1"
 subfolder: 100-props-textures
 info:
   summary: CSK Barges Prop Pack
@@ -25,6 +25,6 @@ assets:
 
 ---
 assetId: peg-csk-barges-prop-pack
-version: "2.05a.1"
-lastModified: "2025-03-09T22:07:53Z"
-url: https://community.simtropolis.com/files/file/13493-peg-csk-barges-prop-pack/?do=download&r=206388
+version: "2.05a.1-1"
+lastModified: "2026-05-31T18:56:12Z"
+url: https://community.simtropolis.com/files/file/13493-peg-csk-barges-prop-pack/?do=download

--- a/src/yaml/peg/13494-csk-add-on-1.yaml
+++ b/src/yaml/peg/13494-csk-add-on-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk-add-on-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK Add On 1
@@ -31,6 +31,6 @@ dependencies:
 
 ---
 assetId: peg-csk-add-on-1
-version: "1.1"
-lastModified: "2025-06-07T22:13:46Z"
-url: https://community.simtropolis.com/files/file/13494-peg-csk-add-on-1/?do=download&r=208004
+version: "1.1-1"
+lastModified: "2026-05-31T20:29:18Z"
+url: https://community.simtropolis.com/files/file/13494-peg-csk-add-on-1/?do=download

--- a/src/yaml/peg/13629-csk2-varible-width-canals.yaml
+++ b/src/yaml/peg/13629-csk2-varible-width-canals.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-varible-width-canals
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK2 Varible Width Canals
@@ -38,6 +38,6 @@ assets:
 
 ---
 assetId: peg-csk2-varible-width-canals
-version: "1.1"
-lastModified: "2025-06-07T22:58:16Z"
-url: https://community.simtropolis.com/files/file/13629-peg-csk2-varible-width-canals/?do=download&r=208016
+version: "1.1-1"
+lastModified: "2026-05-31T19:39:48Z"
+url: https://community.simtropolis.com/files/file/13629-peg-csk2-varible-width-canals/?do=download

--- a/src/yaml/peg/13647-csk-add-on-3.yaml
+++ b/src/yaml/peg/13647-csk-add-on-3.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk-add-on-3
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK Add on 3
@@ -32,6 +32,6 @@ dependencies:
 
 ---
 assetId: peg-csk-add-on-3
-version: "1.1"
-lastModified: "2025-06-07T22:14:59Z"
-url: https://community.simtropolis.com/files/file/13647-peg-csk-add-on-3/?do=download&r=208007
+version: "1.1-1"
+lastModified: "2026-05-31T19:47:49Z"
+url: https://community.simtropolis.com/files/file/13647-peg-csk-add-on-3/?do=download

--- a/src/yaml/peg/13648-csk2-addon-1.yaml
+++ b/src/yaml/peg/13648-csk2-addon-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-addon-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK2 AddOn 1
@@ -26,6 +26,6 @@ dependencies:
 
 ---
 assetId: peg-csk2-addon-1
-version: "1.1"
-lastModified: "2025-06-07T23:03:12Z"
-url: https://community.simtropolis.com/files/file/13648-peg-csk2-addon-1/?do=download&r=208022
+version: "1.1-1"
+lastModified: "2026-05-31T19:37:14Z"
+url: https://community.simtropolis.com/files/file/13648-peg-csk2-addon-1/?do=download

--- a/src/yaml/peg/13666-csk2-annabellelin-restaurant.yaml
+++ b/src/yaml/peg/13666-csk2-annabellelin-restaurant.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-annabellelin-restaurant
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 360-landmark
 info:
   summary: CSK2 Annabellelin Restaurant
@@ -34,7 +34,7 @@ dependencies:
 ---
 group: peg
 name: csk2-annabellelin-restaurant-resource
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 110-resources
 info:
   summary: CSK2 Annabellelin Restaurant resource
@@ -50,6 +50,6 @@ assets:
 
 ---
 assetId: peg-csk2-annabellelin-restaurant
-version: "1.1"
-lastModified: "2025-03-09T21:46:46Z"
-url: https://community.simtropolis.com/files/file/13666-peg-csk2-annabellelin-restaurant/?do=download&r=206382
+version: "1.1-1"
+lastModified: "2026-05-31T18:53:28Z"
+url: https://community.simtropolis.com/files/file/13666-peg-csk2-annabellelin-restaurant/?do=download

--- a/src/yaml/peg/13736-csk2-fountains.yaml
+++ b/src/yaml/peg/13736-csk2-fountains.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-fountains
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: CSK2 Fountains
@@ -27,6 +27,6 @@ dependencies:
 
 ---
 assetId: peg-csk2-fountains
-version: "1.1"
-lastModified: "2025-06-07T22:59:30Z"
-url: https://community.simtropolis.com/files/file/13736-peg-csk2-fountains/?do=download&r=208019
+version: "1.1-1"
+lastModified: "2026-05-31T19:38:50Z"
+url: https://community.simtropolis.com/files/file/13736-peg-csk2-fountains/?do=download

--- a/src/yaml/peg/13913-pier-set-volume-one.yaml
+++ b/src/yaml/peg/13913-pier-set-volume-one.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: pier-set-volume-one
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: PIER SET Volume One
@@ -38,6 +38,6 @@ assets:
 
 ---
 assetId: peg-pier-set-volume-one
-version: "1.1"
-lastModified: "2025-06-07T22:06:52Z"
-url: https://community.simtropolis.com/files/file/13913-peg-pier-set-volume-one/?do=download&r=207995
+version: "1.1-1"
+lastModified: "2026-06-03T00:28:21Z"
+url: https://community.simtropolis.com/files/file/13913-peg-pier-set-volume-one/?do=download

--- a/src/yaml/peg/14026-mtp-random-pine-forest.yaml
+++ b/src/yaml/peg/14026-mtp-random-pine-forest.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-random-pine-forest
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: MTP Random Pine Forest
@@ -25,6 +25,6 @@ assets:
 
 ---
 assetId: peg-mtp-random-pine-forest
-version: "1.1"
-lastModified: "2025-02-08T16:57:15Z"
-url: https://community.simtropolis.com/files/file/14026-peg-mtp-random-pine-forest/?do=download&r=205659
+version: "1.1-1"
+lastModified: "2026-05-31T18:41:27Z"
+url: https://community.simtropolis.com/files/file/14026-peg-mtp-random-pine-forest/?do=download

--- a/src/yaml/peg/14055-mtp-mountain-trail-rail-crossing.yaml
+++ b/src/yaml/peg/14055-mtp-mountain-trail-rail-crossing.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-mountain-trail-rail-crossing
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: MTP Mountain Trail Rail Crossing
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-mtp-mountain-trail-rail-crossing
-version: "1.1"
-lastModified: "2025-02-08T16:41:34Z"
-url: https://community.simtropolis.com/files/file/14055-peg-mtp-mountain-trail-rail-crossing/?do=download&r=205645
+version: "1.1-1"
+lastModified: "2026-05-31T18:24:43Z"
+url: https://community.simtropolis.com/files/file/14055-peg-mtp-mountain-trail-rail-crossing/?do=download

--- a/src/yaml/peg/14056-mtp-mountain-trails-rec-pack-1.yaml
+++ b/src/yaml/peg/14056-mtp-mountain-trails-rec-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-mountain-trails-rec-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: MTP Mountain Trails REC Pack 1
@@ -46,6 +46,6 @@ assets:
 
 ---
 assetId: peg-mtp-mountain-trails-rec-pack-1
-version: "1.1"
-lastModified: "2025-01-20T15:08:40Z"
-url: https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/?do=download&r=205394
+version: "1.1-1"
+lastModified: "2026-05-31T17:53:48Z"
+url: https://community.simtropolis.com/files/file/14056-peg-mtp-mountain-trails-rec-pack-1/?do=download

--- a/src/yaml/peg/14058-mtp-mountain-trail-fire-circle.yaml
+++ b/src/yaml/peg/14058-mtp-mountain-trail-fire-circle.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-mountain-trail-fire-circle
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: MTP Mountain Trail Fire Circle
@@ -30,6 +30,6 @@ assets:
 
 ---
 assetId: peg-mtp-mountain-trail-fire-circle
-version: "1.1"
-lastModified: "2025-02-08T16:35:37Z"
-url: https://community.simtropolis.com/files/file/14058-peg-mtp-mountain-trail-fire-circle/?do=download&r=205642
+version: "1.1-1"
+lastModified: "2026-05-31T18:23:49Z"
+url: https://community.simtropolis.com/files/file/14058-peg-mtp-mountain-trail-fire-circle/?do=download

--- a/src/yaml/peg/14097-mtp-forest-pack-1.yaml
+++ b/src/yaml/peg/14097-mtp-forest-pack-1.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-forest-pack-1
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: MTP Forest Pack 1
@@ -36,6 +36,6 @@ assets:
 
 ---
 assetId: peg-mtp-forest-pack-1
-version: "1.1"
-lastModified: "2025-02-08T15:54:51Z"
-url: https://community.simtropolis.com/files/file/14097-peg-mtp-forest-pack-1/?do=download&r=205637
+version: "1.1-1"
+lastModified: "2026-05-31T18:20:51Z"
+url: https://community.simtropolis.com/files/file/14097-peg-mtp-forest-pack-1/?do=download

--- a/src/yaml/peg/14107-mtp-low-wealth-growable-res-cabins.yaml
+++ b/src/yaml/peg/14107-mtp-low-wealth-growable-res-cabins.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-low-wealth-growable-res-cabins
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: MTP Low Wealth Growable RES Cabins
@@ -41,6 +41,6 @@ assets:
 
 ---
 assetId: peg-mtp-low-wealth-growable-res-cabins
-version: "1.1"
-lastModified: "2025-02-08T15:43:37Z"
-url: https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/?do=download&r=205625
+version: "1.1-1"
+lastModified: "2026-05-31T18:10:10Z"
+url: https://community.simtropolis.com/files/file/14107-peg-mtp-low-wealth-growable-res-cabins/?do=download

--- a/src/yaml/peg/14116-mtp-mid-wealth-growable-res-aframes.yaml
+++ b/src/yaml/peg/14116-mtp-mid-wealth-growable-res-aframes.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-mid-wealth-growable-res-aframes
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: MTP Mid Wealth Growable RES AFrames
@@ -41,6 +41,6 @@ assets:
 
 ---
 assetId: peg-mtp-mid-wealth-growable-res-aframes
-version: "1.1"
-lastModified: "2025-01-20T15:03:12Z"
-url: https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/?do=download&r=205391
+version: "1.1-1"
+lastModified: "2026-05-31T17:52:53Z"
+url: https://community.simtropolis.com/files/file/14116-peg-mtp-mid-wealth-growable-res-aframes/?do=download

--- a/src/yaml/peg/14158-mtp-high-wealth-growable-res-lodges.yaml
+++ b/src/yaml/peg/14158-mtp-high-wealth-growable-res-lodges.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-high-wealth-growable-res-lodges
-version: "1.1"
+version: "1.1-1"
 subfolder: 200-residential
 info:
   summary: MTP High Wealth Growable RES Lodges
@@ -38,6 +38,6 @@ assets:
 
 ---
 assetId: peg-mtp-high-wealth-growable-res-lodges
-version: "1.1"
-lastModified: "2025-02-08T15:45:23Z"
-url: https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/?do=download&r=205628
+version: "1.1-1"
+lastModified: "2026-05-30T00:17:58Z"
+url: https://community.simtropolis.com/files/file/14158-peg-mtp-high-wealth-growable-res-lodges/?do=download

--- a/src/yaml/peg/14241-mtp-urgent-care-clinic.yaml
+++ b/src/yaml/peg/14241-mtp-urgent-care-clinic.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-urgent-care-clinic
-version: "1.1"
+version: "1.1-1"
 subfolder: 630-health
 info:
   summary: MTP Urgent Care Clinic
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: peg-mtp-urgent-care-clinic
-version: "1.1"
-lastModified: "2025-02-08T17:05:04Z"
-url: https://community.simtropolis.com/files/file/14241-peg-mtp-urgent-care-clinic/?do=download&r=205666
+version: "1.1-1"
+lastModified: "2026-05-31T18:42:55Z"
+url: https://community.simtropolis.com/files/file/14241-peg-mtp-urgent-care-clinic/?do=download

--- a/src/yaml/peg/14250-mtp-old-school-house.yaml
+++ b/src/yaml/peg/14250-mtp-old-school-house.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-old-school-house
-version: "1.1"
+version: "1.1-1"
 subfolder: 620-education
 info:
   summary: MTP Old School House
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-mtp-old-school-house
-version: "1.1"
-lastModified: "2025-02-08T16:54:06Z"
-url: https://community.simtropolis.com/files/file/14250-peg-mtp-old-school-house/?do=download&r=205656
+version: "1.1-1"
+lastModified: "2026-05-31T18:40:19Z"
+url: https://community.simtropolis.com/files/file/14250-peg-mtp-old-school-house/?do=download

--- a/src/yaml/peg/14348-csk2-3x-road-swing-bridge.yaml
+++ b/src/yaml/peg/14348-csk2-3x-road-swing-bridge.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-3x-road-swing-bridge
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: CSK2 3x Road Swing Bridge
@@ -30,6 +30,6 @@ assets:
 
 ---
 assetId: peg-csk2-3x-road-swing-bridge
-version: "1.1"
-lastModified: "2025-06-07T22:54:07Z"
-url: https://community.simtropolis.com/files/file/14348-peg-csk2-3x-road-swing-bridge/?do=download&r=208013
+version: "1.1-1"
+lastModified: "2026-05-31T19:40:44Z"
+url: https://community.simtropolis.com/files/file/14348-peg-csk2-3x-road-swing-bridge/?do=download

--- a/src/yaml/peg/14368-csk2-3x-avenue-draw-bridge.yaml
+++ b/src/yaml/peg/14368-csk2-3x-avenue-draw-bridge.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-3x-avenue-draw-bridge
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 700-transit
 info:
   summary: CSK2 3x Avenue Draw Bridge
@@ -37,9 +37,9 @@ assets:
 
 ---
 assetId: peg-csk2-3x-avenue-draw-bridge
-version: "1.1"
-lastModified: "2025-06-07T22:48:14Z"
-url: https://community.simtropolis.com/files/file/14368-peg-csk2-3x-avenue-draw-bridge/?do=download&r=208010
+version: "1.1-1"
+lastModified: "2026-06-03T00:14:52Z"
+url: https://community.simtropolis.com/files/file/14368-peg-csk2-3x-avenue-draw-bridge/?do=download
 archiveType:
   format: Clickteam
   version: "20"

--- a/src/yaml/peg/14379-mtp-santas-village-alternate-audio.yaml
+++ b/src/yaml/peg/14379-mtp-santas-village-alternate-audio.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: santas-village-alternate-audio
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: Santas Village Alternate Audio
@@ -74,6 +74,6 @@ variants:
 
 ---
 assetId: peg-mtp-santas-village-alternate-audio
-version: "1.1"
-lastModified: "2025-02-08T17:02:52Z"
-url: https://community.simtropolis.com/files/file/14379-peg-mtp-santas-village-alternate-audio/?do=download&r=205664
+version: "1.1-1"
+lastModified: "2026-05-31T02:01:37Z"
+url: https://community.simtropolis.com/files/file/14379-peg-mtp-santas-village-alternate-audio/?do=download

--- a/src/yaml/peg/14415-snow-mod-mtp-patch.yaml
+++ b/src/yaml/peg/14415-snow-mod-mtp-patch.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: snow-mod-mtp-patch
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: Snow Mod MTP Patch
@@ -26,6 +26,6 @@ dependencies:
 
 ---
 assetId: peg-snow-mod-mtp-patch
-version: "1.1"
-lastModified: "2025-05-03T00:24:35Z"
-url: https://community.simtropolis.com/files/file/14415-peg-snow-mod-mtp-patch/?do=download&r=207396
+version: "1.1-1"
+lastModified: "2026-05-30T16:32:07Z"
+url: https://community.simtropolis.com/files/file/14415-peg-snow-mod-mtp-patch/?do=download

--- a/src/yaml/peg/14424-snow-mod-seasonal-tree-patch.yaml
+++ b/src/yaml/peg/14424-snow-mod-seasonal-tree-patch.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: snow-mod-seasonal-tree-patch
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: Snow Mod Seasonal Tree Patch
@@ -23,6 +23,6 @@ dependencies:
 
 ---
 assetId: peg-snow-mod-seasonal-tree-patch
-version: "1.1"
-lastModified: "2025-05-03T00:29:39Z"
-url: https://community.simtropolis.com/files/file/14424-peg-snow-mod-seasonal-tree-patch/?do=download&r=207399
+version: "1.1-1"
+lastModified: "2026-05-30T16:30:55Z"
+url: https://community.simtropolis.com/files/file/14424-peg-snow-mod-seasonal-tree-patch/?do=download

--- a/src/yaml/peg/14586-mtp-no-roadway-junk-mod.yaml
+++ b/src/yaml/peg/14586-mtp-no-roadway-junk-mod.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-no-roadway-junk-mod
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: MTP No Roadway Junk MOD
@@ -29,6 +29,6 @@ assets:
 
 ---
 assetId: peg-mtp-no-roadway-junk-mod
-version: "1.1"
-lastModified: "2025-02-08T16:51:48Z"
-url: https://community.simtropolis.com/files/file/14586-peg-mtp-no-roadway-junk-mod/?do=download&r=205654
+version: "1.1-1"
+lastModified: "2026-05-31T18:39:18Z"
+url: https://community.simtropolis.com/files/file/14586-peg-mtp-no-roadway-junk-mod/?do=download

--- a/src/yaml/peg/14620-mtp-rural-roadways-mod.yaml
+++ b/src/yaml/peg/14620-mtp-rural-roadways-mod.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-rural-roadways-mod
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: MTP Rural Roadways Mod
@@ -30,6 +30,6 @@ assets:
 
 ---
 assetId: peg-mtp-rural-roadways-mod
-version: "1.1"
-lastModified: "2025-02-08T17:01:12Z"
-url: https://community.simtropolis.com/files/file/14620-peg-mtp-rural-roadways-mod/?do=download&r=205661
+version: "1.1-1"
+lastModified: "2026-05-31T20:30:25Z"
+url: https://community.simtropolis.com/files/file/14620-peg-mtp-rural-roadways-mod/?do=download

--- a/src/yaml/peg/14809-mtp-scenic-views.yaml
+++ b/src/yaml/peg/14809-mtp-scenic-views.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-scenic-views
-version: "1.1-1"
+version: "1.1-2"
 subfolder: 660-parks
 info:
   summary: MTP Scenic Views
@@ -34,6 +34,6 @@ assets:
 
 ---
 assetId: peg-mtp-scenic-views
-version: "1.1"
-lastModified: "2025-02-08T16:42:54Z"
-url: https://community.simtropolis.com/files/file/14809-peg-mtp-scenic-views/?do=download&r=205648
+version: "1.1-1"
+lastModified: "2026-05-31T18:37:08Z"
+url: https://community.simtropolis.com/files/file/14809-peg-mtp-scenic-views/?do=download

--- a/src/yaml/peg/14810-mtp-sway-bridge.yaml
+++ b/src/yaml/peg/14810-mtp-sway-bridge.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: mtp-sway-bridge
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: MTP Sway Bridge
@@ -29,6 +29,6 @@ assets:
 
 ---
 assetId: peg-mtp-sway-bridge
-version: "1.1"
-lastModified: "2025-02-08T16:44:43Z"
-url: https://community.simtropolis.com/files/file/14810-peg-mtp-sway-bridge/?do=download&r=205651
+version: "1.1-1"
+lastModified: "2026-05-31T18:38:23Z"
+url: https://community.simtropolis.com/files/file/14810-peg-mtp-sway-bridge/?do=download

--- a/src/yaml/peg/15669-csk2-locks.yaml
+++ b/src/yaml/peg/15669-csk2-locks.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-locks
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: CSK2 Locks
@@ -34,6 +34,6 @@ dependencies:
 
 ---
 assetId: peg-csk2-locks
-version: "1.1"
-lastModified: "2025-06-07T23:04:39Z"
-url: https://community.simtropolis.com/files/file/15669-peg-csk2-locks/?do=download&r=208025
+version: "1.1-1"
+lastModified: "2026-05-31T19:35:55Z"
+url: https://community.simtropolis.com/files/file/15669-peg-csk2-locks/?do=download

--- a/src/yaml/peg/20938-snow-mod-deflowrer-patch.yaml
+++ b/src/yaml/peg/20938-snow-mod-deflowrer-patch.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: snow-mod-deflowrer-patch
-version: "1.1"
+version: "1.1-1"
 subfolder: 150-mods
 info:
   summary: Snow Mod Deflowrer Patch
@@ -29,6 +29,6 @@ assets:
 
 ---
 assetId: peg-snow-mod-deflowrer-patch
-version: "1.1"
-lastModified: "2025-05-03T00:22:08Z"
-url: https://community.simtropolis.com/files/file/20938-peg-snow-mod-deflowrer-patch/?do=download&r=207394
+version: "1.1-1"
+lastModified: "2026-05-30T16:35:26Z"
+url: https://community.simtropolis.com/files/file/20938-peg-snow-mod-deflowrer-patch/?do=download

--- a/src/yaml/peg/21661-ppond-kit.yaml
+++ b/src/yaml/peg/21661-ppond-kit.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: ppond-kit
-version: "1.0"
+version: "1.1"
 subfolder: 180-flora
 info:
   summary: PPOND KIT
@@ -91,7 +91,7 @@ assets:
 ---
 group: peg
 name: ppond-kit-resources
-version: "1.0-1"
+version: "1.1"
 subfolder: 110-resources
 info:
   summary: PPOND KIT resources
@@ -107,6 +107,6 @@ assets:
 
 ---
 assetId: peg-ppond-kit
-version: "1.0"
-lastModified: "2009-05-07T07:49:56Z"
-url: https://community.simtropolis.com/files/file/21661-peg-ppond-kit/?do=download&r=47685
+version: "1.1"
+lastModified: "2026-05-29T00:12:11Z"
+url: https://community.simtropolis.com/files/file/21661-peg-ppond-kit/?do=download

--- a/src/yaml/peg/32271-csk2-small-port.yaml
+++ b/src/yaml/peg/32271-csk2-small-port.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-small-port
-version: "1.1"
+version: "1.1-1"
 subfolder: 700-transit
 info:
   summary: CSK2 Small Port
@@ -42,6 +42,6 @@ dependencies:
 
 ---
 assetId: peg-csk2-small-port
-version: "1.1"
-lastModified: "2025-06-07T23:22:13Z"
-url: https://community.simtropolis.com/files/file/32271-peg-csk2-small-port/?do=download&r=208031
+version: "1.1-1"
+lastModified: "2026-06-03T01:00:45Z"
+url: https://community.simtropolis.com/files/file/32271-peg-csk2-small-port/?do=download

--- a/src/yaml/peg/36900-csk2-whats-up-dock.yaml
+++ b/src/yaml/peg/36900-csk2-whats-up-dock.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: csk2-whats-up-dock
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 700-transit
 info:
   summary: CSK2 "What's Up, Dock?"
@@ -40,6 +40,6 @@ assets:
 
 ---
 assetId: peg-csk2-whats-up-dock
-version: "1.0.0"
-lastModified: "2025-06-11T01:33:57Z"
-url: https://community.simtropolis.com/files/file/36900-peg-csk2-whats-up-dock/?do=download&r=208046
+version: "1.0.0-1"
+lastModified: "2026-05-30T04:13:26Z"
+url: https://community.simtropolis.com/files/file/36900-peg-csk2-whats-up-dock/?do=download

--- a/src/yaml/peg/4513-old-west-prop-pack.yaml
+++ b/src/yaml/peg/4513-old-west-prop-pack.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: old-west-prop-pack
-version: "1.1"
+version: "1.1-1"
 subfolder: 100-props-textures
 info:
   summary: Old West Prop Pack
@@ -17,6 +17,6 @@ assets:
 
 ---
 assetId: peg-old-west-prop-pack
-version: "1.1"
-lastModified: "2025-05-02T23:32:09Z"
-url: https://community.simtropolis.com/files/file/4513-peg-old-west-prop-pack-205/?do=download&r=207349
+version: "1.1-1"
+lastModified: "2026-05-30T19:00:15Z"
+url: https://community.simtropolis.com/files/file/4513-peg-old-west-prop-pack-205/?do=download

--- a/src/yaml/peg/4515-mtp-seasonal-woods.yaml
+++ b/src/yaml/peg/4515-mtp-seasonal-woods.yaml
@@ -65,6 +65,6 @@ assets:
 
 ---
 assetId: peg-mtp-seasonal-woods-v208
-version: "2.0.8"
-lastModified: "2025-01-29T09:25:24Z"
-url: https://community.simtropolis.com/files/file/4515-peg-mtp-seasonal-woods-v208/?do=download&r=205494
+version: "2.0.8-1"
+lastModified: "2026-05-30T10:00:57Z"
+url: https://community.simtropolis.com/files/file/4515-peg-mtp-seasonal-woods-v208/?do=download

--- a/src/yaml/peg/4516-arizona-memorial.yaml
+++ b/src/yaml/peg/4516-arizona-memorial.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: arizona-memorial
-version: "1.1"
+version: "1.1-1"
 subfolder: 360-landmark
 info:
   summary: Arizona Memorial
@@ -19,6 +19,6 @@ assets:
 
 ---
 assetId: peg-arizona-memorial-v205
-version: "1.1"
-lastModified: "2025-05-02T02:58:02Z"
-url: https://community.simtropolis.com/files/file/4516-peg-arizona-memorial-v205/?do=download&r=207279
+version: "1.1-1"
+lastModified: "2026-05-31T01:56:59Z"
+url: https://community.simtropolis.com/files/file/4516-peg-arizona-memorial-v205/?do=download

--- a/src/yaml/peg/4526-mtp-random-woods.yaml
+++ b/src/yaml/peg/4526-mtp-random-woods.yaml
@@ -42,6 +42,6 @@ assets:
 
 ---
 assetId: peg-mtp-random-woods-v208
-version: "2.0.8"
-lastModified: "2025-01-29T09:29:02Z"
-url: https://community.simtropolis.com/files/file/4526-peg-mtp-random-woods-v208/?do=download&r=205496
+version: "2.0.8-1"
+lastModified: "2026-05-30T10:13:07Z"
+url: https://community.simtropolis.com/files/file/4526-peg-mtp-random-woods-v208/?do=download

--- a/src/yaml/peg/4528-attitude-park.yaml
+++ b/src/yaml/peg/4528-attitude-park.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: attitude-park
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Attitude Park
@@ -19,6 +19,6 @@ assets:
 
 ---
 assetId: peg-attitude-park-v205
-version: "1.1"
-lastModified: "2025-05-02T02:58:58Z"
-url: https://community.simtropolis.com/files/file/4528-peg-attitude-park-v205/?do=download&r=207281
+version: "1.1-1"
+lastModified: "2026-05-31T01:55:55Z"
+url: https://community.simtropolis.com/files/file/4528-peg-attitude-park-v205/?do=download

--- a/src/yaml/peg/4530-rtk3-watertreatment-plant.yaml
+++ b/src/yaml/peg/4530-rtk3-watertreatment-plant.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: rtk3-watertreatment-plant
-version: "1.1"
+version: "1.1-1"
 subfolder: 500-utilities
 info:
   summary: RTK3 WaterTreatment Plant
@@ -40,6 +40,6 @@ assets:
 
 ---
 assetId: peg-rtk3-watertreatment-plant-v206
-version: "1.1"
-lastModified: "2025-02-08T17:54:44Z"
-url: https://community.simtropolis.com/files/file/4530-peg-rtk3-watertreatment-plant-v206/?do=download&r=205680
+version: "1.1-1"
+lastModified: "2026-05-31T01:59:45Z"
+url: https://community.simtropolis.com/files/file/4530-peg-rtk3-watertreatment-plant-v206/?do=download

--- a/src/yaml/peg/4563-fort-pegasus.yaml
+++ b/src/yaml/peg/4563-fort-pegasus.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: fort-pegasus
-version: "1.1"
+version: "1.1-1"
 subfolder: 360-landmark
 info:
   summary: Fort Pegasus
@@ -32,6 +32,6 @@ assets:
 
 ---
 assetId: peg-fort-pegasus
-version: "1.1"
-lastModified: "2025-05-02T22:58:41Z"
-url: https://community.simtropolis.com/files/file/4563-peg-fort-pegasus/?do=download&r=207330
+version: "1.1-1"
+lastModified: "2026-05-30T19:05:19Z"
+url: https://community.simtropolis.com/files/file/4563-peg-fort-pegasus/?do=download

--- a/src/yaml/peg/4592-oasis-park.yaml
+++ b/src/yaml/peg/4592-oasis-park.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: oasis-park
-version: "1.1"
+version: "1.1-1"
 subfolder: 660-parks
 info:
   summary: Oasis Park
@@ -17,6 +17,6 @@ assets:
 
 ---
 assetId: peg-oasis-park-v205
-version: "1.1"
-lastModified: "2025-05-02T23:31:12Z"
-url: https://community.simtropolis.com/files/file/4592-peg-oasis-park-v205/?do=download&r=207347
+version: "1.1-1"
+lastModified: "2026-05-30T19:00:52Z"
+url: https://community.simtropolis.com/files/file/4592-peg-oasis-park-v205/?do=download

--- a/src/yaml/philforhockey51/36412-irm-fillers-grass-angles.yaml
+++ b/src/yaml/philforhockey51/36412-irm-fillers-grass-angles.yaml
@@ -1,6 +1,6 @@
 group: philforhockey51
 name: irm-fillers-grass-angles
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 400-industrial
 info:
   summary: IRM Fillers - Grass Angles
@@ -68,6 +68,6 @@ assets:
 
 ---
 assetId: philforhockey51-irm-fillers-grass-angles
-version: "1.0.0"
-lastModified: "2024-08-26T05:14:11Z"
-url: https://community.simtropolis.com/files/file/36412-phil-irm-fillers-grass-angles/?do=download&r=202949
+version: "1.0.0-1"
+lastModified: "2026-06-09T19:03:51Z"
+url: https://community.simtropolis.com/files/file/36412-phil-irm-fillers-grass-angles/?do=download

--- a/src/yaml/philforhockey51/36413-irm-fillers-full-concrete-angles.yaml
+++ b/src/yaml/philforhockey51/36413-irm-fillers-full-concrete-angles.yaml
@@ -1,6 +1,6 @@
 group: philforhockey51
 name: irm-fillers-full-concrete-angles
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 400-industrial
 info:
   summary: IRM Fillers - Full Concrete Angles
@@ -62,6 +62,6 @@ assets:
 
 ---
 assetId: philforhockey51-irm-fillers-full-concrete-angles
-version: "1.0.0"
-lastModified: "2024-08-26T05:22:55Z"
-url: https://community.simtropolis.com/files/file/36413-phil-irm-fillers-full-concrete-angles/?do=download&r=202955
+version: "1.0.0-1"
+lastModified: "2026-06-09T19:05:55Z"
+url: https://community.simtropolis.com/files/file/36413-phil-irm-fillers-full-concrete-angles/?do=download

--- a/src/yaml/philforhockey51/36414-irm-fillers-mixed-concrete-angles.yaml
+++ b/src/yaml/philforhockey51/36414-irm-fillers-mixed-concrete-angles.yaml
@@ -1,6 +1,6 @@
 group: philforhockey51
 name: irm-fillers-mixed-concrete-angles
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 400-industrial
 info:
   summary: IRM Fillers - Mixed Concrete Angles
@@ -66,6 +66,6 @@ assets:
 
 ---
 assetId: philforhockey51-irm-fillers-mixed-concrete-angles
-version: "1.0.0"
-lastModified: "2024-08-26T05:31:39Z"
-url: https://community.simtropolis.com/files/file/36414-phil-irm-fillers-mixed-concrete-angles/?do=download&r=202961
+version: "1.0.0-1"
+lastModified: "2026-06-09T19:08:46Z"
+url: https://community.simtropolis.com/files/file/36414-phil-irm-fillers-mixed-concrete-angles/?do=download

--- a/src/yaml/pitti/20441-french-roadsign-pack-update.yaml
+++ b/src/yaml/pitti/20441-french-roadsign-pack-update.yaml
@@ -1,13 +1,12 @@
----
 assetId: pitti-french-roadsign-pack
-version: "2.0.0"
-lastModified: "2024-09-08T12:58:22Z"
+version: "2.0.1"
+lastModified: "2026-05-29T23:04:52Z"
 url: https://community.simtropolis.com/files/file/20441-french-roadsign-pack-update/?do=download
 
 ---
 group: pitti
 name: french-roadsign-pack
-version: "2.0.0"
+version: "2.0.1"
 subfolder: 700-transit
 info:
   summary: French roadsign pack 

--- a/src/yaml/pitti/21012-autobahn-signs.yaml
+++ b/src/yaml/pitti/21012-autobahn-signs.yaml
@@ -1,13 +1,12 @@
----
 assetId: pitti-autobahn-signs
-version: "2.0.0"
-lastModified: "2024-09-08T12:58:47Z"
+version: "2.0.0-1"
+lastModified: "2026-05-29T23:07:03Z"
 url: https://community.simtropolis.com/files/file/21012-autobahn-signs/?do=download
 
 ---
 group: pitti
 name: autobahn-signs
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: Autobahn signs pack

--- a/src/yaml/pitti/25830-german-autobahn-signs-for-rhw-4x.yaml
+++ b/src/yaml/pitti/25830-german-autobahn-signs-for-rhw-4x.yaml
@@ -1,13 +1,12 @@
----
 assetId: pitti-german-autobahn-signs
-version: "2.0.0"
-lastModified: "2024-09-08T12:58:22Z"
+version: "2.0.0-1"
+lastModified: "2026-05-29T23:08:45Z"
 url: https://community.simtropolis.com/files/file/25830-german-autobahn-signs-for-rhw-4x/?do=download
 
 ---
 group: pitti
 name: german-autobahn-signs
-version: "2.0.0"
+version: "2.0.0-1"
 subfolder: 700-transit
 info:
   summary: German Autobahn Signs

--- a/src/yaml/plundere/21934-catenary-essentials.yaml
+++ b/src/yaml/plundere/21934-catenary-essentials.yaml
@@ -1,6 +1,6 @@
 group: "plundere"
 name: "catenary-essentials"
-version: "1.0"
+version: "1.0-1"
 subfolder: "100-props-textures"
 assets:
 - assetId: "plundere-catenary-essentials"
@@ -16,6 +16,6 @@ info:
     
 ---
 assetId: "plundere-catenary-essentials"
-version: "1.0"
-lastModified: "2025-06-19T18:05:55-07:00"
+version: "1.0-1"
+lastModified: "2009-06-25T10:00:33Z"
 url: "https://community.simtropolis.com/files/file/21934-catenary_essentials/?do=download"

--- a/src/yaml/ralphaelninja/21352-utilityradius-trafpollution-modd.yaml
+++ b/src/yaml/ralphaelninja/21352-utilityradius-trafpollution-modd.yaml
@@ -112,6 +112,6 @@ variantInfo:
     description: 512 tile Radius, 0% Traffic Pollution
 ---
 assetId: ralphaelninja-utilityradius-trafpollution-modd
-version: "1.0.0"
-lastModified: "2004-05-04T00:00:00Z"
+version: "1.0.0-1"
+lastModified: "2004-05-03T23:00:00Z"
 url: https://community.simtropolis.com/files/file/21352-utilityradius-trafpollution-modd/?do=download

--- a/src/yaml/rare-guava/36754-scranton-business-park.yaml
+++ b/src/yaml/rare-guava/36754-scranton-business-park.yaml
@@ -1,13 +1,13 @@
 assetId: rare-guava-scranton-business-park
-version: "1.0.0"
-lastModified: "2025-03-17T03:59:40Z"
+version: "1.0.0-1"
+lastModified: "2026-06-09T17:45:13Z"
 url: https://community.simtropolis.com/files/file/36754-scranton-business-park/?do=download
 
 ---
 group: rare-guava
 name: scranton-business-park
 subfolder: 360-landmark
-version: "1.0.0"
+version: "1.0.0-1"
 info:
   summary: Scranton Business Park
   description: |

--- a/src/yaml/rare-guava/36777-club-sega-building-1.yaml
+++ b/src/yaml/rare-guava/36777-club-sega-building-1.yaml
@@ -1,13 +1,13 @@
 assetId: rare-guava-club-sega-building-1
-version: "1.0.0"
-lastModified: "2025-03-17T03:59:40Z"
+version: "1.0.0-1"
+lastModified: "2026-06-09T17:42:49Z"
 url: https://community.simtropolis.com/files/file/36777-club-sega-building-1/?do=download
 
 ---
 group: rare-guava
 name: club-sega-building-1
 subfolder: 360-landmark
-version: "1.0.0"
+version: "1.0.0-1"
 info:
   summary:  Club Sega Building 1
   description: |

--- a/src/yaml/rivit/25338-cricket-rugby-bowls.yaml
+++ b/src/yaml/rivit/25338-cricket-rugby-bowls.yaml
@@ -42,6 +42,6 @@ assets:
 
 ---
 assetId: rivit-cricket-rugby-bowls
-version: "3"
-lastModified: "2011-01-09T06:58:00Z"
+version: "3-1"
+lastModified: "2011-01-08T19:58:09Z"
 url: https://community.simtropolis.com/files/file/25338-cricket-rugby-bowls/?do=download

--- a/src/yaml/rivit/25402-sam4-override-nz-gravel.yaml
+++ b/src/yaml/rivit/25402-sam4-override-nz-gravel.yaml
@@ -87,6 +87,6 @@ assets:
 
 ---
 assetId: rivit-rvt-sam4-nz-gravel
-version: "5.42"
-lastModified: "2021-11-19T11:40:00Z"
+version: "5.42-1"
+lastModified: "2021-11-19T00:40:14Z"
 url: https://community.simtropolis.com/files/file/25402-sam4-override-nz-gravel/?do=download

--- a/src/yaml/rivit/25403-sam5-override-rural-tarseal.yaml
+++ b/src/yaml/rivit/25403-sam5-override-rural-tarseal.yaml
@@ -85,6 +85,6 @@ assets:
 
 ---
 assetId: rivit-rvt-sam5-tsr-rural
-version: "5.42"
-lastModified: "2021-11-19T11:43:00Z"
+version: "5.42-1"
+lastModified: "2021-11-19T00:43:26Z"
 url: https://community.simtropolis.com/files/file/25403-sam5-override-rural-tarseal/?do=download

--- a/src/yaml/rivit/25404-urban-tarsealed-street-modd.yaml
+++ b/src/yaml/rivit/25404-urban-tarsealed-street-modd.yaml
@@ -255,6 +255,6 @@ variants:
 
 ---
 assetId: rivit-urban-tarsealed-street-modd
-version: "4.42"
-lastModified: "2021-11-19T10:52:00Z"
+version: "4.42-1"
+lastModified: "2021-11-18T23:52:18Z"
 url: https://community.simtropolis.com/files/file/25404-urban-tarsealed-street-modd/?do=download

--- a/src/yaml/rivit/25655-sam2-override-red-herringbone-brick.yaml
+++ b/src/yaml/rivit/25655-sam2-override-red-herringbone-brick.yaml
@@ -83,6 +83,6 @@ assets:
 
 ---
 assetId: rivit-rvt-sam2-red-herringbone-brick
-version: "5.42"
-lastModified: "2021-11-19T11:37:00Z"
+version: "5.42-1"
+lastModified: "2021-11-19T00:37:41Z"
 url: https://community.simtropolis.com/files/file/25655-sam2-override-red-herringbone-brick/?do=download

--- a/src/yaml/rivit/26943-tunnel-modd.yaml
+++ b/src/yaml/rivit/26943-tunnel-modd.yaml
@@ -225,6 +225,6 @@ variants:
 
 ---
 assetId: rivit-tunnel-modd
-version: "2.0"
-lastModified: "2011-11-06T13:00:00Z"
+version: "2.0-1"
+lastModified: "2011-11-06T02:00:49Z"
 url: https://community.simtropolis.com/files/file/26943-tunnel-modd/?do=download

--- a/src/yaml/rivit/31977-sam2-override-grey-herringbonebrick.yaml
+++ b/src/yaml/rivit/31977-sam2-override-grey-herringbonebrick.yaml
@@ -85,6 +85,6 @@ assets:
 
 ---
 assetId: rivit-rvt-sam2-grey-herringbone-brick
-version: "5.42"
-lastModified: "2021-11-19T11:35:00Z"
+version: "5.42-1"
+lastModified: "2021-11-19T00:35:16Z"
 url: https://community.simtropolis.com/files/file/31977-sam2-override-grey-herringbonebrick/?do=download

--- a/src/yaml/rretail/35468-meadowbrook-plaza.yaml
+++ b/src/yaml/rretail/35468-meadowbrook-plaza.yaml
@@ -91,6 +91,6 @@ url: https://community.simtropolis.com/files/file/35468-meadowbrook-plaza/?do=do
 
 ---
 assetId: smf16-meadowbrook-plaza-fixed
-version: "1.0.0"
-lastModified: "2024-12-13T15:13:40Z"
+version: "1.0.0-1"
+lastModified: "2026-06-05T18:25:22Z"
 url: https://community.simtropolis.com/files/file/36596-meadowbrook-plaza-fixed/?do=download

--- a/src/yaml/simcoug/28307-maxis-rss-homes.yaml
+++ b/src/yaml/simcoug/28307-maxis-rss-homes.yaml
@@ -1,6 +1,6 @@
 group: simcoug
 name: maxis-rss-homes
-version: "1.0"
+version: "2"
 subfolder: 200-residential
 info:
   summary: Maxis R$$ Homes
@@ -59,6 +59,6 @@ assets:
 
 ---
 assetId: simcoug-maxis-rss-homes
-version: "1.0"
-lastModified: "2012-12-20T16:35:28Z"
-url: https://community.simtropolis.com/files/file/28307-simcoug-maxis-r-homes/?do=download&r=109745
+version: "2"
+lastModified: "2026-06-05T17:45:06Z"
+url: https://community.simtropolis.com/files/file/28307-simcoug-maxis-r-homes/?do=download

--- a/src/yaml/simcoug/28426-old-rs-neighborhoods.yaml
+++ b/src/yaml/simcoug/28426-old-rs-neighborhoods.yaml
@@ -1,6 +1,6 @@
 group: simcoug
 name: old-rs-neighborhoods
-version: "1.0"
+version: "2"
 subfolder: 200-residential
 info:
   summary: Old R$ Neighborhoods
@@ -89,6 +89,6 @@ assets:
 
 ---
 assetId: simcoug-old-rs-neighborhoods
-version: "1.0"
-lastModified: "2013-02-04T03:55:51Z"
-url: https://community.simtropolis.com/files/file/28426-simcougs-old-r-neighborhoods/?do=download&r=111555
+version: "2"
+lastModified: "2026-06-05T17:42:02Z"
+url: https://community.simtropolis.com/files/file/28426-simcougs-old-r-neighborhoods/?do=download

--- a/src/yaml/simcoug/28630-rss-diagonal-homes.yaml
+++ b/src/yaml/simcoug/28630-rss-diagonal-homes.yaml
@@ -1,6 +1,6 @@
 group: simcoug
 name: rss-diagonal-homes
-version: "1.0"
+version: "2.1"
 subfolder: 200-residential
 info:
   summary: R$$ Diagonal Homes
@@ -72,6 +72,6 @@ assets:
 
 ---
 assetId: simcoug-rss-diagonal-homes
-version: "1.0"
-lastModified: "2013-04-08T21:35:56Z"
-url: https://community.simtropolis.com/files/file/28630-simcougs-r-diagonal-homes/?do=download&r=113901
+version: "2.1"
+lastModified: "2026-06-05T17:40:14Z"
+url: https://community.simtropolis.com/files/file/28630-simcougs-r-diagonal-homes/?do=download

--- a/src/yaml/simfox/21945-chaotianmen-tower.yaml
+++ b/src/yaml/simfox/21945-chaotianmen-tower.yaml
@@ -79,6 +79,6 @@ archiveType:
 
 ---
 assetId: simfox-chiao-tianmen-darknite
-version: "1.1"
-lastModified: "2025-05-25T15:47:12Z"
-url: https://community.simtropolis.com/files/file/23536-simfox-chiao-tianmen-dark-nite-version/?do=download&r=50397
+version: "1.1-1"
+lastModified: "2026-06-08T05:59:29Z"
+url: https://community.simtropolis.com/files/file/23536-simfox-chiao-tianmen-dark-nite-version/?do=download

--- a/src/yaml/themurderouscricket/37192-simcity-3000-ordinances-for-sc4-hea-and-public-safety.yaml
+++ b/src/yaml/themurderouscricket/37192-simcity-3000-ordinances-for-sc4-hea-and-public-safety.yaml
@@ -1,6 +1,6 @@
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-hea-and-public-safety"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -27,6 +27,6 @@ info:
 
 ---
 assetId: "tmc-simcity-3000-ordinances-for-sc4-hea-and-public-safetys"
-version: "1.0.0"
-lastModified: "2026-01-10T22:49:03Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:42:23Z"
 url: "https://community.simtropolis.com/files/file/37192-simcity-3000-ordinances-for-sc4-hea-and-public-safety/?do=download"

--- a/src/yaml/themurderouscricket/37193-simcity-3000-ordinances-for-sc4-transportation.yaml
+++ b/src/yaml/themurderouscricket/37193-simcity-3000-ordinances-for-sc4-transportation.yaml
@@ -1,6 +1,6 @@
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-transportation"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -27,6 +27,6 @@ info:
 
 ---
 assetId: "tmc-simcity-3000-ordinances-for-sc4-transportation"
-version: "1.0.0"
-lastModified: "2026-01-10T22:52:32Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:39:38Z"
 url: "https://community.simtropolis.com/files/file/37193-simcity-3000-ordinances-for-sc4-transportation/?do=download"

--- a/src/yaml/themurderouscricket/37195-simcity-3000-ordinances-for-sc4-city-planner.yaml
+++ b/src/yaml/themurderouscricket/37195-simcity-3000-ordinances-for-sc4-city-planner.yaml
@@ -1,19 +1,18 @@
----
 assetId: "tmc-simcity-3000-ordinances-for-sc4-city-planner-p-1"
-version: "1.0.0"
-lastModified: "2026-01-12T13:21:39Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:37:08Z"
 url: "https://community.simtropolis.com/files/file/37195-simcity-3000-ordinances-for-sc4-city-planner-p-1/?do=download"
 
 ---
 assetId: "tmc-simcity-3000-ordinances-for-sc4-city-planner-p-2"
-version: "1.0.0"
-lastModified: "2026-01-12T13:24:34Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:33:02Z"
 url: "https://community.simtropolis.com/files/file/37196-simcity-3000-ordinances-for-sc4-city-planner-p-2/?do=download"
 
 ---
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-city-planner-p-1"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -41,7 +40,7 @@ info:
 ---
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-city-planner-p-2"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"

--- a/src/yaml/themurderouscricket/37218-simcity-3000-ordinances-for-sc4-environment.yaml
+++ b/src/yaml/themurderouscricket/37218-simcity-3000-ordinances-for-sc4-environment.yaml
@@ -1,6 +1,6 @@
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-environment"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -27,6 +27,6 @@ info:
 
 ---
 assetId: "tmc-simcity-3000-ordinances-for-sc4-environment"
-version: "1.0.0"
-lastModified: "2026-01-27T09:03:50Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:45:35Z"
 url: "https://community.simtropolis.com/files/file/37218-simcity-3000-ordinances-for-sc4-environment/?do=download"

--- a/src/yaml/themurderouscricket/37221-simcity-3000-ordinances-for-sc4-utilities.yaml
+++ b/src/yaml/themurderouscricket/37221-simcity-3000-ordinances-for-sc4-utilities.yaml
@@ -1,6 +1,6 @@
 group: "themurderouscricket"
 name: "simcity-3000-ordinances-for-sc4-utilities"
-version: "1.0.0"
+version: "0.9.6"
 subfolder: "140-ordinances"
 dependencies:
 - "null-45:custom-ordinance-exemplar-host-dll"
@@ -27,8 +27,8 @@ info:
 
 ---
 assetId: "tmc-simcity-3000-ordinances-for-sc4-utilities"
-version: "1.0.0"
-lastModified: "2026-01-28T22:26:44Z"
+version: "0.9.6"
+lastModified: "2026-05-30T00:44:03Z"
 url: "https://community.simtropolis.com/files/file/37221-simcity-3000-ordinances-for-sc4-utilities/?do=download"
 
 ---

--- a/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
+++ b/src/yaml/tiepinl/37015-block-maxis-rci-lots.yaml
@@ -1,12 +1,12 @@
 assetId: "block-maxis-rci-lots"
-version: "1.1"
-lastModified: "2025-09-13T06:59:22Z"
+version: "1.1-1"
+lastModified: "2026-06-06T04:10:36Z"
 url: "https://community.simtropolis.com/files/file/37015-block-maxis-rci-lots/?do=download"
 
 ---
 group: "tiepinl"
 name: "block-maxis-i-d"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -31,7 +31,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-m"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -56,7 +56,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-ht"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -81,7 +81,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-i-r"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -106,7 +106,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-residential"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -133,7 +133,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-commercial"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 assets:
 - assetId: "block-maxis-rci-lots"
@@ -162,7 +162,7 @@ dependencies:
 ---
 group: "tiepinl"
 name: "block-maxis-cam"
-version: "1.1.0"
+version: "1.1.0-1"
 subfolder: "900-overrides"
 variants:
 - variant: { CAM: "yes" }

--- a/src/yaml/torresprei/4238-sims-geographic-museum-ii.yaml
+++ b/src/yaml/torresprei/4238-sims-geographic-museum-ii.yaml
@@ -1,6 +1,6 @@
 group: torresprei
 name: sims-geographic-museum-ii
-version: "2.0"
+version: "2.0-1"
 subfolder: 620-education
 dependencies:
   - torresprei:sims-geographic-museum-ii-props
@@ -34,6 +34,6 @@ info:
 
 ---
 assetId: "sims-geographic-museum-ii"
-version: "2.0"
-lastModified: "2025-09-18T16:35:47Z"
+version: "2.0-1"
+lastModified: "2026-05-29T23:26:47Z"
 url: https://community.simtropolis.com/files/file/4238-sims-geographic-museum-ii/?do=download

--- a/src/yaml/urban-vibravant/33850-200-w-40th-street-ny.yaml
+++ b/src/yaml/urban-vibravant/33850-200-w-40th-street-ny.yaml
@@ -1,56 +1,56 @@
 assetId: urban-vibravant-200-w-40th-street-ny-maxisnite-sd
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209313
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212601
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-maxisnite-hd
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209310
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212600
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-darknite-sd
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209309
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212599
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-darknite-hd
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209306
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212598
 
 ---
 
 assetId: urban-vibravant-200-w-40th-street-ny-maxisnite-sd-nobi
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209312
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212604
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-maxisnite-hd-nobi
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209311
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212605
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-darknite-sd-nobi
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209308
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212603
 
 ---
 assetId: urban-vibravant-200-w-40th-street-ny-darknite-hd-nobi
-version: "1.0.0"
-lastModified: "2025-09-22T17:55:55Z"
-url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=209307
+version: "2.0.0"
+lastModified: "2026-05-29T00:07:06Z"
+url: https://community.simtropolis.com/files/file/33850-200-w-40th-street-ny/?do=download&r=212602
 
 ---
 group: urban-vibravant
 name: 200-w-40th-street-ny
 subfolder: 300-commercial
-version: "1.0.0"
+version: "2.0.0"
 info:
   summary: 200 W 40th Street NY
   description: |

--- a/src/yaml/urban-vibravant/33953-725-727-7th-avenue-ny.yaml
+++ b/src/yaml/urban-vibravant/33953-725-727-7th-avenue-ny.yaml
@@ -1,56 +1,31 @@
 assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-sd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=206471
+version: "1.1"
+lastModified: "2026-05-29T00:09:36Z"
+url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=212623
 
 ---
 assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-hd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=206470
+version: "1.1"
+lastModified: "2026-05-29T00:09:36Z"
+url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=212622
 
 ---
 assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-sd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=206469
+version: "1.1"
+lastModified: "2026-05-29T00:09:36Z"
+url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=212621
 
 ---
 assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-hd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=206468
-
----
-
-assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-sd-tsqa
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/34697-723-7th-avenue-ny/?do=download&r=198090
-
----
-assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-hd-tsqa
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/34697-723-7th-avenue-ny/?do=download&r=198089
-
----
-assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-sd-tsqa
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/34697-723-7th-avenue-ny/?do=download&r=198088
-
----
-assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-hd-tsqa
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/34697-723-7th-avenue-ny/?do=download&r=198087
+version: "1.1"
+lastModified: "2026-05-29T00:09:36Z"
+url: https://community.simtropolis.com/files/file/33953-725-727-7th-avenue-ny/?do=download&r=212620
 
 ---
 group: urban-vibravant
 name: 725-727-7th-avenue-ny
 subfolder: 300-commercial
-version: "1.0.0"
+version: "1.1"
 info:
   summary: 725-727 7th Avenue NY
   description: |
@@ -72,34 +47,20 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2021_10/7.jpg.d93e1995a407cff32863fc8ae5fcfae1.jpg
 
 variants:
-  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: sd, urban-vibravant:725-727-7th-avenue-ny:lighting: standard }
+  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: sd }
     assets:
       - assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-sd
-  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: sd, urban-vibravant:725-727-7th-avenue-ny:lighting: standard }
+  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: sd }
     dependencies: [ "simfox:day-and-nite-mod" ]
     assets:
       - assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-sd
-  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: hd, urban-vibravant:725-727-7th-avenue-ny:lighting: standard }
+  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: hd }
     assets:
       - assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-hd
-  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: hd, urban-vibravant:725-727-7th-avenue-ny:lighting: standard }
+  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: hd }
     dependencies: [ "simfox:day-and-nite-mod" ]
     assets:
       - assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-hd      
-  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: sd, urban-vibravant:725-727-7th-avenue-ny:lighting: times-square-ambience }
-    assets:
-      - assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-sd-tsqa
-  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: sd, urban-vibravant:725-727-7th-avenue-ny:lighting: times-square-ambience }
-    dependencies: [ "simfox:day-and-nite-mod" ]
-    assets:
-      - assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-sd-tsqa
-  - variant: { nightmode: standard, urban-vibravant:725-727-7th-avenue-ny:resolution: hd, urban-vibravant:725-727-7th-avenue-ny:lighting: times-square-ambience }
-    assets:
-      - assetId: urban-vibravant-725-727-7th-avenue-ny-maxisnite-hd-tsqa
-  - variant: { nightmode: dark, urban-vibravant:725-727-7th-avenue-ny:resolution: hd, urban-vibravant:725-727-7th-avenue-ny:lighting: times-square-ambience }
-    dependencies: [ "simfox:day-and-nite-mod" ]
-    assets:
-      - assetId: urban-vibravant-725-727-7th-avenue-ny-darknite-hd-tsqa      
 
 variantInfo:
   - variantId: urban-vibravant:725-727-7th-avenue-ny:resolution
@@ -109,10 +70,3 @@ variantInfo:
         description: HD resolution means that SimCity4 works with Hardware Rendering (DirectX Rendering).
       - value: sd
         description: SD resolution can also be used for OpenGL versions, Software Rendering, and even Hardware Rendering.
-  - variantId: urban-vibravant:725-727-7th-avenue-ny:lighting
-    description: Due to the particular nature of modding, there are two versions of the building lighting.
-    values:
-      - value: standard
-        description: The standard version has a darker color
-      - value: times-square-ambience
-        description: The Times Square Ambience version has a lighter color

--- a/src/yaml/urban-vibravant/37020-1-5-eldridge-street-ny.yaml
+++ b/src/yaml/urban-vibravant/37020-1-5-eldridge-street-ny.yaml
@@ -1,31 +1,31 @@
 assetId: urban-vibravant-1-5-eldridge-street-ny-maxisnite-sd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=209275
+version: "1.0.0-1"
+lastModified: "2026-05-29T00:03:55Z"
+url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=212597
 
 ---
 assetId: urban-vibravant-1-5-eldridge-street-ny-maxisnite-hd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=209274
+version: "1.0.0-1"
+lastModified: "2026-05-29T00:03:55Z"
+url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=212596
 
 ---
 assetId: urban-vibravant-1-5-eldridge-street-ny-darknite-sd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=209273
+version: "1.0.0-1"
+lastModified: "2026-05-29T00:03:55Z"
+url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=212595
 
 ---
 assetId: urban-vibravant-1-5-eldridge-street-ny-darknite-hd
-version: "1.0.0"
-lastModified: "2025-09-20T06:27:42Z"
-url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=209272
+version: "1.0.0-1"
+lastModified: "2026-05-29T00:03:55Z"
+url: https://community.simtropolis.com/files/file/37020-1-5-eldridge-street-ny/?do=download&r=212594
 
 ---
 group: urban-vibravant
 name: 1-5-eldridge-street-ny
 subfolder: 300-commercial
-version: "1.0.0"
+version: "1.0.0-1"
 info:
   summary: 1-5 Eldridge Street NY
   description: |

--- a/src/yaml/wallibuk/30079-town-gate.yaml
+++ b/src/yaml/wallibuk/30079-town-gate.yaml
@@ -1,6 +1,6 @@
 group: wallibuk
 name: town-gate
-version: "1.0a"
+version: "1.0a-1"
 subfolder: 360-landmark
 info:
   summary: Town gate
@@ -29,6 +29,6 @@ assets:
 
 ---
 assetId: wallibuk-town-gate
-version: "1.0a"
-lastModified: "2025-02-15T01:09:39Z"
+version: "1.0a-1"
+lastModified: "2026-06-10T07:44:05Z"
 url: https://community.simtropolis.com/files/file/30079-town-gate/?do=download

--- a/src/yaml/wallibuk/30170-kostoly-na-gemeri.yaml
+++ b/src/yaml/wallibuk/30170-kostoly-na-gemeri.yaml
@@ -1,6 +1,6 @@
 group: wallibuk
 name: kostoly-na-gemeri
-version: "1.0a"
+version: "1.0a-1"
 subfolder: "650-religion"
 info:
   summary: Kostoly na Gemeri
@@ -50,6 +50,6 @@ assets:
 
 ---
 assetId: wallibuk-kostoly-na-gemeri
-version: "1.0a"
-lastModified: "2025-02-15T01:04:55Z"
+version: "1.0a-1"
+lastModified: "2026-06-10T07:46:59Z"
 url: https://community.simtropolis.com/files/file/30170-kostoly-na-gemeri/?do=download

--- a/src/yaml/wannglondon/36213-medit-bldg-59.yaml
+++ b/src/yaml/wannglondon/36213-medit-bldg-59.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: medit-bldg-59
-version: "1.0.0-1"
+version: "1.0.0m"
 subfolder: 200-residential
 info:
   summary: Medit Bldg 59
@@ -27,6 +27,6 @@ variants:
 
 ---
 assetId: wannglondon-medit-bldg-59-darknite
-version: "1.0.0-1"
-lastModified: "2025-03-20T21:57:01Z"
-url: https://community.simtropolis.com/files/file/36213-medit-bldg-59/?do=download&r=206579
+version: "1.0.0m"
+lastModified: "2026-06-13T04:44:25Z"
+url: https://community.simtropolis.com/files/file/36213-medit-bldg-59/?do=download

--- a/src/yaml/wannglondon/36385-san-francisco-buildings-1.yaml
+++ b/src/yaml/wannglondon/36385-san-francisco-buildings-1.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: san-francisco-buildings-1
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: San Francisco Buildings 1
@@ -27,6 +27,6 @@ variants:
 
 ---
 assetId: wannglondon-san-francisco-buildings-1-darknite
-version: "1.0.0"
-lastModified: "2024-08-09T16:37:54Z"
-url: https://community.simtropolis.com/files/file/36385-san-francisco-buildings-1/?do=download&r=202362
+version: "1.0.0-1"
+lastModified: "2026-06-13T05:08:00Z"
+url: https://community.simtropolis.com/files/file/36385-san-francisco-buildings-1/?do=download

--- a/src/yaml/wannglondon/36482-raven-hollow-inn.yaml
+++ b/src/yaml/wannglondon/36482-raven-hollow-inn.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: raven-hollow-inn
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 360-landmark
 info:
   summary: Raven Hollow Inn
@@ -25,6 +25,6 @@ variants:
 
 ---
 assetId: wannglondon-raven-hollow-inn-darknite
-version: "1.0.0"
-lastModified: "2024-10-01T17:52:53Z"
-url: https://community.simtropolis.com/files/file/36482-raven-hollow-inn/?do=download&r=203667
+version: "1.0.0-1"
+lastModified: "2026-06-13T05:05:55Z"
+url: https://community.simtropolis.com/files/file/36482-raven-hollow-inn/?do=download

--- a/src/yaml/wannglondon/36523-american-rowhome-8.yaml
+++ b/src/yaml/wannglondon/36523-american-rowhome-8.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: american-rowhome-8
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: American Rowhome 8
@@ -28,6 +28,6 @@ variants:
 
 ---
 assetId: wannglondon-american-rowhome-8-darknite
-version: "1.0.0"
-lastModified: "2024-10-23T17:15:29Z"
-url: https://community.simtropolis.com/files/file/36523-american-rowhome-8/?do=download&r=204040
+version: "1.0.0-1"
+lastModified: "2026-06-13T05:03:28Z"
+url: https://community.simtropolis.com/files/file/36523-american-rowhome-8/?do=download

--- a/src/yaml/wannglondon/36567-mid-century-modern-homes-pack.yaml
+++ b/src/yaml/wannglondon/36567-mid-century-modern-homes-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: mid-century-modern-homes-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Mid Century Modern Homes Pack
@@ -29,6 +29,6 @@ assets:
 
 ---
 assetId: wannglondon-mid-century-modern-homes-pack
-version: "1.0.0"
-lastModified: "2024-11-20T06:00:49Z"
-url: https://community.simtropolis.com/files/file/36567-mid-century-modern-homes-pack/?do=download&r=204460
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:59:54Z"
+url: https://community.simtropolis.com/files/file/36567-mid-century-modern-homes-pack/?do=download

--- a/src/yaml/wannglondon/36570-apartments-2.yaml
+++ b/src/yaml/wannglondon/36570-apartments-2.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: apartments-2
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Apartments 2
@@ -27,6 +27,6 @@ assets:
 
 ---
 assetId: wannglondon-apartments-2
-version: "1.0.0"
-lastModified: "2024-11-25T18:48:41Z"
-url: https://community.simtropolis.com/files/file/36570-apartments-2/?do=download&r=204504
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:57:57Z"
+url: https://community.simtropolis.com/files/file/36570-apartments-2/?do=download

--- a/src/yaml/wannglondon/36575-apartments-3.yaml
+++ b/src/yaml/wannglondon/36575-apartments-3.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: apartments-3
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Apartments 3
@@ -25,6 +25,6 @@ assets:
 
 ---
 assetId: wannglondon-apartments-3
-version: "1.0.0"
-lastModified: "2024-12-01T20:18:56Z"
-url: https://community.simtropolis.com/files/file/36575-apartments-3/?do=download&r=204551
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:56:48Z"
+url: https://community.simtropolis.com/files/file/36575-apartments-3/?do=download

--- a/src/yaml/wannglondon/36576-tulum-homes.yaml
+++ b/src/yaml/wannglondon/36576-tulum-homes.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: tulum-homes
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Tulum Homes
@@ -23,6 +23,6 @@ assets:
 
 ---
 assetId: wannglondon-tulum-homes
-version: "1.0.0"
-lastModified: "2024-12-03T17:30:30Z"
-url: https://community.simtropolis.com/files/file/36576-tulum-homes/?do=download&r=204560
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:55:22Z"
+url: https://community.simtropolis.com/files/file/36576-tulum-homes/?do=download

--- a/src/yaml/wannglondon/36578-vintage-sign-prop-pack.yaml
+++ b/src/yaml/wannglondon/36578-vintage-sign-prop-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: vintage-sign-prop-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 100-props-textures
 info:
   summary: Vintage Sign Prop Pack
@@ -18,6 +18,6 @@ assets:
 
 ---
 assetId: wannglondon-vintage-sign-prop-pack
-version: "1.0.0"
-lastModified: "2024-12-04T18:48:52Z"
-url: https://community.simtropolis.com/files/file/36578-vintage-sign-prop-pack/?do=download&r=204564
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:53:53Z"
+url: https://community.simtropolis.com/files/file/36578-vintage-sign-prop-pack/?do=download

--- a/src/yaml/wannglondon/36621-grand-mediterranean-hotels.yaml
+++ b/src/yaml/wannglondon/36621-grand-mediterranean-hotels.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: grand-mediterranean-hotels
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Grand Mediterranean Hotels
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: wannglondon-grand-mediterranean-hotels
-version: "1.0.0"
-lastModified: "2024-12-22T17:34:13Z"
-url: https://community.simtropolis.com/files/file/36621-grand-mediterranean-hotels/?do=download&r=204803
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:51:36Z"
+url: https://community.simtropolis.com/files/file/36621-grand-mediterranean-hotels/?do=download

--- a/src/yaml/wannglondon/36671-los-angeles-home-5.yaml
+++ b/src/yaml/wannglondon/36671-los-angeles-home-5.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: los-angeles-home-5
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Los Angeles Home 5
@@ -27,6 +27,6 @@ variants:
 
 ---
 assetId: wannglondon-los-angeles-home-5-darknite
-version: "1.0.0"
-lastModified: "2025-01-16T21:47:21Z"
-url: https://community.simtropolis.com/files/file/36671-los-angeles-home-5/?do=download&r=205292
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:49:58Z"
+url: https://community.simtropolis.com/files/file/36671-los-angeles-home-5/?do=download

--- a/src/yaml/wannglondon/36762-american-shops-pack-1.yaml
+++ b/src/yaml/wannglondon/36762-american-shops-pack-1.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: american-shops-pack-1
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: American Shops Pack 1
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: wannglondon-american-shops-pack-1
-version: "1.0.0"
-lastModified: "2025-03-10T18:17:31Z"
-url: https://community.simtropolis.com/files/file/36762-american-shops-pack-1/?do=download&r=206408
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:48:34Z"
+url: https://community.simtropolis.com/files/file/36762-american-shops-pack-1/?do=download

--- a/src/yaml/wannglondon/36768-california-bungalow-pack.yaml
+++ b/src/yaml/wannglondon/36768-california-bungalow-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: california-bungalow-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: California Bungalow Pack
@@ -27,6 +27,6 @@ assets:
 
 ---
 assetId: wannglondon-california-bungalow-pack
-version: "1.0.0"
-lastModified: "2025-03-13T02:07:49Z"
-url: https://community.simtropolis.com/files/file/36768-california-bungalow-pack/?do=download&r=206448
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:45:45Z"
+url: https://community.simtropolis.com/files/file/36768-california-bungalow-pack/?do=download

--- a/src/yaml/wannglondon/36814-los-angeles-home-7.yaml
+++ b/src/yaml/wannglondon/36814-los-angeles-home-7.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: los-angeles-home-7
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Los Angeles Home 7
@@ -15,6 +15,6 @@ assets:
 
 ---
 assetId: wannglondon-los-angeles-home-7
-version: "1.0.0"
-lastModified: "2025-04-05T20:43:45Z"
-url: https://community.simtropolis.com/files/file/36814-los-angeles-home-7/?do=download&r=206825
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:40:13Z"
+url: https://community.simtropolis.com/files/file/36814-los-angeles-home-7/?do=download

--- a/src/yaml/wannglondon/36973-los-angeles-apartment-pack-1.yaml
+++ b/src/yaml/wannglondon/36973-los-angeles-apartment-pack-1.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: los-angeles-apartment-pack-1
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Los Angeles Apartment Pack 1
@@ -26,6 +26,6 @@ assets:
 
 ---
 assetId: wannglondon-los-angeles-apartment-pack-1
-version: "1.0.0"
-lastModified: "2025-08-05T16:43:35Z"
-url: https://community.simtropolis.com/files/file/36973-los-angeles-apartment-pack-1/?do=download&r=208676
+version: "1.0.0-1"
+lastModified: "2026-06-13T04:36:42Z"
+url: https://community.simtropolis.com/files/file/36973-los-angeles-apartment-pack-1/?do=download

--- a/src/yaml/wannglondon/37059-american-homes-pack.yaml
+++ b/src/yaml/wannglondon/37059-american-homes-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: american-homes-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: American Homes Pack
@@ -31,6 +31,6 @@ variants:
 
 ---
 assetId: wannglondon-american-homes-pack
-version: "1.0.0"
-lastModified: "2025-10-16T19:18:22Z"
-url: https://community.simtropolis.com/files/file/37059-american-homes-pack/?do=download&r=209662
+version: "1.0.0-1"
+lastModified: "2026-06-11T17:08:28Z"
+url: https://community.simtropolis.com/files/file/37059-american-homes-pack/?do=download

--- a/src/yaml/wannglondon/37071-new-orleans-home-pack.yaml
+++ b/src/yaml/wannglondon/37071-new-orleans-home-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: new-orleans-home-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: New Orleans Home Pack
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: wannglondon-new-orleans-home-pack
-version: "1.0.0"
-lastModified: "2025-10-30T17:15:41Z"
-url: https://community.simtropolis.com/files/file/37071-new-orleans-home-pack/?do=download&r=209844
+version: "1.0.0-1"
+lastModified: "2026-06-11T17:14:00Z"
+url: https://community.simtropolis.com/files/file/37071-new-orleans-home-pack/?do=download

--- a/src/yaml/wannglondon/37073-san-francisco-homes-pack.yaml
+++ b/src/yaml/wannglondon/37073-san-francisco-homes-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: san-francisco-homes-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: San Francisco Homes Pack
@@ -20,6 +20,6 @@ assets:
 
 ---
 assetId: wannglondon-san-francisco-homes-pack
-version: "1.0.0"
-lastModified: "2025-10-31T16:55:15Z"
-url: https://community.simtropolis.com/files/file/37073-san-francisco-homes-pack/?do=download&r=209855
+version: "1.0.0-1"
+lastModified: "2026-06-11T17:15:12Z"
+url: https://community.simtropolis.com/files/file/37073-san-francisco-homes-pack/?do=download

--- a/src/yaml/wannglondon/37086-los-angeles-apartments-4.yaml
+++ b/src/yaml/wannglondon/37086-los-angeles-apartments-4.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: los-angeles-apartments-4
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 200-residential
 info:
   summary: Los Angeles Apartments 4
@@ -18,6 +18,6 @@ assets:
 
 ---
 assetId: wannglondon-los-angeles-apartments-4
-version: "1.0.0"
-lastModified: "2025-11-14T00:19:38Z"
-url: https://community.simtropolis.com/files/file/37086-los-angeles-apartments-4/?do=download&r=210028
+version: "1.0.0-1"
+lastModified: "2026-06-11T16:54:12Z"
+url: https://community.simtropolis.com/files/file/37086-los-angeles-apartments-4/?do=download

--- a/src/yaml/wannglondon/37144-art-deco-commercial-pack.yaml
+++ b/src/yaml/wannglondon/37144-art-deco-commercial-pack.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: art-deco-commercial-pack
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: Art Deco Commercial Pack
@@ -22,6 +22,6 @@ assets:
 
 ---
 assetId: wannglondon-art-deco-commercial-pack
-version: "1.0.0"
-lastModified: "2025-12-16T21:26:44Z"
-url: https://community.simtropolis.com/files/file/37144-art-deco-commercial-pack/?do=download&r=210425
+version: "1.0.0-1"
+lastModified: "2026-06-11T16:53:01Z"
+url: https://community.simtropolis.com/files/file/37144-art-deco-commercial-pack/?do=download

--- a/src/yaml/wannglondon/37234-american-shop-15.yaml
+++ b/src/yaml/wannglondon/37234-american-shop-15.yaml
@@ -1,6 +1,6 @@
 group: wannglondon
 name: american-shop-15
-version: "1.0.0"
+version: "1.0.0-1"
 subfolder: 300-commercial
 info:
   summary: American Shop 15
@@ -17,6 +17,6 @@ assets:
 
 ---
 assetId: wannglondon-american-shop-15
-version: "1.0.0"
-lastModified: "2026-01-31T22:38:51Z"
-url: https://community.simtropolis.com/files/file/37234-american-shop-15/?do=download&r=211012
+version: "1.0.0-1"
+lastModified: "2026-06-11T16:51:38Z"
+url: https://community.simtropolis.com/files/file/37234-american-shop-15/?do=download


### PR DESCRIPTION
This updates most of the recently restored STEX files to their current version to catch up with the recent updates.

A few non-trivial cases have been skipped. See #421.

I didn't bother checking image URLs.

Note that the Simtropolis API seems to return at most 256 results, so with the hundreds of files being updated in the last few weeks and the actions issue #419, this could result in some files falling off the update queue. To avoid this, I went through the whole channel in small batches to check for potential updates.

Merging this PR is especially important for STEX entries with multiple files (e.g. DN/MN variants) where by default Simtropolis simply sends the latest file if the subfile-ID does not exist anymore (so users might receive files for the wrong variant).