### PR TITLE
Preserve previously set `info.websites` on update

### DIFF
--- a/actions/fetch/check-previous-version.js
+++ b/actions/fetch/check-previous-version.js
@@ -51,6 +51,11 @@ export default async function checkPreviousVersion(id, metadata, opts) {
 	let [main] = packages;
 	pkg.group = main.group;
 	pkg.name = main.name;
+	if (main.info?.websites?.length > 0) {
+		pkg.info ??= {};
+		pkg.info.websites = [...main.info.websites];
+		delete pkg.info.website;
+	}
 
 	// Now return that the old file has to be deleted when creating a new PR. 
 	// Note that if the name of the file doesn't change, this isn't a problem, 

--- a/actions/fetch/test/integration-test.js
+++ b/actions/fetch/test/integration-test.js
@@ -1409,6 +1409,50 @@ describe('The fetch action', function() {
 
 	});
 
+	it('preserves previously defined websites when updating an existing package', async function() {
+
+		const upload = faker.upload({
+			id: 42594,
+			uid: 5642,
+			author: 'smf_16',
+			title: 'New Title',
+		});
+		const { fs, run } = this.setup({
+			uploads: [upload],
+		});
+		let existing = [
+			{
+				group: 'smf-16',
+				name: 'old-title',
+				version: '1.0.0',
+				info: {
+					websites: [
+						'https://community.simtropolis.com/files/file/42594-old-title/',
+						'https://www.sc4evermore.com/example-page',
+					],
+				},
+			},
+			{
+				assetId: 'smf-16-old-title',
+				url: 'https://www.old-url.com',
+			},
+		];
+		let src = existing.map(js => stringify(js)).join('\n---\n');
+		await fs.promises.mkdir('/src/yaml/smf-16', { recursive: true });
+		fs.writeFileSync('/src/yaml/smf-16/42594-old-title.yaml', src);
+
+		let { read } = await run({ id: upload.id });
+		let metadata = await read('/src/yaml/smf-16/42594-new-title.yaml');
+		expect(metadata[0].group).to.equal('smf-16');
+		expect(metadata[0].name).to.equal('old-title');
+		expect(metadata[0].info.websites).to.deep.equal([
+			'https://community.simtropolis.com/files/file/42594-old-title/',
+			'https://www.sc4evermore.com/example-page',
+		]);
+		expect(metadata[0].info.website).to.equal(undefined);
+
+	});
+
 	it('changes the filename of an uploaded package with custom metadata without a name (#42)', async function() {
 
 		const upload = faker.upload({


### PR DESCRIPTION
Fixes #408. Updates only preserved the old group/name, so the prior custom `info.websites` property was replaced by an auto-generated `info.website` property.