### PR TITLE
fix maxis variants of `rivit:urban-tarsealed-street-modd`

### DIFF
--- a/src/yaml/rivit/25404-urban-tarsealed-street-modd.yaml
+++ b/src/yaml/rivit/25404-urban-tarsealed-street-modd.yaml
@@ -1,6 +1,6 @@
 group: rivit
 name: urban-tarsealed-street-modd
-version: "4.42"
+version: "4.42-1"
 subfolder: 900-overrides
 info:
   summary: RVT Urban Tarsealed Street Modd
@@ -125,8 +125,7 @@ assets:
     include:
     - /RVT Streets/RVT Tarsealed Streets - RRWx RHD.dat
   - ifVariant: { rivit:urban-tarsealed-street-modd:rail: maxis }
-    exclude:
-    - .
+    # includes no additional files in addition to other variants defined above
 
 ---
 group: rivit


### PR DESCRIPTION
The maxis variants excluded everything unintentionally, due to an unfortunate combination of `exclude: [ . ]` with other variants.