### PR TITLE
SPAM Base Set rework variant system

### DIFF
--- a/lint-config.yaml
+++ b/lint-config.yaml
@@ -24,6 +24,3 @@ group-to-github:
   - caspervg: caspervg
   - ulisse-wolf: UlisseWolf
   - rj-simas: UncleUncleRj
-
-ignore-nonunique-includes:
-  - peg:spam-base-set

--- a/lint-config.yaml
+++ b/lint-config.yaml
@@ -24,3 +24,6 @@ group-to-github:
   - caspervg: caspervg
   - ulisse-wolf: UlisseWolf
   - rj-simas: UncleUncleRj
+
+ignore-nonunique-includes:
+  - peg:spam-base-set

--- a/src/yaml/peg/36983-simpeg-agricultural-mod-spam-base-set.yaml
+++ b/src/yaml/peg/36983-simpeg-agricultural-mod-spam-base-set.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: spam-base-set
-version: "2.1.0-1"
+version: "2.2.0"
 subfolder: 410-agriculture
 info:
   summary: SPAM - Base Set
@@ -25,17 +25,15 @@ variants:
   - variant: { CAM: "no", fantozzi:colossus-farming:spam: "yes" }
     assets:
     - assetId: "peg-spam-base-set"
-      include:
+      exclude:
       - "/CAM/"
-      - "/PEGPROD/"
   - variant: { CAM: "yes" }
     assets:
     - assetId: "peg-spam-base-set"
-      include:
-      - "/CAM/"
-      - "/PEGPROD/"
+      exclude:
+      - "/SPAM/"
 ---
 assetId: peg-spam-base-set
-version: "2.1.0-1"
-lastModified: "2026-06-25T20:43:48Z"
+version: "2.2.0"
+lastModified: "2026-07-07T20:58:43Z"
 url: https://community.simtropolis.com/files/file/36983-simpeg-agricultural-mod-spam-base-set/?do=download

--- a/src/yaml/peg/36983-simpeg-agricultural-mod-spam-base-set.yaml
+++ b/src/yaml/peg/36983-simpeg-agricultural-mod-spam-base-set.yaml
@@ -1,6 +1,6 @@
 group: peg
 name: spam-base-set
-version: "2.1.0"
+version: "2.1.0-1"
 subfolder: 410-agriculture
 info:
   summary: SPAM - Base Set
@@ -16,22 +16,26 @@ dependencies:
   - peg:mtp-super-pack
   - t-wrecks:maxis-prop-names-and-query-fix
 
-assets:
-- assetId: "peg-spam-base-set"
-  withConditions:
-  - ifVariant: { CAM: "no" ,fantozzi:colossus-farming:spam: "no" }
-    include:
-    - "/PEGPROD/"
-  - ifVariant: { CAM: "no" ,fantozzi:colossus-farming:spam: "yes" }
-    include:
-    - "/CAM/"
-    - "/PEGPROD/"
-  - ifVariant: { CAM: "yes" }
-    include:
-    - "/CAM/"
-    - "/PEGPROD/"
+variants:
+  - variant: { CAM: "no", fantozzi:colossus-farming:spam: "no" }
+    assets:
+    - assetId: "peg-spam-base-set"
+      include:
+      - "/PEGPROD/"
+  - variant: { CAM: "no", fantozzi:colossus-farming:spam: "yes" }
+    assets:
+    - assetId: "peg-spam-base-set"
+      include:
+      - "/CAM/"
+      - "/PEGPROD/"
+  - variant: { CAM: "yes" }
+    assets:
+    - assetId: "peg-spam-base-set"
+      include:
+      - "/CAM/"
+      - "/PEGPROD/"
 ---
 assetId: peg-spam-base-set
-version: "2.1.0"
+version: "2.1.0-1"
 lastModified: "2026-06-25T20:43:48Z"
 url: https://community.simtropolis.com/files/file/36983-simpeg-agricultural-mod-spam-base-set/?do=download


### PR DESCRIPTION
The current configuration of the variants in the SPAM Base Set requires you to enter the variable _fantozzi:colossus-farming:spam_ regardless of whether you use CAM or SPAM. To avoid confusion among users, we use the solution proposed by @memo33 , which helps prevent this confusion, especially for less experienced users.

Note: We should probably take a moment to consider the SPAM variant system, since there are mods that are compatible with both SPAM and CAM. Therefore, instead of using `ignore-nonunique-includes`, we could improve the approach to variants when dealing with mods that are compatible with both systems, to avoid confusion for less experienced users.
