### PR TITLE
fix: Update `adrianor:rs-pack-santiaguino`

### DIFF
--- a/src/yaml/adrianor/31284-rs-pack-santiaguino.yaml
+++ b/src/yaml/adrianor/31284-rs-pack-santiaguino.yaml
@@ -1,6 +1,6 @@
 group: adrianor
 name: rs-pack-santiaguino
-version: "1.0.2"
+version: "1.0.3"
 subfolder: 200-residential
 info:
   summary: R$ Pack Santiaguino
@@ -30,6 +30,6 @@ assets:
 
 ---
 assetId: adrianor-rs-pack-santiaguino-1
-version: "1.0.2"
-lastModified: "2016-09-26T22:11:55Z"
-url: https://community.simtropolis.com/files/file/31284-r-pack-santiaguino-1/?do=download&r=163304
+version: "1.0.3"
+lastModified: "2026-06-22T20:57:46Z
+url: https://community.simtropolis.com/files/file/31284-r-pack-santiaguino-1/?do=download

--- a/src/yaml/adrianor/31284-rs-pack-santiaguino.yaml
+++ b/src/yaml/adrianor/31284-rs-pack-santiaguino.yaml
@@ -31,5 +31,5 @@ assets:
 ---
 assetId: adrianor-rs-pack-santiaguino-1
 version: "1.0.3"
-lastModified: "2026-06-22T20:57:46Z
+lastModified: "2026-06-22T20:57:46Z"
 url: https://community.simtropolis.com/files/file/31284-r-pack-santiaguino-1/?do=download


### PR DESCRIPTION
Closes #442. Previous version contained a folder ending in a space, which is illegal in Windows. The trailing space is silently stripped by Windows automatically, so users installing manually did not see an issue, but users installing via sc4pac did.