### PR TITLE
replaced dependency

### DIFF
--- a/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
+++ b/src/yaml/smf-16/36707-universal-sea-level-mod.yaml
@@ -27,7 +27,7 @@ info:
     - https://www.simtropolis.com/objects/screens/monthly_2025_02/1500m.jpg.57ed7239bbbc0cdd3320e5902568f7f2.jpg
     - https://www.simtropolis.com/objects/screens/monthly_2025_02/2000m.jpg.c049b47c4075f3a4cd7fbae8ebfdbdbd.jpg
 dependencies:
-  - memo:submenus-dll
+  - null-45:sc4-resource-loading-hooks
 variants:
   - variant: { smf-16:universal-sea-level-mod:height: 0m }
     assets:

--- a/src/yaml/smf-16/36819-universal-tree-line-mod.yaml
+++ b/src/yaml/smf-16/36819-universal-tree-line-mod.yaml
@@ -15,7 +15,7 @@ info:
 
     # Dependencies:
 
-    -   [memo:submenus-dll](https://community.simtropolis.com/files/file/36142-submenus-dll/) (this is needed for the exemplar functionality to work).
+    -   [null-45:sc4-resource-loading-hooks](https://community.simtropolis.com/files/file/36242-resource-loading-hooks-dll-for-simcity-4/) (this is needed for the exemplar functionality to work).
 
     # Acknowledgements
 
@@ -25,7 +25,7 @@ info:
   images:
     - https://www.simtropolis.com/objects/screens/monthly_2025_04/thumbnail.jpg.2478e13ab1d607fd96f439d30bdd3f14.jpg
 dependencies:
-  - memo:submenus-dll
+  - null-45:sc4-resource-loading-hooks
 variants:
   - variant: { smf-16:universal-tree-line-mod:height: 500m }
     assets:


### PR DESCRIPTION
if I understand https://github.com/memo33/submenus-dll?tab=readme-ov-file#exemplar-patching correctly, the submenu DLL isn't needed. By testing with the SC4ResourceLoadingHooks DLL installed, I couldn't see a difference with and without the submenu DLL for these two mods (I did see a difference for other mods that have submenu items though, but the submenu functionality isn't needed for these two)